### PR TITLE
Misc fixes

### DIFF
--- a/antismash/common/layers.py
+++ b/antismash/common/layers.py
@@ -10,7 +10,7 @@
 import os
 from typing import Any, List, Optional, Tuple
 
-from antismash.config import ConfigType
+from antismash.config import ConfigType, get_config
 from antismash.common.module_results import ModuleResults
 from antismash.common.secmet import Record, Cluster
 from antismash.typing import AntismashModule
@@ -158,7 +158,7 @@ class ClusterLayer:
             + ' - Gene Cluster %s. Type = %s. Location: %s - %s nt. ' % (
                         self.get_cluster_number(), self.get_product_string(),
                         self.location.start + 1, self.location.end)
-        if self.probability != "BROKEN":  # TODO: real value check
+        if get_config().cf_create_clusters:
             description_text += 'ClusterFinder probability: %s. ' % self.probability
         description_text += 'Click on genes for more information.'
 

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -352,7 +352,7 @@ def records_contain_shotgun_scaffolds(records: List[Record]) -> bool:
 
 
 def ensure_no_duplicate_cds_gene_ids(sequences: List[Record]) -> None:
-    """ Ensures that every CDS across all sequences has a unique id
+    """ Ensures that every CDS has a unique id within it's Record
 
         Arguments:
             sequences: the secmet.Record instances to process
@@ -360,15 +360,19 @@ def ensure_no_duplicate_cds_gene_ids(sequences: List[Record]) -> None:
         Returns:
             None
     """
-    all_ids = set()  # type: Set[str]
     for sequence in sequences:
+        all_ids = set()  # type: Set[str]
         for cdsfeature in sequence.get_cds_features():
             name = cdsfeature.get_name()
             if name in all_ids:
                 name, _ = generate_unique_id(name[:8], all_ids, start=1)
             if cdsfeature.product is None:
                 cdsfeature.product = name
-            cdsfeature.locus_tag = name
+            # update only the name causing the conflict
+            if cdsfeature.locus_tag == cdsfeature.get_name():
+                cdsfeature.locus_tag = name
+            elif cdsfeature.gene == cdsfeature.get_name():
+                cdsfeature.gene = name
             all_ids.add(name)
 
 

--- a/antismash/common/secmet/qualifiers/secmet.py
+++ b/antismash/common/secmet/qualifiers/secmet.py
@@ -63,8 +63,11 @@ class SecMetQualifier(list):
     def __init__(self, products: Set[str], domains: List["SecMetQualifier.Domain"]) -> None:
         self._domains = domains
         self.domain_ids = []  # type: List[str]
+        self.unique_domain_ids = set()  # type: Set[str]
         for domain in self._domains:
             assert isinstance(domain, SecMetQualifier.Domain)
+            assert domain.query_id not in self.unique_domain_ids, "domains were duplicated"
+            self.unique_domain_ids.add(domain.query_id)
             self.domain_ids.append(domain.query_id)
         self._products = set()  # type: Set[str]
         self.add_products(products)
@@ -91,9 +94,14 @@ class SecMetQualifier(list):
 
     def add_domains(self, domains: List["SecMetQualifier.Domain"]) -> None:
         """ Add a group of Domains to the the qualifier """
+        unique = []
         for domain in domains:
             assert isinstance(domain, SecMetQualifier.Domain)
-        self._domains.extend(domains)
+            if domain.query_id in self.unique_domain_ids:
+                continue  # no sense keeping duplicates
+            self.unique_domain_ids.add(domain.query_id)
+            unique.append(domain)
+        self._domains.extend(unique)
 
     @property
     def domains(self) -> List["SecMetQualifier.Domain"]:

--- a/antismash/detection/hmm_detection/__init__.py
+++ b/antismash/detection/hmm_detection/__init__.py
@@ -92,6 +92,8 @@ def regenerate_previous_results(results: Dict[str, Any], record: Record,
     if set(regenerated.enabled_types) != set(get_supported_cluster_types()):
         raise RuntimeError("Cluster types supported by HMM detection have changed, all results invalid")
     regenerated.rule_results.annotate_cds_features()
+    for border in regenerated.get_predictions():
+        record.add_cluster_border(border)
     return regenerated
 
 

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -652,7 +652,7 @@ def run_antismash(sequence_file: Optional[str], options: ConfigType) -> int:
         log_module_runtimes(results.timings_by_record)
 
     logging.debug("antiSMASH calculation finished at %s; runtime: %s",
-                  str(datetime.now()), str(running_time))
+                  datetime.now().strftime("%Y-%m-%d %H:%M:%S"), str(running_time))
 
     logging.info("antiSMASH status: SUCCESS")
     return 0

--- a/antismash/modules/nrps_pks/nrps_predictor.py
+++ b/antismash/modules/nrps_pks/nrps_predictor.py
@@ -74,7 +74,7 @@ class PredictorSVMResult(Prediction):
                "   <dd>%s</dd>\n"
                "   <dt>Single AA prediction:</dt>\n"
                "   <dd>%s</dd>\n"
-               "   <dt>Nearest stachelhaus code:</dt>\n"
+               "   <dt>Nearest Stachelhaus code:</dt>\n"
                "   <dd>%s</dd>\n"
                "  </dl>\n"
                "  </dd>\n"

--- a/antismash/modules/nrps_pks/orderfinder.py
+++ b/antismash/modules/nrps_pks/orderfinder.py
@@ -32,7 +32,8 @@ def analyse_biosynthetic_order(nrps_pks_features: List[CDSFeature],
     compound_predictions = {}  # type: Dict[int, Tuple[str, bool]]
     # Find NRPS/PKS gene clusters
     nrpspksclusters = [cluster for cluster in record.get_clusters()
-                       if "nrps" in cluster.products or "pks" in "-".join(cluster.products)]
+                       if "nrps" in "-".join(cluster.products)
+                       or "pks" in "-".join(cluster.products)]
     if not nrpspksclusters:
         return {}
     # Predict biosynthetic gene order in gene cluster using starter domains,

--- a/antismash/outputs/html/js.py
+++ b/antismash/outputs/html/js.py
@@ -104,7 +104,7 @@ def convert_cluster_border_features(borders: Iterable[ClusterBorder]) -> List[Di
     # them into a single row
     putatives = [border for border in borders if border.product == clusterfinder.PUTATIVE_PRODUCT]
     non_putatives = [border for border in borders if border.product != clusterfinder.PUTATIVE_PRODUCT]
-    borders = putatives + sorted(non_putatives, key=lambda x: x.product or "unknown")
+    borders = putatives + sorted(non_putatives, key=lambda x: (x.location.start, -len(x.location), x.product or "unknown"))
     for i, border in enumerate(borders):
         js_border = {"start": border.location.start,
                      "end": border.location.end,

--- a/antismash/outputs/html/js/jnj.js
+++ b/antismash/outputs/html/js/jnj.js
@@ -19,7 +19,7 @@ function switch_to_cluster() {
     }
 
     if (geneclusters[anchor] !== undefined) {
-      svgene.drawClusters(anchor+"-svg", [geneclusters[anchor]], 20, 700);
+      svgene.drawCluster(anchor+"-svg", geneclusters[anchor], 20, 700);
     }
     if ($("#" + anchor + "-details-svg").length > 0) {
       jsdomain.drawDomains(anchor+ "-details-svg", details_data[anchor], 40, 700);

--- a/run_antismash.py
+++ b/run_antismash.py
@@ -5,6 +5,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 """Run the antiSMASH pipeline"""
 
+import os
 import sys
 from typing import List
 
@@ -66,8 +67,15 @@ def main(args: List[str]) -> int:
     if options.sequences:
         sequence = options.sequences[0]
         options.__dict__.pop("sequences")
+        if not os.path.exists(sequence):
+            parser.error("Input file does not exist: %s" % sequence)
+            return 1
     else:
         sequence = ""
+
+    if options.reuse_results and not os.path.exists(options.reuse_results):
+        parser.error("Input file does not exist: %s" % options.reuse_results)
+        return 1
 
     options.version = get_version()
 


### PR DESCRIPTION
- correctly sized/drawn HTML clusters when there are many clusters
- order displayed cluster borders deterministicly
- minor cleanup of output and logging
- exit more cleanly when input files don't exist
- prevents SecMetQualifiers from having duplicate domains added when multiple cluster types would add their hits
- prevents renaming of CDS features when they only share a name with a CDS in another record
- generates monomer predictions for relevant nrpsfragment clusters