### PR TITLE
NRPS/PKS domain fixes

### DIFF
--- a/antismash/detection/nrps_pks_domains/domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/domain_identification.py
@@ -5,6 +5,7 @@
     features.
 """
 
+from collections import defaultdict
 import logging
 from typing import Any, Dict, List, Optional
 
@@ -309,12 +310,7 @@ def generate_domain_features(record: Record, gene: CDSFeature,
             a dictionary mapping the HMMResult used to the matching AntismashDomain
     """
     new_features = {}
-    at_domains = 0
-    a_domains = 0
-    cal_domains = 0
-    kr_domains = 0
-    ks_domains = 0
-    x_domains = 0
+    domain_counts = defaultdict(int)  # type: Dict[str, int]
     for domain in domains:
         loc = gene.get_sub_location_from_protein_coordinates(domain.query_start, domain.query_end)
 
@@ -330,24 +326,9 @@ def generate_domain_features(record: Record, gene: CDSFeature,
         transl_table = gene.transl_table or 1
         new_feature.translation = str(new_feature.extract(record.seq).translate(table=transl_table))
 
-        if domain.hit_id == "AMP-binding":
-            a_domains += 1
-            domain_name = "{}_A{}".format(gene.get_name(), a_domains)
-        elif domain.hit_id == "PKS_AT":
-            at_domains += 1
-            domain_name = "{}_AT{}".format(gene.get_name(), at_domains)
-        elif domain.hit_id == "CAL_domain":
-            cal_domains += 1
-            domain_name = gene.get_name() + "_CAL" + str(cal_domains)
-        elif domain.hit_id == "PKS_KR":
-            kr_domains += 1
-            domain_name = gene.get_name() + "_KR" + str(kr_domains)
-        elif domain.hit_id == "PKS_KS":
-            ks_domains += 1
-            domain_name = gene.get_name() + "_KS" + str(ks_domains)
-        else:
-            x_domains += 1
-            domain_name = gene.get_name().partition(".")[0] + "_Xdom" + str(x_domains)
+        domain_counts[domain.hit_id] += 1  # 1-indexed, so increment before use
+        domain_name = "{}_{}.{}".format(gene.get_name(), domain.hit_id, domain_counts[domain.hit_id])
+
         new_feature.domain_id = "nrpspksdomains_" + domain_name
         new_feature.label = domain_name
 

--- a/antismash/modules/nrps_pks/parsers.py
+++ b/antismash/modules/nrps_pks/parsers.py
@@ -186,7 +186,7 @@ def update_prediction(locus: str, preds: Dict[str, str], target: str,
             locus: the name of the gene
             preds: a dict mapping domain label (e.g. nrpspksdomains_SCO123_AT1)
                    to a prediction for that domain
-            target: "_KS" or "_AT" for checking AT vs trans-AT
+            target: "PKS_KS" or "PKS_AT" for checking AT vs trans-AT
             target_list: a list of positions in the gene's domains where target is found
             lists: a list of lists of positions for KR, DH and ER domains
             mappings: a list of dictionaries mapping a prediction to an altered prediction
@@ -196,7 +196,7 @@ def update_prediction(locus: str, preds: Dict[str, str], target: str,
     """
     assert len(lists) == len(mappings)
     for idx, target_element in enumerate(target_list):
-        key = "nrpspksdomains_" + locus + target + str(idx + 1)
+        key = "nrpspksdomains_{}_{}.{}".format(locus, target, idx + 1)
         for sublist, mapping in zip(lists, mappings):
             for position in sublist:
                 if not target_element < position:
@@ -235,10 +235,10 @@ def modify_monomer_predictions(cds_features: List[CDSFeature], predictions: Dict
                  find_duplicate_position(domain_names, 'PKS_ER')]
 
         if 'transatpks' not in cds.region.products:
-            label = "_AT"
+            label = "PKS_AT"
             data = find_duplicate_position(domain_names, 'PKS_AT')
         else:
-            label = "_KS"
+            label = "PKS_KS"
             data = find_duplicate_position(domain_names, 'PKS_KS')
         # TODO: should the transat predictions be used if relevant?
         update_prediction(cds.get_name(), predictions, label, data, lists, mappings)

--- a/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
+++ b/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
@@ -49,10 +49,12 @@ class IntegrationNRPSPKS(unittest.TestCase):
         filename = helpers.get_path_to_balhymicin_genbank()
         results = helpers.run_and_regenerate_results_for_module(filename, nrps_pks, self.options)
         assert len(results.domain_predictions) == 9
-        a_domains = ["bpsA_A1", "bpsA_A2", "bpsA_A3", "bpsB_A1", "bpsB_A2", "bpsB_A3",
-                     "bpsC_A1", "bpsD_A1"]
-        feature_names = ['nrpspksdomains_%s' % a_dom for a_dom in a_domains]
-        feature_names.append("nrpspksdomains_pks_CAL1")
+        a_domains = [("bpsA", 1), ("bpsA", 2), ("bpsA", 3),
+                     ("bpsB", 1), ("bpsB", 2), ("bpsB", 3),
+                     ("bpsC", 1),
+                     ("bpsD", 1)]
+        nrps_names = ['nrpspksdomains_%s_AMP-binding.%d' % a_dom for a_dom in a_domains]
+        feature_names = nrps_names + ["nrpspksdomains_pks_CAL_domain.1"]
         assert set(results.domain_predictions) == set(feature_names)
 
         assert set(results.domain_predictions[feature_names[0]]) == {"NRPSPredictor2"}
@@ -62,10 +64,10 @@ class IntegrationNRPSPKS(unittest.TestCase):
                 continue
             nrpspred2_results[domain] = methods["NRPSPredictor2"].get_classification()
         expected_preds = [["leu"], ["bht"], ["asn"], ["hpg"], ["hpg"], ["bht"], ["dhpg"], ["tyr"], ["pk"]]
-        expected_nrps2 = {name: pred for name, pred in zip(feature_names, expected_preds) if name[-2] == "A"}
+        expected_nrps2 = {name: pred for name, pred in zip(nrps_names, expected_preds)}
         assert nrpspred2_results == expected_nrps2
 
-        cal = results.domain_predictions["nrpspksdomains_pks_CAL1"]["minowa_cal"]
+        cal = results.domain_predictions["nrpspksdomains_pks_CAL_domain.1"]["minowa_cal"]
         assert len(cal.predictions) == 5
         assert cal.predictions[0] == ["AHBA", 167.0]
 
@@ -85,13 +87,14 @@ class IntegrationNRPSPKS(unittest.TestCase):
         filename = path.get_full_path(__file__, 'data', 'CP002271.1.cluster019.gbk')
         results = helpers.run_and_regenerate_results_for_module(filename, nrps_pks, self.options)
         # catch ordering changes along with ensuring ATResults are there
-        assert results.domain_predictions["nrpspksdomains_STAUR_3982_AT1"]["signature"].predictions[0].score == 87.5
+        pred = results.domain_predictions["nrpspksdomains_STAUR_3982_PKS_AT.1"]
+        assert pred["signature"].predictions[0].score == 87.5
         # ensure all genes are present and have the right consensus
-        assert results.consensus == {'nrpspksdomains_STAUR_3982_AT1': 'ohmmal',
-                                     'nrpspksdomains_STAUR_3983_AT1': 'ccmmal',
-                                     'nrpspksdomains_STAUR_3984_AT1': 'ccmmal',
-                                     'nrpspksdomains_STAUR_3985_AT1': 'mmal',
-                                     'nrpspksdomains_STAUR_3985_AT2': 'pk'}
+        assert results.consensus == {'nrpspksdomains_STAUR_3982_PKS_AT.1': 'ohmmal',
+                                     'nrpspksdomains_STAUR_3983_PKS_AT.1': 'ccmmal',
+                                     'nrpspksdomains_STAUR_3984_PKS_AT.1': 'ccmmal',
+                                     'nrpspksdomains_STAUR_3985_PKS_AT.1': 'mmal',
+                                     'nrpspksdomains_STAUR_3985_PKS_AT.2': 'pk'}
         assert len(results.region_predictions) == 1
         assert list(results.region_predictions) == [1]
         assert len(results.region_predictions[1]) == 1
@@ -100,15 +103,15 @@ class IntegrationNRPSPKS(unittest.TestCase):
         assert sc_pred.polymer == '(ccmmal) + (ccmmal) + (mmal-pk) + (ohmmal)'
         assert sc_pred.domain_docking_used
         assert len(results.domain_predictions) == 10
-        expected_domains = {'nrpspksdomains_STAUR_3982_AT1',
-                            'nrpspksdomains_STAUR_3983_AT1',
-                            'nrpspksdomains_STAUR_3984_AT1',
-                            'nrpspksdomains_STAUR_3985_AT1',
-                            'nrpspksdomains_STAUR_3985_AT2',
-                            'nrpspksdomains_STAUR_3972_KR1',
-                            'nrpspksdomains_STAUR_3984_KR1',
-                            'nrpspksdomains_STAUR_3985_KR1',
-                            'nrpspksdomains_STAUR_3983_KR1',
-                            'nrpspksdomains_STAUR_3983_KR1',
-                            'nrpspksdomains_STAUR_3982_KR1'}
+        expected_domains = {'nrpspksdomains_STAUR_3982_PKS_AT.1',
+                            'nrpspksdomains_STAUR_3983_PKS_AT.1',
+                            'nrpspksdomains_STAUR_3984_PKS_AT.1',
+                            'nrpspksdomains_STAUR_3985_PKS_AT.1',
+                            'nrpspksdomains_STAUR_3985_PKS_AT.2',
+                            'nrpspksdomains_STAUR_3972_PKS_KR.1',
+                            'nrpspksdomains_STAUR_3984_PKS_KR.1',
+                            'nrpspksdomains_STAUR_3985_PKS_KR.1',
+                            'nrpspksdomains_STAUR_3983_PKS_KR.1',
+                            'nrpspksdomains_STAUR_3983_PKS_KR.1',
+                            'nrpspksdomains_STAUR_3982_PKS_KR.1'}
         assert set(results.domain_predictions) == expected_domains

--- a/antismash/modules/nrps_pks/test/test_parsers.py
+++ b/antismash/modules/nrps_pks/test/test_parsers.py
@@ -4,6 +4,7 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=no-self-use,protected-access,missing-docstring
 
+import functools
 import unittest
 
 from antismash.common.secmet import Region
@@ -39,6 +40,10 @@ class TestNRPSParserMonomerModification(unittest.TestCase):
                             'ccmmal', 'emal', 'redmmal', 'mmal', 'ccmxmal',
                             'mxmal', 'redemal', 'ohmal', 'mal', 'ccemal']
 
+    @staticmethod
+    def gen_specific_domain_name(locus, pks_variant, counter):
+        return "nrpspksdomains_{}_PKS_{}.{}".format(locus, pks_variant, counter)
+
     def gen_domain_names(self):
         # generates a dict with values containing
         # - each type in a list once alone
@@ -61,7 +66,7 @@ class TestNRPSParserMonomerModification(unittest.TestCase):
             for domain in gene_domains:
                 if domain == "PKS_" + pks_type:
                     counter += 1
-                    res["nrpspksdomains_{}_{}{}".format(gene_name, pks_type, counter)] = pred
+                    res[self.gen_specific_domain_name(gene_name, pks_type, counter)] = pred
         return res
 
     def detect_change(self, preds, original, expected):
@@ -72,35 +77,52 @@ class TestNRPSParserMonomerModification(unittest.TestCase):
         assert changed == expected
 
     def test_insert_modified_monomers(self):
+        dom_name = functools.partial(self.gen_specific_domain_name, "all")
+
         # in pairs of (at, trans-at)
         expected_changes = [
-            (set(), set()),  # redmxmal
-            ({('nrpspksdomains_all_AT3', 'redmal'), ('nrpspksdomains_all_AT1', 'redmal'), ('nrpspksdomains_all_AT2', 'redmal')},
-             {('nrpspksdomains_all_KS2', 'redmal'), ('nrpspksdomains_all_KS3', 'redmal'), ('nrpspksdomains_all_KS1', 'redmal')}),  # ccmal
-            ({('nrpspksdomains_all_AT3', 'redemal'), ('nrpspksdomains_all_AT1', 'redemal'), ('nrpspksdomains_all_AT2', 'redemal')},
-             {('nrpspksdomains_all_KS2', 'redemal'), ('nrpspksdomains_all_KS3', 'redemal'), ('nrpspksdomains_all_KS1', 'redemal')}),  # ohemal
-            ({('nrpspksdomains_all_AT3', 'redmxmal'), ('nrpspksdomains_all_AT1', 'redmxmal'), ('nrpspksdomains_all_AT2', 'redmxmal')},
-             {('nrpspksdomains_all_KS2', 'redmxmal'), ('nrpspksdomains_all_KS3', 'redmxmal'), ('nrpspksdomains_all_KS1', 'redmxmal')}),  # ohmxmal
-            ({('nrpspksdomains_all_AT3', 'redmmal'), ('nrpspksdomains_all_AT1', 'redmmal'), ('nrpspksdomains_all_AT2', 'redmmal')},
-             {('nrpspksdomains_all_KS2', 'redmmal'), ('nrpspksdomains_all_KS3', 'redmmal'), ('nrpspksdomains_all_KS1', 'redmmal')}),  # ohmmal
-            ({('nrpspksdomains_all_AT3', 'redmmal'), ('nrpspksdomains_all_AT1', 'redmmal'), ('nrpspksdomains_all_AT2', 'redmmal')},
-             {('nrpspksdomains_all_KS2', 'redmmal'), ('nrpspksdomains_all_KS3', 'redmmal'), ('nrpspksdomains_all_KS1', 'redmmal')}),  # ccmmal
-            ({('nrpspksdomains_all_AT3', 'redemal'), ('nrpspksdomains_all_AT1', 'redemal'), ('nrpspksdomains_all_AT2', 'redemal')},
-             {('nrpspksdomains_all_KS2', 'redemal'), ('nrpspksdomains_all_KS1', 'redemal')}),  # emal
-            (set(), set()),  # redmmal
-            ({('nrpspksdomains_all_AT3', 'redmmal'), ('nrpspksdomains_all_AT1', 'redmmal'), ('nrpspksdomains_all_AT2', 'redmmal')},
-             {('nrpspksdomains_all_KS2', 'redmmal'), ('nrpspksdomains_all_KS1', 'redmmal')}),  # mmal
-            ({('nrpspksdomains_all_AT3', 'redmxmal'), ('nrpspksdomains_all_AT1', 'redmxmal'), ('nrpspksdomains_all_AT2', 'redmxmal')},
-             {('nrpspksdomains_all_KS2', 'redmxmal'), ('nrpspksdomains_all_KS3', 'redmxmal'), ('nrpspksdomains_all_KS1', 'redmxmal')}),  # ccmxmal
-            ({('nrpspksdomains_all_AT3', 'redmxmal'), ('nrpspksdomains_all_AT1', 'redmxmal'), ('nrpspksdomains_all_AT2', 'redmxmal')},
-             {('nrpspksdomains_all_KS2', 'redmxmal'), ('nrpspksdomains_all_KS1', 'redmxmal')}),  # mxmal
-            (set(), set()),  # redemal
-            ({('nrpspksdomains_all_AT3', 'redmal'), ('nrpspksdomains_all_AT1', 'redmal'), ('nrpspksdomains_all_AT2', 'redmal')},
-             {('nrpspksdomains_all_KS2', 'redmal'), ('nrpspksdomains_all_KS3', 'redmal'), ('nrpspksdomains_all_KS1', 'redmal')}),  # ohmal
-            ({('nrpspksdomains_all_AT3', 'redmal'), ('nrpspksdomains_all_AT1', 'redmal'), ('nrpspksdomains_all_AT2', 'redmal')},
-             {('nrpspksdomains_all_KS2', 'redmal'), ('nrpspksdomains_all_KS1', 'redmal')}),   # mal
-            ({('nrpspksdomains_all_AT3', 'redemal'), ('nrpspksdomains_all_AT1', 'redemal'), ('nrpspksdomains_all_AT2', 'redemal')},
-             {('nrpspksdomains_all_KS2', 'redemal'), ('nrpspksdomains_all_KS3', 'redemal'), ('nrpspksdomains_all_KS1', 'redemal')}),  # ccemal
+            # redmxmal
+            (set(), set()),
+            # ccmal
+            ({(dom_name("AT", 3), 'redmal'), (dom_name("AT", 1), 'redmal'), (dom_name("AT", 2), 'redmal')},
+             {(dom_name("KS", 2), 'redmal'), (dom_name("KS", 3), 'redmal'), (dom_name("KS", 1), 'redmal')}),
+            # ohemal
+            ({(dom_name("AT", 3), 'redemal'), (dom_name("AT", 1), 'redemal'), (dom_name("AT", 2), 'redemal')},
+             {(dom_name("KS", 2), 'redemal'), (dom_name("KS", 3), 'redemal'), (dom_name("KS", 1), 'redemal')}),
+            # ohmxmal
+            ({(dom_name("AT", 3), 'redmxmal'), (dom_name("AT", 1), 'redmxmal'), (dom_name("AT", 2), 'redmxmal')},
+             {(dom_name("KS", 2), 'redmxmal'), (dom_name("KS", 3), 'redmxmal'), (dom_name("KS", 1), 'redmxmal')}),
+            # ohmmal
+            ({(dom_name("AT", 3), 'redmmal'), (dom_name("AT", 1), 'redmmal'), (dom_name("AT", 2), 'redmmal')},
+             {(dom_name("KS", 2), 'redmmal'), (dom_name("KS", 3), 'redmmal'), (dom_name("KS", 1), 'redmmal')}),
+            # ccmal
+            ({(dom_name("AT", 3), 'redmmal'), (dom_name("AT", 1), 'redmmal'), (dom_name("AT", 2), 'redmmal')},
+             {(dom_name("KS", 2), 'redmmal'), (dom_name("KS", 3), 'redmmal'), (dom_name("KS", 1), 'redmmal')}),
+            # emal
+            ({(dom_name("AT", 3), 'redemal'), (dom_name("AT", 1), 'redemal'), (dom_name("AT", 2), 'redemal')},
+             {(dom_name("KS", 2), 'redemal'), (dom_name("KS", 1), 'redemal')}),
+            # redmmal
+            (set(), set()),
+            # mmal
+            ({(dom_name("AT", 3), 'redmmal'), (dom_name("AT", 1), 'redmmal'), (dom_name("AT", 2), 'redmmal')},
+             {(dom_name("KS", 2), 'redmmal'), (dom_name("KS", 1), 'redmmal')}),
+            # ccmxmal
+            ({(dom_name("AT", 3), 'redmxmal'), (dom_name("AT", 1), 'redmxmal'), (dom_name("AT", 2), 'redmxmal')},
+             {(dom_name("KS", 2), 'redmxmal'), (dom_name("KS", 3), 'redmxmal'), (dom_name("KS", 1), 'redmxmal')}),
+            # mxmal
+            ({(dom_name("AT", 3), 'redmxmal'), (dom_name("AT", 1), 'redmxmal'), (dom_name("AT", 2), 'redmxmal')},
+             {(dom_name("KS", 2), 'redmxmal'), (dom_name("KS", 1), 'redmxmal')}),
+            # redemal
+            (set(), set()),
+            # ohmal
+            ({(dom_name("AT", 3), 'redmal'), (dom_name("AT", 1), 'redmal'), (dom_name("AT", 2), 'redmal')},
+             {(dom_name("KS", 2), 'redmal'), (dom_name("KS", 3), 'redmal'), (dom_name("KS", 1), 'redmal')}),
+            # mal
+            ({(dom_name("AT", 3), 'redmal'), (dom_name("AT", 1), 'redmal'), (dom_name("AT", 2), 'redmal')},
+             {(dom_name("KS", 2), 'redmal'), (dom_name("KS", 1), 'redmal')}),
+            # ccemal
+            ({(dom_name("AT", 3), 'redemal'), (dom_name("AT", 1), 'redemal'), (dom_name("AT", 2), 'redemal')},
+             {(dom_name("KS", 2), 'redemal'), (dom_name("KS", 3), 'redemal'), (dom_name("KS", 1), 'redemal')}),
         ]
 
         for pred, expected in zip(self.predictions, expected_changes):


### PR DESCRIPTION
All but a few domains found by nrps_pks_domains were being labelled as X in genbank output/features. 

Also incidentally fixes cases where CDS names contained `.`, which caused generation of non-unique names for those mislabeled X domains.