### PR TITLE
Handle circular genome mega-clusters

### DIFF
--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -62,13 +62,13 @@ class CDSFeature(Feature):
         self._sec_met = None  # type: SecMetQualifier
         self._nrps_pks = NRPSPKSQualifier(self.location.strand)
 
-        self.motifs = []  # type: List[feature.CDSMotif]
+        self.motifs = []  # type: List[features.CDSMotif]
 
         if not (protein_id or locus_tag or gene):
             raise ValueError("CDSFeature requires at least one of: gene, protein_id, locus_tag")
 
         # runtime-only data
-        self.cluster = None  # type: Optional[feature.Cluster]
+        self.cluster = None  # type: Optional[features.Cluster]
         self.unique_id = None  # type: Optional[str] # set only when added to a record
 
     @property

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -44,8 +44,6 @@ class CDSFeature(Feature):
         if location.strand not in [1, -1]:
             raise ValueError("Strand must be 1 or -1 for a CDS, not %s" % location.strand)
         # mandatory
-        #  codon_start
-        #  db_xref
         self._gene_functions = GeneFunctionAnnotations()
 
         # semi-optional

--- a/antismash/common/secmet/features/cluster.py
+++ b/antismash/common/secmet/features/cluster.py
@@ -36,7 +36,7 @@ class Cluster(Feature):
         for product in products:
             self.add_product(product)
 
-        self.contig_edge = None  # type: Optional[bool] # hmm_detection borderpredict
+        self.contig_edge = None  # type: Optional[bool]
         self.detection_rules = []  # type: List[str]
         self.smiles_structure = None  # type: Optional[str] # SMILES string
 

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -9,7 +9,10 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from Bio.SeqFeature import SeqFeature, FeatureLocation, CompoundLocation
 from Bio.Seq import Seq
 
-from antismash.common.secmet.locations import convert_protein_position_to_dna
+from antismash.common.secmet.locations import (
+    convert_protein_position_to_dna,
+    location_bridges_origin
+)
 
 
 class Feature:
@@ -22,6 +25,8 @@ class Feature:
     def __init__(self, location: FeatureLocation, feature_type: str,
                  created_by_antismash: bool = False) -> None:
         assert isinstance(location, (FeatureLocation, CompoundLocation)), type(location)
+        if location_bridges_origin(location):
+            raise ValueError("Features that bridge the record origin cannot be directly created: %s" % location)
         assert location.start < location.end, "Feature location invalid"
         self.location = location
         self.notes = []  # type: List[str]

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -9,59 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from Bio.SeqFeature import SeqFeature, FeatureLocation, CompoundLocation
 from Bio.Seq import Seq
 
-
-def _convert_protein_position_to_dna(start: int, end: int, location: FeatureLocation) -> Tuple[int, int]:
-    """ Convert a protein position to a nucleotide sequence position for use in generating
-        new FeatureLocations from existing FeatureLocations and/or CompoundLocations.
-
-        Arguments:
-            position: the position in question, must be contained by the location
-            location: the location of the related feature, for handling introns/split locations
-
-        Returns:
-            an int representing the calculated DNA location
-    """
-    if not 0 <= start < end <= len(location) // 3:
-        raise ValueError("Protein positions %d and %d must be contained by %s" % (start, end, location))
-    if location.strand == -1:
-        dna_start = location.start + len(location) - end * 3
-        dna_end = location.start + len(location) - start * 3
-    else:
-        dna_start = location.start + start * 3
-        dna_end = location.start + end * 3
-
-    # only CompoundLocations are complicated
-    if not isinstance(location, CompoundLocation):
-        if not location.start <= dna_start < dna_end <= location.end:
-            raise ValueError(("Converted coordinates %d..%d "
-                              "out of bounds for location %s") % (dna_start, dna_end, location))
-        return dna_start, dna_end
-
-    parts = sorted(location.parts, key=lambda x: x.start)
-    gap = 0
-    last_end = parts[0].start
-    start_found = False
-    end_found = False
-    for part in parts:
-        if start_found and end_found:
-            break
-        gap += part.start - last_end
-        if not start_found and dna_start + gap in part:
-            start_found = True
-            dna_start = dna_start + gap
-        if not end_found and dna_end + gap - 1 in part:
-            end_found = True
-            dna_end = dna_end + gap
-
-        last_end = part.end
-
-    assert start_found
-    assert end_found
-
-    if not location.start <= dna_start < dna_end <= location.end:
-        raise ValueError(("Converted coordinates %d..%d "
-                          "out of bounds for location %s") % (dna_start, dna_end, location))
-    return dna_start, dna_end
+from antismash.common.secmet.locations import convert_protein_position_to_dna
 
 
 class Feature:
@@ -115,7 +63,7 @@ class Feature:
         if start >= end:
             raise ValueError("Protein start coordinate must be less than the end coordinate")
 
-        dna_start, dna_end = _convert_protein_position_to_dna(start, end, self.location)
+        dna_start, dna_end = convert_protein_position_to_dna(start, end, self.location)
 
         if not 0 <= dna_start - self.location.start < self.location.end - 2:
             raise ValueError("Protein coordinate start %d (nucl %d) is outside feature %s" % (start, dna_start, self))

--- a/antismash/common/secmet/features/test/test_feature.py
+++ b/antismash/common/secmet/features/test/test_feature.py
@@ -9,7 +9,6 @@ import unittest
 from antismash.common.test import helpers
 
 from antismash.common.secmet.features.feature import (
-    _convert_protein_position_to_dna,
     CompoundLocation,
     Feature,
     FeatureLocation,
@@ -82,87 +81,3 @@ class TestFeature(unittest.TestCase):
                 feature = Feature(FeatureLocation(start, end, strand=-1),
                                   feature_type=feature_type)
                 assert str(feature) == "%s([%d:%d](-))" % (feature_type, start, end)
-
-
-class TestProteinPositionConversion(unittest.TestCase):
-    def setUp(self):
-        self.func = _convert_protein_position_to_dna
-
-    def test_position_conversion_simple_forward(self):
-        location = FeatureLocation(0, 15, strand=1)
-        assert len(location) == 15
-        assert self.func(0, 2, location) == (0, 6)
-        assert self.func(1, 4, location) == (3, 12)
-
-    def test_position_conversion_simple_reverse(self):
-        location = FeatureLocation(0, 15, strand=-1)
-        assert len(location) == 15
-        assert self.func(0, 2, location) == (9, 15)
-        assert self.func(1, 4, location) == (3, 12)
-
-    def test_position_conversion_nonzero_start(self):
-        location = FeatureLocation(6, 21, strand=1)
-        assert len(location) == 15
-        assert self.func(0, 2, location) == (6, 12)
-        assert self.func(1, 4, location) == (9, 18)
-
-        location = FeatureLocation(6, 21, strand=-1)
-        assert len(location) == 15
-        assert self.func(0, 2, location) == (15, 21)
-        assert self.func(1, 4, location) == (9, 18)
-
-    def test_position_conversion_nonzero_start_compound(self):
-        location = CompoundLocation([FeatureLocation(6, 18, strand=1),
-                                     FeatureLocation(24, 27, strand=1)])
-        assert len(location) == 15
-        assert self.func(0, 2, location) == (6, 12)
-        assert self.func(1, 4, location) == (9, 18)
-        assert self.func(3, 5, location) == (15, 27)
-
-        location = CompoundLocation([FeatureLocation(6, 15, strand=-1),
-                                     FeatureLocation(21, 27, strand=-1)])
-        assert len(location) == 15
-        assert self.func(0, 2, location) == (21, 27)
-        assert self.func(1, 4, location) == (9, 24)
-        assert self.func(3, 5, location) == (6, 12)
-
-    def test_position_conversion_compound_forward(self):
-        location = CompoundLocation([FeatureLocation(0, 6, strand=1),
-                                     FeatureLocation(9, 18, strand=1)])
-        assert len(location) == 15
-        assert self.func(0, 4, location) == (0, 15)
-        assert self.func(1, 5, location) == (3, 18)
-
-        location = CompoundLocation([FeatureLocation(0, 6, strand=1),
-                                     FeatureLocation(12, 15, strand=1),
-                                     FeatureLocation(21, 27, strand=1)])
-        assert len(location) == 15
-        assert self.func(0, 4, location) == (0, 24)
-        assert self.func(1, 5, location) == (3, 27)
-        assert self.func(2, 3, location) == (12, 15)
-
-    def test_position_conversion_compound_reverse(self):
-        location = CompoundLocation([FeatureLocation(0, 6, strand=-1),
-                                     FeatureLocation(9, 18, strand=-1)])
-        assert len(location) == 15
-        assert self.func(0, 4, location) == (3, 18)
-        assert self.func(1, 5, location) == (0, 15)
-
-        location = CompoundLocation([FeatureLocation(0, 6, strand=-1),
-                                     FeatureLocation(12, 15, strand=-1),
-                                     FeatureLocation(21, 27, strand=-1)])
-        assert len(location) == 15
-        assert self.func(0, 4, location) == (3, 27)
-        assert self.func(1, 5, location) == (0, 24)
-        assert self.func(2, 3, location) == (12, 15)
-
-    def test_other(self):
-        location = CompoundLocation([FeatureLocation(5922, 6190, strand=1),
-                                     FeatureLocation(5741, 5877, strand=1),
-                                     FeatureLocation(4952, 5682, strand=1)])
-        assert self.func(97, 336, location) == (5243, 6064)
-
-        location = CompoundLocation([FeatureLocation(5922, 6190, strand=-1),
-                                     FeatureLocation(5741, 5877, strand=-1),
-                                     FeatureLocation(4952, 5682, strand=-1)])
-        assert self.func(97, 336, location) == (5078, 5854)

--- a/antismash/common/secmet/features/test/test_feature.py
+++ b/antismash/common/secmet/features/test/test_feature.py
@@ -81,3 +81,9 @@ class TestFeature(unittest.TestCase):
                 feature = Feature(FeatureLocation(start, end, strand=-1),
                                   feature_type=feature_type)
                 assert str(feature) == "%s([%d:%d](-))" % (feature_type, start, end)
+
+    def test_bridging_fails(self):
+        parts = [FeatureLocation(9, 12, strand=1), FeatureLocation(0, 3, strand=1)]
+        with self.assertRaisesRegex(ValueError, "bridge the record origin"):
+            Feature(CompoundLocation(parts, operator="join"), feature_type="test")
+        Feature(CompoundLocation(parts[::-1], operator="join"), feature_type="test")

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -60,3 +60,33 @@ def convert_protein_position_to_dna(start: int, end: int, location: FeatureLocat
         raise ValueError(("Converted coordinates %d..%d "
                           "out of bounds for location %s") % (dna_start, dna_end, location))
     return dna_start, dna_end
+
+
+def location_bridges_origin(location: CompoundLocation) -> bool:
+    """ Determines if a CompoundLocation would cross the origin of a record.
+
+        Arguments:
+            location: the CompoundLocation to check
+
+        Returns:
+            False if the location does not bridge the origin or if the location
+            is of indeterminate strand, otherwise True
+    """
+    assert isinstance(location, (FeatureLocation, CompoundLocation)), type(location)
+
+    # if it's not compound, it can't bridge at all
+    if not isinstance(location, CompoundLocation):
+        return False
+
+    # invalid strands mean direction can't be determined, may need to be an error
+    if location.strand not in [1, -1]:
+        return False
+
+    for i, part in enumerate(location.parts[1:]):
+        if location.strand == 1:
+            if part.start <= location.parts[i].end:
+                return True
+        else:
+            if part.start >= location.parts[i].end:
+                return True
+    return False

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -3,7 +3,7 @@
 
 """ Helper functions for location operations """
 
-from typing import Tuple
+from typing import List, Tuple
 
 from Bio.SeqFeature import FeatureLocation, CompoundLocation
 
@@ -90,3 +90,38 @@ def location_bridges_origin(location: CompoundLocation) -> bool:
             if part.start >= location.parts[i].end:
                 return True
     return False
+
+
+def split_origin_bridging_location(location: CompoundLocation) -> Tuple[
+                                                      List[FeatureLocation], List[FeatureLocation]]:
+    """ Splits a CompoundLocation into two sections.
+        The first contains the low-position parts (immediately after the origin
+        in a forward direction), the second handles the high-position parts.
+
+        Arguments:
+            location: the CompoundLocation to split
+
+        Returns:
+            a tuple of lists, each list containing one or more FeatureLocations
+    """
+    lower = []  # type: List[FeatureLocation]
+    upper = []  # type: List[FeatureLocation]
+    if location.strand == 1:
+        for part in location.parts:
+            if not upper or part.start > upper[-1].end:
+                upper.append(part)
+            else:
+                lower.append(part)
+    elif location.strand == -1:
+        for part in location.parts:
+            if not lower or part.start < lower[-1].end:
+                lower.append(part)
+            else:
+                upper.append(part)
+    else:
+        raise ValueError("Cannot separate bridged location without a valid strand")
+
+    if not (lower and upper):
+        raise ValueError("Location does not bridge origin: %s" % location)
+
+    return lower, upper

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -1,0 +1,62 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+""" Helper functions for location operations """
+
+from typing import Tuple
+
+from Bio.SeqFeature import FeatureLocation, CompoundLocation
+
+
+def convert_protein_position_to_dna(start: int, end: int, location: FeatureLocation) -> Tuple[int, int]:
+    """ Convert a protein position to a nucleotide sequence position for use in generating
+        new FeatureLocations from existing FeatureLocations and/or CompoundLocations.
+
+        Arguments:
+            position: the position in question, must be contained by the location
+            location: the location of the related feature, for handling introns/split locations
+
+        Returns:
+            an int representing the calculated DNA location
+    """
+    if not 0 <= start < end <= len(location) // 3:
+        raise ValueError("Protein positions %d and %d must be contained by %s" % (start, end, location))
+    if location.strand == -1:
+        dna_start = location.start + len(location) - end * 3
+        dna_end = location.start + len(location) - start * 3
+    else:
+        dna_start = location.start + start * 3
+        dna_end = location.start + end * 3
+
+    # only CompoundLocations are complicated
+    if not isinstance(location, CompoundLocation):
+        if not location.start <= dna_start < dna_end <= location.end:
+            raise ValueError(("Converted coordinates %d..%d "
+                              "out of bounds for location %s") % (dna_start, dna_end, location))
+        return dna_start, dna_end
+
+    parts = sorted(location.parts, key=lambda x: x.start)
+    gap = 0
+    last_end = parts[0].start
+    start_found = False
+    end_found = False
+    for part in parts:
+        if start_found and end_found:
+            break
+        gap += part.start - last_end
+        if not start_found and dna_start + gap in part:
+            start_found = True
+            dna_start = dna_start + gap
+        if not end_found and dna_end + gap - 1 in part:
+            end_found = True
+            dna_end = dna_end + gap
+
+        last_end = part.end
+
+    assert start_found
+    assert end_found
+
+    if not location.start <= dna_start < dna_end <= location.end:
+        raise ValueError(("Converted coordinates %d..%d "
+                          "out of bounds for location %s") % (dna_start, dna_end, location))
+    return dna_start, dna_end

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import Bio.Alphabet
 from Bio.Seq import Seq
-from Bio.SeqFeature import SeqFeature, FeatureLocation
+from Bio.SeqFeature import SeqFeature, FeatureLocation, CompoundLocation
 from Bio.SeqRecord import SeqRecord
 
 from .features import (
@@ -32,6 +32,11 @@ from .features import (
     Gene,
     PFAMDomain,
     Prepeptide,
+)
+
+from .locations import (
+    location_bridges_origin,
+    split_origin_bridging_location
 )
 
 
@@ -458,7 +463,65 @@ class Record:
                 # to handle a biopython issue, set the references to None
                 feature.ref = None
                 feature.ref_db = None
+
+            locations_adjusted = False
+            name_modified = False
+
+            if record.is_circular() and location_bridges_origin(feature.location):
+                locations_adjusted = True
+                original_location = feature.location
+                lower, upper = split_origin_bridging_location(feature.location)
+
+                if feature.type in ['CDS', 'gene']:
+                    name_modified = True
+                    original_gene_name = feature.qualifiers.get("gene", [None])[0]
+                    gene_name = original_gene_name
+                    locus_tag = feature.qualifiers.get("locus_tag", [None])[0]
+                    # if neither exist, set the gene name as it is less precise
+                    # in meaning
+                    if not gene_name and not locus_tag:
+                        gene_name = "bridge"
+
+                # nuke any translation, since it's now out of date
+                feature.qualifiers.pop('translation', None)
+
+                # add a separate feature for the upper section
+                if len(upper) > 1:
+                    feature.location = CompoundLocation(upper, original_location.operator)
+                else:
+                    feature.location = upper[0]
+                if name_modified:
+                    if gene_name:
+                        feature.qualifiers["gene"] = [gene_name + "_UPPER"]
+                    if locus_tag:
+                        feature.qualifiers["locus_tag"] = [locus_tag + "_UPPER"]
+                record.add_biopython_feature(feature)
+
+                # adjust the current feature to only be the lower section
+                if len(lower) > 1:
+                    feature.location = CompoundLocation(lower, original_location.operator)
+                else:
+                    feature.location = lower[0]
+                if name_modified:
+                    if gene_name:
+                        feature.qualifiers["gene"] = [gene_name + "_LOWER"]
+                    if locus_tag:
+                        feature.qualifiers["locus_tag"] = [locus_tag + "_LOWER"]
+
             record.add_biopython_feature(feature)
+
+            # reset back to how the feature looked originally
+            if locations_adjusted:
+                feature.location = original_location
+                if name_modified:
+                    if not locus_tag:
+                        feature.qualifiers.pop("locus_tag", "")
+                    else:
+                        feature.qualifiers["locus_tag"][0] = locus_tag
+                    if not original_gene_name:
+                        feature.qualifiers.pop("gene", "")
+                    else:
+                        feature.qualifiers["gene"][0] = original_gene_name
         return record
 
     def _link_cds_to_parent(self, cds: CDSFeature) -> None:

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -89,6 +89,10 @@ class Record:
         except AttributeError:
             raise AttributeError("Record does not support dynamically adding attributes")
 
+    def is_circular(self) -> bool:
+        """ Returns True if the genome is circular """
+        return self._record.annotations.get("topology", "").lower() == "circular"
+
     def add_annotation(self, key: str, value: List) -> None:
         """Adding annotations in Record"""
         if not isinstance(key, str) or not isinstance(value, (str, list)):

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -290,6 +290,8 @@ class Record:
         assert isinstance(cluster, Cluster)
         assert cluster.location.start >= 0, cluster
         assert cluster.location.end <= len(self), "%s > %d" % (cluster, len(self))
+        if cluster.contig_edge is None:
+            cluster.contig_edge = cluster.location.start == 0 or cluster.location.end == len(self)
         index = 0
         for i, existing_cluster in enumerate(self._clusters):  # TODO: fix performance
             if cluster.overlaps_with(existing_cluster):

--- a/antismash/common/secmet/test/test_circular_conversion.py
+++ b/antismash/common/secmet/test/test_circular_conversion.py
@@ -1,0 +1,142 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+# for test files, silence irrelevant and noisy pylint warnings
+# pylint: disable=no-self-use,protected-access,missing-docstring
+
+import unittest
+
+from Bio.Seq import UnknownSeq
+from Bio.SeqFeature import SeqFeature
+from Bio.SeqRecord import SeqRecord
+
+from antismash.common.secmet.locations import FeatureLocation, CompoundLocation
+from antismash.common.secmet.record import Record
+
+
+class TestBridgeConversion(unittest.TestCase):
+    def setUp(self):
+        self.seqrec = SeqRecord(UnknownSeq(21))
+        loc = CompoundLocation([FeatureLocation(12, 15, strand=1),
+                                FeatureLocation(18, 21, strand=1),
+                                FeatureLocation(0, 3, strand=1),
+                                FeatureLocation(6, 9, strand=1)],
+                                operator="join")
+        self.seqcds = SeqFeature(loc, type="CDS")
+        self.seqgene = SeqFeature(loc, type="gene")
+        self.seqrec.annotations["topology"] = "circular"
+
+    def test_bridge_in_linear_record(self):
+        self.seqrec.annotations["topology"] = "linear"
+        self.seqrec.features.append(self.seqcds)
+        with self.assertRaisesRegex(ValueError, "Features that bridge"):
+            Record.from_biopython(self.seqrec, taxon='bacteria')
+        self.seqrec.features[0] = self.seqgene
+        with self.assertRaisesRegex(ValueError, "Features that bridge"):
+            Record.from_biopython(self.seqrec, taxon='bacteria')
+
+    def test_cds_split(self):
+        self.seqrec.features.append(self.seqcds)
+        print(self.seqcds)
+        for id_name in ["locus_tag", "gene"]:
+            self.seqcds.qualifiers[id_name] = ["test"]
+            rec = Record.from_biopython(self.seqrec, taxon="bacteria")
+            cdses = rec.get_cds_features()
+            assert len(cdses) == 2
+
+            assert cdses[0].location.start == 0
+            assert cdses[0].location.end == 9
+            assert getattr(cdses[0], id_name) == "test_LOWER"
+            assert cdses[0].get_name() == "test_LOWER"
+
+            assert cdses[1].location.start == 12
+            assert cdses[1].location.end == 21
+            assert getattr(cdses[1], id_name) == "test_UPPER"
+            assert cdses[1].get_name() == "test_UPPER"
+
+            self.seqcds.qualifiers.pop(id_name)
+
+    def test_gene_split(self):
+        self.seqrec.features.append(self.seqgene)
+        for id_name in ["locus_tag", "gene"]:
+            self.seqgene.qualifiers[id_name] = [id_name + "_test"]
+            expected = id_name + "_test"
+            rec = Record.from_biopython(self.seqrec, taxon="bacteria")
+            self.seqgene.qualifiers.pop(id_name)
+            genes = rec.get_genes()
+            assert len(genes) == 2
+
+            if id_name == "gene":
+                id_name = "gene_name"  # since a Gene doesn't have a gene member
+
+            assert genes[0].location.start == 12
+            assert genes[0].location.end == 21
+            assert getattr(genes[0], id_name) == expected + "_UPPER"
+            assert genes[0].get_name() == expected + "_UPPER"
+
+            assert genes[1].location.start == 0
+            assert genes[1].location.end == 9
+            assert getattr(genes[1], id_name) == expected + "_LOWER"
+            assert genes[1].get_name() == expected + "_LOWER"
+
+
+    def test_cds_with_no_id(self):
+        self.seqrec.features.append(self.seqcds)
+        rec = Record.from_biopython(self.seqrec, taxon="bacteria")
+        cdses = rec.get_cds_features()
+        assert len(cdses) == 2
+        assert cdses[0].location.start == 0
+        assert cdses[0].location.end == 9
+        assert cdses[0].get_name() == "bridge_LOWER"
+
+        assert cdses[1].location.start == 12
+        assert cdses[1].location.end == 21
+        assert cdses[1].get_name() == "bridge_UPPER"
+
+    def test_gene_with_no_id(self):
+        self.seqrec.features.append(self.seqgene)
+        rec = Record.from_biopython(self.seqrec, taxon="bacteria")
+        genes = rec.get_genes()
+        assert len(genes) == 2
+
+        assert genes[0].location.start == 12
+        assert genes[0].location.end == 21
+        assert genes[0].get_name() == "bridge_UPPER"
+
+        assert genes[1].location.start == 0
+        assert genes[1].location.end == 9
+        assert genes[1].get_name() == "bridge_LOWER"
+
+
+class TestSingleLower(TestBridgeConversion):
+    def setUp(self):
+        self.seqrec = SeqRecord(UnknownSeq(21))
+        loc = CompoundLocation([FeatureLocation(12, 15, strand=1),
+                                FeatureLocation(18, 21, strand=1),
+                                FeatureLocation(0, 9, strand=1)],
+                                operator="join")
+        self.seqcds = SeqFeature(loc, type="CDS")
+        self.seqgene = SeqFeature(loc, type="gene")
+        self.seqrec.annotations["topology"] = "circular"
+
+
+class TestSingleUpper(TestBridgeConversion):
+    def setUp(self):
+        self.seqrec = SeqRecord(UnknownSeq(21))
+        loc = CompoundLocation([FeatureLocation(12, 21, strand=1),
+                                FeatureLocation(0, 3, strand=1),
+                                FeatureLocation(6, 9, strand=1)],
+                                operator="join")
+        self.seqcds = SeqFeature(loc, type="CDS")
+        self.seqgene = SeqFeature(loc, type="gene")
+        self.seqrec.annotations["topology"] = "circular"
+
+class TestSingleBoth(TestBridgeConversion):
+    def setUp(self):
+        self.seqrec = SeqRecord(UnknownSeq(21))
+        loc = CompoundLocation([FeatureLocation(12, 21, strand=1),
+                                FeatureLocation(0, 9, strand=1)],
+                                operator="join")
+        self.seqcds = SeqFeature(loc, type="CDS")
+        self.seqgene = SeqFeature(loc, type="gene")
+        self.seqrec.annotations["topology"] = "circular"

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -1,0 +1,97 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+# for test files, silence irrelevant and noisy pylint warnings
+# pylint: disable=no-self-use,protected-access,missing-docstring
+
+import unittest
+
+from antismash.common.secmet.locations import (
+    convert_protein_position_to_dna,
+    FeatureLocation,
+    CompoundLocation
+)
+
+
+class TestProteinPositionConversion(unittest.TestCase):
+    def setUp(self):
+        self.func = convert_protein_position_to_dna
+
+    def test_position_conversion_simple_forward(self):
+        location = FeatureLocation(0, 15, strand=1)
+        assert len(location) == 15
+        assert self.func(0, 2, location) == (0, 6)
+        assert self.func(1, 4, location) == (3, 12)
+
+    def test_position_conversion_simple_reverse(self):
+        location = FeatureLocation(0, 15, strand=-1)
+        assert len(location) == 15
+        assert self.func(0, 2, location) == (9, 15)
+        assert self.func(1, 4, location) == (3, 12)
+
+    def test_position_conversion_nonzero_start(self):
+        location = FeatureLocation(6, 21, strand=1)
+        assert len(location) == 15
+        assert self.func(0, 2, location) == (6, 12)
+        assert self.func(1, 4, location) == (9, 18)
+
+        location = FeatureLocation(6, 21, strand=-1)
+        assert len(location) == 15
+        assert self.func(0, 2, location) == (15, 21)
+        assert self.func(1, 4, location) == (9, 18)
+
+    def test_position_conversion_nonzero_start_compound(self):
+        location = CompoundLocation([FeatureLocation(6, 18, strand=1),
+                                     FeatureLocation(24, 27, strand=1)])
+        assert len(location) == 15
+        assert self.func(0, 2, location) == (6, 12)
+        assert self.func(1, 4, location) == (9, 18)
+        assert self.func(3, 5, location) == (15, 27)
+
+        location = CompoundLocation([FeatureLocation(6, 15, strand=-1),
+                                     FeatureLocation(21, 27, strand=-1)])
+        assert len(location) == 15
+        assert self.func(0, 2, location) == (21, 27)
+        assert self.func(1, 4, location) == (9, 24)
+        assert self.func(3, 5, location) == (6, 12)
+
+    def test_position_conversion_compound_forward(self):
+        location = CompoundLocation([FeatureLocation(0, 6, strand=1),
+                                     FeatureLocation(9, 18, strand=1)])
+        assert len(location) == 15
+        assert self.func(0, 4, location) == (0, 15)
+        assert self.func(1, 5, location) == (3, 18)
+
+        location = CompoundLocation([FeatureLocation(0, 6, strand=1),
+                                     FeatureLocation(12, 15, strand=1),
+                                     FeatureLocation(21, 27, strand=1)])
+        assert len(location) == 15
+        assert self.func(0, 4, location) == (0, 24)
+        assert self.func(1, 5, location) == (3, 27)
+        assert self.func(2, 3, location) == (12, 15)
+
+    def test_position_conversion_compound_reverse(self):
+        location = CompoundLocation([FeatureLocation(0, 6, strand=-1),
+                                     FeatureLocation(9, 18, strand=-1)])
+        assert len(location) == 15
+        assert self.func(0, 4, location) == (3, 18)
+        assert self.func(1, 5, location) == (0, 15)
+
+        location = CompoundLocation([FeatureLocation(0, 6, strand=-1),
+                                     FeatureLocation(12, 15, strand=-1),
+                                     FeatureLocation(21, 27, strand=-1)])
+        assert len(location) == 15
+        assert self.func(0, 4, location) == (3, 27)
+        assert self.func(1, 5, location) == (0, 24)
+        assert self.func(2, 3, location) == (12, 15)
+
+    def test_other(self):
+        location = CompoundLocation([FeatureLocation(5922, 6190, strand=1),
+                                     FeatureLocation(5741, 5877, strand=1),
+                                     FeatureLocation(4952, 5682, strand=1)])
+        assert self.func(97, 336, location) == (5243, 6064)
+
+        location = CompoundLocation([FeatureLocation(5922, 6190, strand=-1),
+                                     FeatureLocation(5741, 5877, strand=-1),
+                                     FeatureLocation(4952, 5682, strand=-1)])
+        assert self.func(97, 336, location) == (5078, 5854)

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -8,6 +8,8 @@ import unittest
 
 from antismash.common.secmet.locations import (
     convert_protein_position_to_dna,
+    location_bridges_origin as is_bridged,
+    split_origin_bridging_location as splitter,
     FeatureLocation,
     CompoundLocation
 )
@@ -95,3 +97,87 @@ class TestProteinPositionConversion(unittest.TestCase):
                                      FeatureLocation(5741, 5877, strand=-1),
                                      FeatureLocation(4952, 5682, strand=-1)])
         assert self.func(97, 336, location) == (5078, 5854)
+
+
+def build_compound(pairs, strand, operator="join"):
+    assert len(pairs) >= 2, "invalid CompoundLocation would be created"
+    parts = []
+    for start, end in pairs:
+        parts.append(FeatureLocation(start, end, strand))
+    return CompoundLocation(parts, operator=operator)
+
+
+class TestBridgeDetection(unittest.TestCase):
+    def test_forward(self):
+        assert is_bridged(build_compound([(9, 12), (0, 3)], 1))
+        assert is_bridged(build_compound([(9, 12), (0, 3), (4, 5)], 1))
+        assert is_bridged(build_compound([(4, 5), (9, 12), (0, 3)], 1))
+        assert not is_bridged(build_compound([(0, 3), (9, 12)], 1))
+
+    def test_reverse(self):
+        assert is_bridged(build_compound([(0, 3), (9, 12)], -1))
+        assert is_bridged(build_compound([(6, 9), (0, 3), (15, 18)], -1))
+        assert is_bridged(build_compound([(0, 3), (15, 18), (6, 9)], -1))
+        assert not is_bridged(build_compound([(9, 12), (0, 3)], -1))
+
+    def test_bad_strand(self):
+        pairs = [(9, 12), (0, 3)]
+        assert is_bridged(build_compound(pairs, 1))
+        assert not is_bridged(build_compound(pairs, None))
+
+
+class TestBridgedSplit(unittest.TestCase):
+    def check_pairs(self, parts, pairs):
+        assert [(int(part.start), int(part.end)) for part in parts] == pairs
+
+    def test_simple_forward(self):
+        loc = build_compound([(9, 12), (0, 3)], 1)
+        lower, upper = splitter(loc)
+        self.check_pairs(lower, [(0, 3)])
+        self.check_pairs(upper, [(9, 12)])
+
+    def test_simple_reverse(self):
+        loc = build_compound([(0, 3), (9, 12)], -1)
+        lower, upper = splitter(loc)
+        self.check_pairs(lower, [(0, 3)])
+        self.check_pairs(upper, [(9, 12)])
+
+    def test_extras_forward(self):
+        loc = build_compound([(15, 18), (0, 3), (6, 9)], 1)
+        lower, upper = splitter(loc)
+        self.check_pairs(lower, [(0, 3), (6, 9)])
+        self.check_pairs(upper, [(15, 18)])
+
+        loc = build_compound([(6, 9), (15, 18), (0, 3)], 1)
+        lower, upper = splitter(loc)
+        self.check_pairs(lower, [(0, 3)])
+        self.check_pairs(upper, [(6, 9), (15, 18)])
+
+    def test_extras_reverse(self):
+        loc = build_compound([(6, 9), (0, 3), (15, 18)], -1)
+        lower, upper = splitter(loc)
+        self.check_pairs(lower, [(6, 9), (0, 3)])
+        self.check_pairs(upper, [(15, 18)])
+
+        loc = build_compound([(0, 3), (15, 18), (6, 9)], -1)
+        lower, upper = splitter(loc)
+        self.check_pairs(lower, [(0, 3)])
+        self.check_pairs(upper, [(15, 18), (6, 9)])
+
+    def test_not_bridging_forward(self):
+        loc = build_compound([(0, 3), (9, 12)], 1)
+        with self.assertRaisesRegex(ValueError, "Location does not bridge origin"):
+            print(splitter(loc))
+
+    def test_not_bridging_reverse(self):
+        loc = build_compound([(9, 12), (0, 3)], -1)
+        with self.assertRaisesRegex(ValueError, "Location does not bridge origin"):
+            print(splitter(loc))
+
+    def test_bad_strand(self):
+        loc = build_compound([(9, 12), (0, 3)], -1)
+        loc.parts[0].strand = 1
+        loc.parts[1].strand = -1
+        assert loc.strand is None
+        with self.assertRaisesRegex(ValueError, "Cannot separate bridged location without a valid strand"):
+            print(splitter(loc))

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ tests_require = [
     'pytest',
     'minimock',
     'coverage',
-    'pylint',
+    'pylint == 1.8.4', # until pylint handles ignore lines the same way
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ install_requires = [
     'pandas',
     'matplotlib',
     'scipy',
-    'scikit-learn',
+    'scikit-learn == 0.19.0', # until pickles are rebuilt automatically
 ]
 
 tests_require = [


### PR DESCRIPTION
Prevents potential entire-genome clusters being formed due to a gene/CDS crossing the record origin in a circular genome (e.g. in NZ_CP016793.1).

For now, this is solved by splitting any bridging features into two new features. A more thorough version will need a large rewrite of any section of code that uses a location start and end point.

Also adds a minor change to enforce clusters having a valid `contig_edge` member, though this can still be `True` in circular genomes until clusters can be formed across the bridge.