### PR TITLE
NRPS/PKS drawing split

### DIFF
--- a/antismash/common/json.py
+++ b/antismash/common/json.py
@@ -1,0 +1,61 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+""" JSON-friendly classes explicitly for use by the javascript drawing libraries
+"""
+
+from typing import Any, Iterator, List, Tuple
+
+from antismash.common.secmet.features import CDSFeature
+from antismash.common.secmet.qualifiers import NRPSPKSQualifier
+
+
+class JSONBase(dict):
+    """ A base class for JSON-serialisable objects """
+    def __init__(self, keys: List[str]) -> None:
+        super().__init__()
+        self._keys = keys
+
+    def __getitem__(self, key: str) -> Any:
+        return getattr(self, key)
+
+    def items(self) -> Iterator[Tuple[str, Any]]:  # type: ignore
+        for key in self._keys:
+            yield (key, getattr(self, key))
+
+    def values(self) -> Iterator[Any]:  # type: ignore
+        for key in self._keys:
+            yield getattr(self, key)
+
+    def __len__(self) -> int:
+        return len(self._keys)
+
+
+class JSONDomain(JSONBase):
+    """ A JSON-serialisable object for simplifying domain datatypes throughout this file """
+    def __init__(self, domain: NRPSPKSQualifier.Domain, predictions: List[Tuple[str, str]], napdos_link: str,
+                 blast_link: str, sequence: str, dna: str) -> None:
+        super().__init__(['type', 'start', 'end', 'predictions', 'napdoslink',
+                          'blastlink', 'sequence', 'dna_sequence'])
+        self.type = str(domain.name)
+        self.start = int(domain.start)
+        self.end = int(domain.end)
+        self.predictions = predictions
+        self.napdoslink = str(napdos_link)
+        self.blastlink = str(blast_link)
+        self.sequence = str(sequence)
+        self.dna_sequence = str(dna)
+
+
+class JSONOrf(JSONBase):
+    """ A JSON-serialisable object for simplifying ORF datatypes throughout this file """
+    def __init__(self, feature: CDSFeature) -> None:
+        super().__init__(['id', 'sequence', 'domains'])
+        self.sequence = feature.translation
+        self.id = feature.get_name()
+        self.domains = []  # type: List[JSONDomain]
+
+    def add_domain(self, domain: JSONDomain) -> None:
+        """ Add a JSONDomain to the list of domains in this ORF """
+        assert isinstance(domain, JSONDomain)
+        self.domains.append(domain)

--- a/antismash/common/layers.py
+++ b/antismash/common/layers.py
@@ -93,8 +93,7 @@ class ClusterLayer:
         assert isinstance(cluster_feature, Cluster), type(cluster_feature)
         assert cluster_feature.parent_record
         self.record = record  # type: RecordLayer
-        self.anchor_id = "r{}c{}".format(cluster_feature.parent_record.record_index,
-                                         cluster_feature.get_cluster_number())
+        self.anchor_id = self.build_anchor_id(cluster_feature)
         self.handlers = []  # type: List[AntismashModule]
         self.cluster_feature = cluster_feature  # type: Cluster
 
@@ -227,3 +226,9 @@ class ClusterLayer:
             if hasattr(handler, "generate_sidepanel"):
                 return True
         return False
+
+    @staticmethod
+    def build_anchor_id(cluster: Cluster) -> str:
+        """ Builds a consistent HTML anchor identifier for a cluster """
+        return "r{}c{}".format(cluster.parent_record.record_index,
+                               cluster.get_cluster_number())

--- a/antismash/detection/nrps_pks_domains/__init__.py
+++ b/antismash/detection/nrps_pks_domains/__init__.py
@@ -12,6 +12,7 @@ from antismash.common.secmet import Record
 from antismash.config import ConfigType
 from antismash.config.args import ModuleArgs
 
+from .domain_drawing import generate_details_div, generate_js_domains, will_handle
 from .domain_identification import generate_domains, NRPSPKSDomains
 
 NAME = "nrps_pks_domains"

--- a/antismash/detection/nrps_pks_domains/domain_drawing.py
+++ b/antismash/detection/nrps_pks_domains/domain_drawing.py
@@ -1,0 +1,97 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+""" Generates HTML and JSON for the nrps_pks_domains module
+
+    Generated content will include a prediction consensus in the drawn domains,
+    but will not cover details or options. That is left to the predicting module
+    to describe in the sidepanel.
+"""
+
+from typing import Dict, List, Optional, Union
+
+from jinja2 import FileSystemLoader, Environment, StrictUndefined
+
+from antismash.common import path
+from antismash.common.json import JSONDomain, JSONOrf
+from antismash.common.layers import ClusterLayer, RecordLayer, OptionsLayer
+from antismash.common.module_results import ModuleResults
+from antismash.common.secmet import CDSFeature, Cluster, Record
+from antismash.common.secmet.qualifiers import NRPSPKSQualifier
+
+
+def will_handle(products: List[str]) -> bool:
+    """ Returns true if one or more relevant products are present """
+    return bool(set(products).intersection({"nrps", "t1pks", "t2pks", "transatpks",
+                                            "nrpsfragment", "otherks"}))
+
+def _parse_domain(record: Record, domain: NRPSPKSQualifier.Domain,
+                  feature: CDSFeature) -> JSONDomain:
+    """ Convert a NRPS/PKS domain string to a dict useable by json.dumps
+
+        Arguments:
+            record: the Record containing the domain
+            domain: the NRPSPKSQualifier.Domain in question
+            feature: the CDSFeature that the domain belongs to
+
+        Returns:
+            a populated JSONDomain instance
+    """
+    predictions = list(domain.predictions.items())
+
+    # Create url_link to NaPDoS for C and KS domains
+    napdoslink = ""
+    domainseq = str(feature.translation)[domain.start:domain.end]
+    base = ("http://napdos.ucsd.edu/cgi-bin/process_request.cgi?"
+            "query_type=aa&amp;ref_seq_file=all_{0}_public_12062011.faa"
+            "&amp;Sequence=%3E{0}_domain_from_antiSMASH%0D{1}")
+    if domain.name == "PKS_KS":
+        napdoslink = base.format("KS", domainseq)
+    elif "Condensation" in domain.name:
+        napdoslink = base.format("C", domainseq)
+    blastlink = ("http://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE=Proteins"
+                 "&amp;PROGRAM=blastp&amp;BLAST_PROGRAMS=blastp"
+                 "&amp;QUERY={}"
+                 "&amp;LINK_LOC=protein&amp;PAGE_TYPE=BlastSearch").format(domainseq)
+
+    dna_sequence = feature.extract(record.seq)
+    return JSONDomain(domain, predictions, napdoslink, blastlink, domainseq, dna_sequence)
+
+
+def generate_js_domains(cluster: Cluster, record: Record) -> Optional[Dict[str, Union[str, List[JSONOrf]]]]:
+    """ Creates a JSON-like structure for domains, used by javascript in
+        drawing the domains
+    """
+    orfs = []  # type: List[JSONOrf]
+    for feature in cluster.cds_children:
+        if not feature.nrps_pks:
+            continue
+        js_orf = JSONOrf(feature)
+        for domain in feature.nrps_pks.domains:
+            js_orf.add_domain(_parse_domain(record, domain, feature))
+        orfs.append(js_orf)
+
+    if orfs:
+        return {'id': ClusterLayer.build_anchor_id(cluster),
+                'orfs': orfs}
+
+    return None
+
+
+def has_domain_details(cluster: Cluster) -> bool:
+    """ Returns True if there are domain details to be had for the given cluster """
+    for cds in cluster.cds_children:
+        if cds.nrps_pks:
+            return True
+    return False
+
+
+def generate_details_div(cluster_layer: ClusterLayer, _void: ModuleResults,
+                         record_layer: RecordLayer, options_layer: OptionsLayer) -> str:
+    """ Generate the details section of NRPS/PKS domains in the main HTML output """
+    env = Environment(loader=FileSystemLoader(path.get_full_path(__file__, 'templates')),
+                      autoescape=True, undefined=StrictUndefined)
+    template = env.get_template('details.html')
+    details_div = template.render(has_domain_details=has_domain_details,
+                                  cluster=cluster_layer)
+    return details_div

--- a/antismash/detection/nrps_pks_domains/templates/details.html
+++ b/antismash/detection/nrps_pks_domains/templates/details.html
@@ -1,6 +1,6 @@
 <div class="details">
   <h3>Detailed annotation</h3>
-    {% if cluster.get_domain_details() %}
+    {% if has_domain_details %}
       <div class="details-svg" id="{{cluster.anchor_id}}-details-svg"></div>
     {% endif %}
 </div>

--- a/antismash/modules/nrps_pks/__init__.py
+++ b/antismash/modules/nrps_pks/__init__.py
@@ -11,7 +11,7 @@ from antismash.common.secmet import Record
 from antismash.config import ConfigType
 from antismash.config.args import ModuleArgs
 
-from .html_output import will_handle, generate_sidepanel, generate_details_div, generate_js_domains
+from .html_output import will_handle, generate_sidepanel
 from .results import NRPS_PKS_Results
 from .specific_analysis import specific_analysis
 

--- a/antismash/outputs/html/generator.py
+++ b/antismash/outputs/html/generator.py
@@ -49,16 +49,15 @@ def generate_webpage(records: List[Record], results: List[Dict[str, module_resul
     for i, record in enumerate(records):
         json_record = json_records[i]
         json_record['seq_id'] = "".join(char for char in json_record['seq_id'] if char in string.printable)
-        for json_cluster in json_record['clusters']:  # json clusters
-            from antismash import get_analysis_modules  # TODO break circular dependency
-            handlers = find_plugins_for_cluster(get_analysis_modules(), json_cluster)
+        for cluster, json_cluster in zip(record.get_clusters(), json_record['clusters']):
+            from antismash import get_all_modules  # TODO break circular dependency
+            handlers = find_plugins_for_cluster(get_all_modules(), json_cluster)
             for handler in handlers:
                 # if there's no results for the module, don't let it try
                 if handler.__name__ not in results[i]:
                     continue
                 if "generate_js_domains" in dir(handler):
-                    domains = handler.generate_js_domains(json_cluster, record,  # type: ignore
-                                                          results[i][handler.__name__], options)
+                    domains = handler.generate_js_domains(cluster, record)
                     if domains:
                         js_domains.append(domains)
 

--- a/antismash/typing.pyi
+++ b/antismash/typing.pyi
@@ -7,12 +7,13 @@
 # pylint: disable=pointless-statement,unused-argument,missing-docstring,multiple-statements
 
 from types import ModuleType
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from .config.args import ModuleArgs
 
+from .common.json import JSONOrf
 from .common.module_results import ModuleResults
-from .common.secmet import Record
+from .common.secmet import Cluster, Record
 
 
 class ConfigType:
@@ -54,3 +55,7 @@ class AntismashModule(ModuleType):
     # not implemented by every module, but by most
     @staticmethod
     def will_handle(products: List[str]) -> bool: ...
+
+    @staticmethod
+    def generate_js_domains(cluster: Cluster, record: Record
+                            ) -> Optional[Dict[str, Union[str, List[JSONOrf]]]]: ...


### PR DESCRIPTION
Moves responsibility for the drawing of NRPS/PKS domains from the nrps_pks module (which may get excluded by `--minimal`) to the nrps_pks_domains detection module, which finds the domains to start with.