### PR TITLE
common.hmmer: use trusted cutoffs on PFAM searches

### DIFF
--- a/antismash/common/hmmer.py
+++ b/antismash/common/hmmer.py
@@ -140,6 +140,6 @@ def run_hmmer(record: Record, features: List[CDSFeature], max_evalue: float,
     if not os.path.exists(database):
         raise ValueError("Given database does not exist: %s" % database)
     query_sequence = fasta.get_fasta_from_features(features)
-    hmmscan_results = subprocessing.run_hmmscan(database, query_sequence)
+    hmmscan_results = subprocessing.run_hmmscan(database, query_sequence, opts=["--cut_tc"])
     hits = build_hits(record, hmmscan_results, min_score, max_evalue, database)
     return HmmerResults(record.id, max_evalue, min_score, database, tool, hits)

--- a/antismash/detection/cluster_hmmer/test/integration_cluster_hmmer.py
+++ b/antismash/detection/cluster_hmmer/test/integration_cluster_hmmer.py
@@ -45,7 +45,7 @@ class TestClusterHmmer(unittest.TestCase):
 
         results = helpers.run_and_regenerate_results_for_module(nisin, cluster_hmmer, self.options)
         json = results.to_json()
-        assert len(results.hits) == 24
+        assert len(results.hits) == 13
         self.check_add_to_record(nisin, results)
 
         # test regeneration when thresholds are less restrictive
@@ -62,14 +62,14 @@ class TestClusterHmmer(unittest.TestCase):
         self.set_max_evalue(self.original_max_evalue)
 
         # test regeneration when evalue threshold is more restrictive
-        new_evalue_threshold = sorted(hit["evalue"] for hit in results.hits)[12]
+        new_evalue_threshold = sorted(hit["evalue"] for hit in results.hits)[6]
         assert new_evalue_threshold < self.original_max_evalue
         new_hits = []
         for hit in results.hits:
             if hit["evalue"] <= new_evalue_threshold:
                 new_hits.append(hit)
         new_hits.sort(key=lambda x: x["evalue"])
-        assert len(new_hits) < 24
+        assert len(new_hits) < 13
 
         self.set_max_evalue(new_evalue_threshold)
         new_results = cluster_hmmer.regenerate_previous_results(json, record, self.options)
@@ -78,14 +78,14 @@ class TestClusterHmmer(unittest.TestCase):
         self.check_add_to_record(nisin, results)
 
         # test regeneration when score threshold is more restrictive
-        new_score_threshold = sorted(hit["score"] for hit in results.hits)[12]
+        new_score_threshold = sorted(hit["score"] for hit in results.hits)[6]
         assert new_score_threshold > cluster_hmmer.MIN_SCORE
         new_hits = []
         for hit in results.hits:
             if hit["score"] >= new_score_threshold:
                 new_hits.append(hit)
         new_hits.sort(key=lambda x: x["score"])
-        assert len(new_hits) < 24
+        assert len(new_hits) < 13
 
         self.set_min_score(new_score_threshold)
         new_results = cluster_hmmer.regenerate_previous_results(json, record, self.options)

--- a/antismash/detection/full_hmmer/test/integration_full_hmmer.py
+++ b/antismash/detection/full_hmmer/test/integration_full_hmmer.py
@@ -45,7 +45,7 @@ class TestFullHmmer(unittest.TestCase):
 
         results = helpers.run_and_regenerate_results_for_module(nisin, full_hmmer, self.options)
         json = results.to_json()
-        assert len(results.hits) == 24
+        assert len(results.hits) == 13
         self.check_add_to_record(nisin, results)
 
         # test regeneration when thresholds are less restrictive
@@ -62,7 +62,7 @@ class TestFullHmmer(unittest.TestCase):
         self.set_max_evalue(self.original_max_evalue)
 
         # test regeneration when evalue threshold is more restrictive
-        new_evalue_threshold = sorted(hit["evalue"] for hit in results.hits)[12]
+        new_evalue_threshold = sorted(hit["evalue"] for hit in results.hits)[6]
         assert new_evalue_threshold < self.original_max_evalue
         new_hits = []
         for hit in results.hits:
@@ -78,7 +78,7 @@ class TestFullHmmer(unittest.TestCase):
         self.check_add_to_record(nisin, results)
 
         # test regeneration when score threshold is more restrictive
-        new_score_threshold = sorted(hit["score"] for hit in results.hits)[12]
+        new_score_threshold = sorted(hit["score"] for hit in results.hits)[6]
         assert new_score_threshold > full_hmmer.MIN_SCORE
         new_hits = []
         for hit in results.hits:


### PR DESCRIPTION
Restricts fullhmmer and clusterhmmer to using only hmmscan results which are better than the PFAM supplied cutoffs