### PR TITLE
Output directory improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ omit = --omit '*indigo*','*/external/*'
 coverage = coverage run $(omit) --source antismash -m pytest
 integration_flags = --override-ini=python_files=integration_*.py
 integration_coverage = .coverage_integration
-sanity_run = echo "sanity TTA run" && ./run_antismash.py --minimal --tta antismash/test/integration/data/nisin.gbk
+sanity_run = echo "sanity TTA run" && rm -rf nisin && ./run_antismash.py --minimal --tta antismash/test/integration/data/nisin.gbk
 
 unit:
-	echo "sanity TTA run" && ./run_antismash.py --tta antismash/test/integration/data/nisin.gbk
+	$(sanity_run)
 	echo "simple reuse test" && ./run_antismash.py --reuse-results nisin/nisin.json
 	pytest --durations=3 antismash
 

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -577,6 +577,11 @@ def debug_options() -> ModuleArgs:
                      action='store_true',
                      default=False,
                      help="Skip input record sanitisation. Use with care.")
+    group.add_option('--skip-zip-file',
+                     dest='skip_zip_file',
+                     action='store_true',
+                     default=False,
+                     help="Do not create a zip of the output")
     return group
 
 

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -404,14 +404,14 @@ def write_outputs(results: serialiser.AntismashResults, options: ConfigType) -> 
     SeqIO.write(bio_records, combined_filename, "genbank")
 
     zipfile = base_filename + ".zip"
-    logging.debug("Zipping output to '%s'", zipfile)
     if os.path.exists(zipfile):
         os.remove(zipfile)
-
-    with tempfile.NamedTemporaryFile(prefix="as_zip_tmp", suffix=".zip") as temp:
-        shutil.make_archive(temp.name.replace(".zip", ""), "zip", root_dir=options.output_dir)
-        shutil.copy(temp.name, zipfile)
-    assert os.path.exists(zipfile)
+    if not options.skip_zip_file:
+        logging.debug("Zipping output to '%s'", zipfile)
+        with tempfile.NamedTemporaryFile(prefix="as_zip_tmp", suffix=".zip") as temp:
+            shutil.make_archive(temp.name.replace(".zip", ""), "zip", root_dir=options.output_dir)
+            shutil.copy(temp.name, zipfile)
+        assert os.path.exists(zipfile)
 
 
 def annotate_records(results: serialiser.AntismashResults) -> None:

--- a/antismash/outputs/html/top_header.html
+++ b/antismash/outputs/html/top_header.html
@@ -10,7 +10,9 @@
     <a href="#" id="download"><img src="images/{{options.taxon}}_download.png" alt="download" title="Download results"></a>
     <div id="downloadmenu">
       <ul id="downloadoptions">
+        {% if not options.skip_zip_file %}
         <li><a href={{options.input_file}}.zip>Download all results</a></li>
+        {% endif %}
         <li><a href={{options.input_file}}.gbk> Download GenBank summary file</a></li>
         {% if options.logfile and options.download_logfile() != None %}
           <li><a href={{options.download_logfile()}}> Download log file</a></li>

--- a/antismash/test/integration/integration_antismash.py
+++ b/antismash/test/integration/integration_antismash.py
@@ -6,7 +6,7 @@
 
 import glob
 import os
-from tempfile import TemporaryDirectory
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 import unittest
 
 from antismash.main import run_antismash, get_all_modules
@@ -58,14 +58,22 @@ class TestVerbose(TestAntismash):
         return ["--minimal", "-v"]
 
 
-class TestLogfile(TestAntismash):
-    def get_args(self):
-        # add verbose so something will get logged
-        return ["--minimal", "-v", "--logfile", os.path.join(self.temp_dir.name, "logfile")]
+class TestLogging(TestAntismash):
+    def setUp(self):
+        self.logfile = NamedTemporaryFile()
+        super().setUp()
 
-    def test_nisin_minimal(self):
-        super().test_nisin_minimal()
-        assert os.path.exists(os.path.join(self.temp_dir.name, "logfile"))
+    def tearDown(self):
+        super().tearDown()
+        self.logfile.close()
+
+    def get_args(self):
+        return ["--minimal", "-v", "--logfile", os.path.join(self.logfile.name)]
+
+    def check_output_files(self):
+        super().check_output_files()
+        log_path = self.get_args()[-1]
+        assert os.path.exists(self.logfile.name)
 
 
 class TestResultsReuse(TestAntismash):


### PR DESCRIPTION
Prevents use of an output directory if it contains other content (unless --reuse is specified).

Adds a --skip-zip-file option for performance when the zip file isn't desired.