### PR TITLE
Coverage adjustment

### DIFF
--- a/antismash/common/hmm_rule_parser/test/test_rule_parser.py
+++ b/antismash/common/hmm_rule_parser/test/test_rule_parser.py
@@ -51,9 +51,7 @@ class DetectionTest(unittest.TestCase):
         cds_with_hits = sorted(self.results_by_id,
                                key=lambda gene_id: self.feature_by_id[gene_id].location.start)
         for cds in cds_with_hits:
-            detected_type = detected_types.get(cds)
-            if detected_type:
-                continue
+            assert cds not in detected_types
             rule_results = []
             for rule in rules:
                 rule_results.append(rule.detect(cds, self.feature_by_id, self.results_by_id))

--- a/antismash/common/test/integration_subprocessing.py
+++ b/antismash/common/test/integration_subprocessing.py
@@ -31,6 +31,15 @@ class TestParallelPython(unittest.TestCase):
     def tearDown(self):
         destroy_config()
 
+    def test_dummy(self):
+        # checks that the dummy function actually works as expected
+        assert dummy() == os.getpid()
+        assert dummy(0) == os.getpid()
+        with self.assertRaisesRegex(ValueError, "Lucky number"):
+            dummy(1)
+        for i in range(2, 10):
+            assert dummy(i) == os.getpid()
+
     def test_actually_parallel(self):
         results = subprocessing.parallel_function(dummy, [[0]]*2)
         assert len(set(results)) == self.config_cpus
@@ -67,9 +76,12 @@ class TestParallelPython(unittest.TestCase):
             subprocessing.parallel_function(dummy, [[i] for i in range(5)])
 
     def test_local_funcs(self):
+        # this test is mostly to let us know if something changes in pool/pickle
         def local(value):
             return value + 1
-        # this test is mostly to let us know if something changes in pool/pickle
+        # ensure the function works as expected when called directly
+        assert local(1) == 2
+        # check if it still fails within a parallel pool
         with self.assertRaisesRegex(AttributeError, "Can't pickle local object"):
             subprocessing.parallel_function(local, [[i] for i in range(3)])
 

--- a/antismash/common/test/test_all_orfs.py
+++ b/antismash/common/test/test_all_orfs.py
@@ -14,14 +14,6 @@ from .helpers import DummyRecord
 
 
 class TestOrfCounts(unittest.TestCase):
-    def reverse_starts_and_stops(self, seq):
-        # replace for reverse direction testing
-        for start, comp in [('ATG', 'TCA'), ('GTG', 'CAC'), ('TTG', 'AAC')]:
-            seq = seq.replace(start, comp)
-        for stop, comp in [('TAA', 'ATT'), ('TAG', 'ATC'), ('TGA', 'ACT')]:
-            seq = seq.replace(stop, comp)
-        return seq
-
     def run_both_dirs(self, expected, seq):
         def reverse_location(location, length):
             return location._flip(length)

--- a/antismash/detection/hmm_detection/test/test_hmm_detection.py
+++ b/antismash/detection/hmm_detection/test/test_hmm_detection.py
@@ -19,25 +19,6 @@ import antismash.detection.hmm_detection as core
 from antismash.detection.hmm_detection import signatures
 
 
-def create_rule(name, cutoff, extent, conditions):
-    text = "RULE {} CUTOFF {} EXTENT {} CONDITIONS {}".format(name, cutoff,
-                                                              extent, conditions)
-    return rule_parser.Parser(text, set()).rules[0]
-
-
-class TestArgs(unittest.TestCase):
-    def setUp(self):
-        self.parser = args.build_parser(modules=[core])
-
-    def tearDown(self):
-        destroy_config()
-
-    def build_options(self, options):
-        destroy_config()
-        options = self.parser.parse_args(options)
-        return update_config(options)
-
-
 class HmmDetectionTest(unittest.TestCase):
     def setUp(self):
         self.rules_file = path.get_full_path(__file__, "..", "cluster_rules.txt")

--- a/antismash/modules/clusterblast/test/integration_clusterblast.py
+++ b/antismash/modules/clusterblast/test/integration_clusterblast.py
@@ -31,7 +31,7 @@ class Base(unittest.TestCase):
         """ override with the args you'll need to use in setUp(),
             format is as on the commandline, e.g. ["--tta", "--minimal"]
         """
-        self.fail()  # not overridden
+        raise NotImplementedError("get_args not overridden")
 
     def tearDown(self):
         destroy_config()

--- a/antismash/modules/nrps_pks/test/test_orderfinder.py
+++ b/antismash/modules/nrps_pks/test/test_orderfinder.py
@@ -108,9 +108,7 @@ class TestOrdering(unittest.TestCase):
         genes = {name: DummyCDS(locus_tag=name) for name in orders[0]}
         gene_orders = [[genes[k] for k in order] for order in orders]
         res = orderfinder.rank_biosynthetic_orders(n_terms, c_terms, gene_orders)
-        if isinstance(orders[0], str):
-            return "".join(gene.locus_tag for gene in res)
-        return [gene.get_name() for gene in res]
+        return "".join(gene.locus_tag for gene in res)
 
     def test_permutations_no_start_no_end(self):
         perms = self.run_ordering_simple("", "")

--- a/antismash/modules/pfam2go/test/test_pfam2go.py
+++ b/antismash/modules/pfam2go/test/test_pfam2go.py
@@ -219,9 +219,3 @@ class PfamToGoTest(unittest.TestCase):
             from_broken_json = pfam2go.Pfam2GoResults.from_json(broken_json, fake_record)
             assert "Schema version mismatch, discarding Pfam2GO results" in str(log_cm.output)
             assert not from_broken_json
-
-
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/antismash/modules/sactipeptides/test/integration_sactipeptides.py
+++ b/antismash/modules/sactipeptides/test/integration_sactipeptides.py
@@ -22,16 +22,6 @@ class IntegrationSactipeptides(unittest.TestCase):
     def tearDown(self):
         destroy_config()
 
-    def set_fimo_enabled(self, val):
-        update_config({"without_fimo": not val})
-
-    def gather_all_motifs(self, result):
-        motifs = []
-        for locii in result.clusters.values():
-            for locus in locii:
-                motifs.extend(result.motifs_by_locus[locus])
-        return motifs
-
     def run_analyis(self, filename):
         data_file = path.get_full_path(__file__, "data", filename)
         return helpers.run_and_regenerate_results_for_module(data_file, sactipeptides, self.options)

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,7 @@ disallow_untyped_defs=True
 check_untyped_defs=True
 ignore_missing_imports=True
 warn_unused_ignores=True
+
+[coverage:report]
+exclude_lines = 
+    raise NotImplementedError


### PR DESCRIPTION
Adds a coverage exclusion for lines which raise NotImplementedError (and incidentally removes the nocover pragma that wasn't used anywhere).

Removes or adjusts dead code in unit and integration tests such that all unit and integration test files are 100% covered or excluded.

Also fixes an incomplete test in pfam2go that was found during the process.