### PR TITLE
RiPP cleavage fixes

### DIFF
--- a/antismash/modules/lanthipeptides/test/test_specific_analysis.py
+++ b/antismash/modules/lanthipeptides/test/test_specific_analysis.py
@@ -22,87 +22,81 @@ from antismash.modules.lanthipeptides.specific_analysis import (
 
 
 class TestLanthipeptide(unittest.TestCase):
+    def setUp(self):
+        self.lant = Lanthipeptide(CleavageSiteHit(42, 17, 'Class-I'), 23)
+
     def test_init(self):
         "Test Lanthipeptide instantiation"
-        lant = Lanthipeptide(CleavageSiteHit(23, 42, 17, 'Class-I'), 23)
-        self.assertTrue(isinstance(lant, Lanthipeptide))
-        self.assertEqual(23, lant.start)
-        self.assertEqual(42, lant.end)
-        self.assertEqual(17, lant.score)
-        self.assertEqual('Class-I', lant.lantype)
-        self.assertEqual('', lant.core)
+        assert isinstance(self.lant, Lanthipeptide)
+        assert self.lant.end == 42
+        assert self.lant.score == 17
+        assert self.lant.lantype == "Class-I"
+        assert self.lant.core == ""
         with self.assertRaisesRegex(AssertionError, "calculating weight without a core"):
-            print(lant.molecular_weight)
+            print(self.lant.molecular_weight)
 
     def test_repr(self):
         "Test Lanthipeptide representation"
-        lant = Lanthipeptide(CleavageSiteHit(23, 42, 17, 'Class-I'), 23)
-        expected = "Lanthipeptide(23..42, 17, 'Class-I', '', -1, -1(-1))"
-        self.assertEqual(expected, repr(lant))
+        expected = "Lanthipeptide(..42, 17, 'Class-I', '', -1, -1(-1))"
+        assert repr(self.lant) == expected
 
     def test_core(self):
         "Test Lanthipeptide.core"
-        lant = Lanthipeptide(CleavageSiteHit(23, 42, 17, 'Class-I'), 23)
-        self.assertEqual('', lant.core)
-        assert lant.core_analysis is None
-        lant.core = "MAGICHAT"
-        self.assertEqual('MAGICHAT', lant.core)
-        assert lant.core_analysis
+        assert self.lant.core == ""
+        assert self.lant.core_analysis is None
+        self.lant.core = "MAGICHAT"
+        assert self.lant.core == "MAGICHAT"
+        assert self.lant.core_analysis
 
     def test_core_ignore_invalid(self):
         "Test Lanthipeptide.core ignores invalid amino acids"
-        lant = Lanthipeptide(CleavageSiteHit(23, 42, 17, 'Class-I'), 23)
-        self.assertEqual('', lant.core)
-        assert lant.core_analysis is None
-        lant.core = "MAGICXHAT"
-        self.assertEqual('MAGICXHAT', lant.core)
-        assert lant.core_analysis
+        assert self.lant.core == ""
+        assert self.lant.core_analysis is None
+        self.lant.core = "MAGICXHAT"
+        assert self.lant.core == "MAGICXHAT"
+        assert self.lant.core_analysis
 
     def test_number_of_lan_bridges(self):
         "Test Lanthipeptide.number_of_lan_bridges"
-        lant = Lanthipeptide(CleavageSiteHit(23, 42, 17, 'Class-I'), 23)
-        lant.core = "MAGICHAT"
-        self.assertEqual(1, lant.number_of_lan_bridges)
-        lant.core = "MAGICHATCS"
-        self.assertEqual(2, lant.number_of_lan_bridges)
-        lant.core = "MAGICHATCSS"
-        self.assertEqual(2, lant.number_of_lan_bridges)
-        lant.core = "MAGICHATCT"
-        self.assertEqual(2, lant.number_of_lan_bridges)
-        lant.core = "MAGICHATCCS"
-        self.assertEqual(2, lant.number_of_lan_bridges)
+        self.lant.core = "MAGICHAT"
+        assert self.lant.number_of_lan_bridges == 1
+        self.lant.core = "MAGICHATCS"
+        assert self.lant.number_of_lan_bridges == 2
+        self.lant.core = "MAGICHATCSS"
+        assert self.lant.number_of_lan_bridges == 2
+        self.lant.core = "MAGICHATCT"
+        assert self.lant.number_of_lan_bridges == 2
+        self.lant.core = "MAGICHATCCS"
+        assert self.lant.number_of_lan_bridges == 2
 
     def test_monoisotopic_mass(self):
         "Test Lanthipeptide.monoisotopic_mass"
-        lant = Lanthipeptide(CleavageSiteHit(23, 42, 17, 'Class-I'), 23)
-        lant.core = "MAGICHAT"
+        self.lant.core = "MAGICHAT"
         analysis = ProteinAnalysis("MAGICHAT", monoisotopic=True)
         weight = analysis.molecular_weight()
         # Thr is assumed to be dehydrated
         weight -= 18
-        self.assertAlmostEqual(weight, lant.monoisotopic_mass)
-        self.assertAlmostEqual(weight, lant._monoisotopic_weight)
+        self.assertAlmostEqual(weight, self.lant.monoisotopic_mass)
+        self.assertAlmostEqual(weight, self.lant._monoisotopic_weight)
 
     def test_molecular_weight(self):
         "Test Lanthipeptide.molecular_weight"
-        lant = Lanthipeptide(CleavageSiteHit(23, 42, 17, 'Class-I'), 23)
-        lant.core = "MAGICHAT"
+        self.lant.core = "MAGICHAT"
         analysis = ProteinAnalysis("MAGICHAT", monoisotopic=False)
         weight = analysis.molecular_weight()
         # Thr is assumed to be dehydrated
         weight -= 18.02
-        self.assertAlmostEqual(weight, lant.molecular_weight)
-        self.assertAlmostEqual(weight, lant._weight)
+        self.assertAlmostEqual(weight, self.lant.molecular_weight)
+        self.assertAlmostEqual(weight, self.lant._weight)
 
     def test_alternative_weights(self):
         "Test Lanthipeptide.alt_weights"
-        lant = Lanthipeptide(CleavageSiteHit(23, 42, 17, 'Class-I'), 23)
-        lant.core = "MAGICHATS"
+        self.lant.core = "MAGICHATS"
         analysis = ProteinAnalysis("MAGICHATS", monoisotopic=False)
         weight = analysis.molecular_weight()
         # One Ser/Thr is assumed to be dehydrated, but not the other
         weight -= 18.02
-        self.assertEqual([weight], lant.alternative_weights)
+        self.assertEqual([weight], self.lant.alternative_weights)
 
 
 class TestSpecificAnalysis(unittest.TestCase):
@@ -123,7 +117,6 @@ class TestSpecificAnalysis(unittest.TestCase):
         self.hmmpfam_return_vals.append([fake_hit])
 
         res = predict_cleavage_site('foo', 'bar')
-        self.assertEqual(23, res.start)
         self.assertEqual(42, res.end)
         self.assertEqual(17, res.score)
         self.assertEqual('fake', res.lantype)
@@ -132,7 +125,7 @@ class TestSpecificAnalysis(unittest.TestCase):
         "Test lanthipeptides.result_vec_to_features()"
         orig_feature = DummyCDS(0, 165)
         orig_feature.locus_tag = 'FAKE0001'
-        vec = Lanthipeptide(CleavageSiteHit(17, 23, 42, 'Class-I'), 23)
+        vec = Lanthipeptide(CleavageSiteHit(23, 42, 'Class-I'), 23)
         seq = "TAILTAILTAILTAILTAILTAILTAILTAILTAILCC"
         vec.core = seq
         vec.leader = "HEADHEADHEAD"
@@ -179,7 +172,7 @@ class TestNoCores(unittest.TestCase):
 
     def test_prediction_with_no_core(self):
         # the real cleavage site result (+1 at end for the C)
-        cleavage_result = CleavageSiteHit(start=38, end=48, score=-6.8, lantype="Class-II")
+        cleavage_result = CleavageSiteHit(end=48, score=-6.8, lantype="Class-II")
         mock("lanthi.predict_cleavage_site", returns=cleavage_result)
 
         for part in ["I", "II"]:
@@ -187,18 +180,18 @@ class TestNoCores(unittest.TestCase):
 
     def test_prediction_with_core_class1(self):
         # the cleavage result adjusted to leave at least one amino in core
-        cleavage_result = CleavageSiteHit(start=38, end=40, score=-6.8, lantype="Class-I")
+        cleavage_result = CleavageSiteHit(end=40, score=-6.8, lantype="Class-I")
         mock("lanthi.predict_cleavage_site", returns=cleavage_result)
         results = run_lanthipred(DummyRecord(features=[self.cds]),
                                  self.cds, "Class-I", self.domains)
         assert results
-        assert str(results).startswith("Lanthipeptide(38..40, -6, 'Class-I', 'LSQGLGGC', 1, 715")
+        assert str(results).startswith("Lanthipeptide(..40, -6, 'Class-I', 'LSQGLGGC', 1, 715")
 
     def test_prediction_with_core_class2(self):
         # the cleavage result adjusted to leave at least one amino in core
-        cleavage_result = CleavageSiteHit(start=38, end=40, score=-6.8, lantype="Class-II")
+        cleavage_result = CleavageSiteHit(end=40, score=-6.8, lantype="Class-II")
         mock("lanthi.predict_cleavage_site", returns=cleavage_result)
         results = run_lanthipred(DummyRecord(features=[self.cds]),
                                  self.cds, "Class-II", self.domains)
         assert results is not None
-        assert str(results).startswith("Lanthipeptide(38..40, -6, 'Class-II', 'LSQGLGGC', 1, 715")
+        assert str(results).startswith("Lanthipeptide(..40, -6, 'Class-II', 'LSQGLGGC', 1, 715")

--- a/antismash/modules/lassopeptides/test/test_specific_analysis.py
+++ b/antismash/modules/lassopeptides/test/test_specific_analysis.py
@@ -22,9 +22,8 @@ from antismash.modules.lassopeptides.specific_analysis import (
 class TestLassopeptide(unittest.TestCase):
     def test_init(self):
         "Test Lassopeptide instantiation"
-        lasso = Lassopeptide(23, 42, 17, 51, "", "")
+        lasso = Lassopeptide(42, 17, 51, "", "")
         self.assertTrue(isinstance(lasso, Lassopeptide))
-        self.assertEqual(23, lasso.start)
         self.assertEqual(42, lasso.end)
         self.assertEqual(17, lasso.score)
         self.assertEqual('Class II', lasso._lassotype)
@@ -35,25 +34,25 @@ class TestLassopeptide(unittest.TestCase):
 
     def test_repr(self):
         "Test Lassopeptide representation"
-        lasso = Lassopeptide(23, 42, 17, 51, "lead", "ABCDEFGHIJKLM")
-        expected = "Lassopeptide(23..42, 17, 'Class II', 'ABCDEFGHIJKLM', 0, -1(-1), , )"
+        lasso = Lassopeptide(42, 17, 51, "lead", "ABCDEFGHIJKLM")
+        expected = "Lassopeptide(..42, 17, 'Class II', 'ABCDEFGHIJKLM', 0, -1(-1), , )"
         self.assertEqual(expected, repr(lasso))
 
     def test_core(self):
         "Test Lassopeptide.core"
-        lasso = Lassopeptide(23, 42, 17, 51, "lead", "MAGICHAT")
+        lasso = Lassopeptide(42, 17, 51, "lead", "MAGICHAT")
         assert lasso.core == "MAGICHAT"
         self.assertAlmostEqual(lasso.monoisotopic_mass, 784.3, delta=1)
 
     def test_core_ignore_invalid(self):
         "Test Lassopeptide.core ignores invalid amino acids"
-        lasso = Lassopeptide(23, 42, 17, 51, "lead", "MAGICXHAT")
+        lasso = Lassopeptide(42, 17, 51, "lead", "MAGICXHAT")
         assert lasso.core == "MAGICXHAT"
         self.assertAlmostEqual(lasso.monoisotopic_mass, 784.3, delta=1)
 
     def test_number_bridges_class(self):
         "Test Lassopeptide.number_bridges"
-        lasso = Lassopeptide(23, 42, 20, 51, "lead", "MAGIXHAT")
+        lasso = Lassopeptide(42, 20, 51, "lead", "MAGIXHAT")
         self.assertEqual(0, lasso.number_bridges)
         self.assertEqual('Class II', lasso.lasso_class)
         lasso.core = "CAGIMHAC"
@@ -65,7 +64,7 @@ class TestLassopeptide(unittest.TestCase):
 
     def test_monoisotopic_mass(self):
         "Test Lassopeptide.monoisotopic_mass"
-        lasso = Lassopeptide(23, 42, 17, 51, "lead", "MAGICHATTIP")
+        lasso = Lassopeptide(42, 17, 51, "lead", "MAGICHATTIP")
         lasso.c_cut = "TIP"
         analysis = ProteinAnalysis("MAGICHATTIP", monoisotopic=True)
         cut_analysis = ProteinAnalysis("MAGICHAT", monoisotopic=True)
@@ -76,7 +75,7 @@ class TestLassopeptide(unittest.TestCase):
 
     def test_molecular_weight(self):
         "Test Lassopeptide.molecular_weight"
-        lasso = Lassopeptide(23, 42, 17, 51, "lead", "MAGICHATTIP")
+        lasso = Lassopeptide(42, 17, 51, "lead", "MAGICHATTIP")
         lasso.c_cut = "TIP"
         analysis = ProteinAnalysis("MAGICHATTIP", monoisotopic=False)
         cut_analysis = ProteinAnalysis("MAGICHAT", monoisotopic=False)
@@ -87,7 +86,7 @@ class TestLassopeptide(unittest.TestCase):
 
     def test_macrolactam(self):
         "Test Lassopeptide.macrolactam"
-        lasso = Lassopeptide(23, 42, 20, 51, "lead", "GAAAAADLLLLLLLLL")
+        lasso = Lassopeptide(42, 20, 51, "lead", "GAAAAADLLLLLLLLL")
         self.assertEqual("GAAAAAD", lasso.macrolactam)
 
 
@@ -110,16 +109,15 @@ class TestSpecificAnalysis(unittest.TestCase):
     def test_predict_cleavage_site(self):
         "Test lassopeptides.predict_cleavage_site()"
         resvec = predict_cleavage_site('foo', 'bar', 51)
-        self.assertEqual((None, None, None), resvec)
+        assert resvec == (None, None)
         fake_hit = self.FakeHit(24, 42, 17, 'Class II')
         self.hmmpfam_return_vals.append([fake_hit, fake_hit])
 
         resvec = predict_cleavage_site('foo', 'bar', 51)
-        self.assertEqual((None, None, None), resvec)
+        assert resvec == (None, None)
 
-        start, end, score = predict_cleavage_site('foo', 'bar', 15)
+        end, score = predict_cleavage_site('foo', 'bar', 15)
 
-        self.assertEqual(23, start)
         self.assertEqual(41, end)
         self.assertEqual(17, score)
 
@@ -127,7 +125,7 @@ class TestSpecificAnalysis(unittest.TestCase):
         "Test lassopeptides.result_vec_to_features()"
         orig_feature = DummyCDS(0, 165, strand=1, locus_tag='FAKE0001')
         seq = "TAILTAILTAILTAILTAILTAILTAILTAILTAILCCTIP"
-        vec = Lassopeptide(17, 23, 42, 51, "HEADHEADHEAD", seq)
+        vec = Lassopeptide(23, 42, 51, "HEADHEADHEAD", seq)
         vec.c_cut = "TIP"
         motif = result_vec_to_motif(orig_feature, vec)
         assert motif.locus_tag == "FAKE0001"

--- a/antismash/modules/thiopeptides/test/test_thio_specific_analysis.py
+++ b/antismash/modules/thiopeptides/test/test_thio_specific_analysis.py
@@ -22,9 +22,8 @@ from antismash.modules.thiopeptides.specific_analysis import (
 class TestThiopeptide(unittest.TestCase):
     def test_init(self):
         "Test Thiopeptide instantiation"
-        thio = Thiopeptide(20, 31, 32, 51)
+        thio = Thiopeptide(31, 32, 51)
         assert isinstance(thio, Thiopeptide)
-        self.assertEqual(20, thio.start)
         self.assertEqual(31, thio.end)
         self.assertEqual(32, thio.score)
         self.assertEqual('', thio.thio_type)
@@ -35,19 +34,19 @@ class TestThiopeptide(unittest.TestCase):
 
     def test_repr(self):
         "Test Thiopeptide representation"
-        thio = Thiopeptide(20, 31, 32, 51)
+        thio = Thiopeptide(31, 32, 51)
         thio.core = "MAGIC"
         thio.thio_type = "Type I"
         thio.c_cut = "DUMMYC"
         thio.macrocycle = "dummy macro"
-        expected = ("Thiopeptide(20..31, 32, 'MAGIC', 'Type I', -1.0(-1.0), dummy macro, False, "
+        expected = ("Thiopeptide(..31, 32, 'MAGIC', 'Type I', -1.0(-1.0), dummy macro, False, "
                     "Central ring: pyridine tetrasubstituted (hydroxyl group present); second macrocycle, "
                     "DUMMYC)")
         self.assertEqual(expected, repr(thio))
 
     def test_core(self):
         "Test Thiopeptide.core"
-        thio = Thiopeptide(20, 31, 32, 51)
+        thio = Thiopeptide(31, 32, 51)
         thio.core = "MAGICHAT"
         self.assertEqual('MAGICHAT', thio.core)
         assert thio.core_analysis
@@ -57,7 +56,7 @@ class TestThiopeptide(unittest.TestCase):
 
     def test_macrocycle_size(self):
         "Test Thiopeptide._predict_macrocycle"
-        thio = Thiopeptide(20, 31, 32, 51)
+        thio = Thiopeptide(31, 32, 51)
         thio.core = "SAAAAAAAASC"
         self.assertEqual('26-member', thio.macrocycle)
         thio.core = "SAAAAAAAAASSSSSS"
@@ -70,7 +69,7 @@ class TestThiopeptide(unittest.TestCase):
     def test_weights(self):
         "Test Thiopeptide.alt_mature_weights"
         # includes all weights (even after maturation)
-        thio = Thiopeptide(23, 42, 17, 51)
+        thio = Thiopeptide(42, 17, 51)
         thio.core = "MAGICCHATS"
         thio.amidation = True
         thio.thio_type = "Type I"
@@ -123,13 +122,12 @@ class TestSpecificAnalysis(unittest.TestCase):
     def test_predict_cleavage_site(self):
         "Test thiopeptides.predict_cleavage_site()"
         resvec = predict_cleavage_site('foo', 'bar', 51)
-        self.assertEqual((None, None, None), resvec)
+        assert resvec == (None, None)
         fake_hit = FakeHit(24, 42, 17, 'fake')
         self.hmmpfam_return_vals.append([fake_hit])
 
-        start, end, score = predict_cleavage_site('foo', 'bar', 15)
+        end, score = predict_cleavage_site('foo', 'bar', 15)
 
-        self.assertEqual(24, start)
         self.assertEqual(28, end)
         self.assertEqual(17, score)
 
@@ -137,7 +135,7 @@ class TestSpecificAnalysis(unittest.TestCase):
         "Test thiopeptides.result_vec_to_features()"
         loc = FeatureLocation(0, 66, strand=1)
         orig_feature = DummyCDS(0, 66, locus_tag='FAKE0001')
-        vec = Thiopeptide(17, 23, 42, 51)
+        vec = Thiopeptide(23, 42, 51)
         seq = 'SCTSSCTSS'
         vec.thio_type = 'Type III'
         vec.core = seq


### PR DESCRIPTION
The 'start' position of a cleavage site was calculated and never used. Since all affected RiPP analyses used the beginning of the CDS translation as their leader start point anyway, the 'start' has been removed from all these functions and classes.

Also ensures that those regex-based cleavage site locators that subtract from the cleavage site position don't end up with a non-existant leader.