### PR TITLE
NRPS PKS ordering fix

### DIFF
--- a/antismash/modules/nrps_pks/orderfinder.py
+++ b/antismash/modules/nrps_pks/orderfinder.py
@@ -230,7 +230,7 @@ def find_possible_orders(cds_features: List[CDSFeature], start_cds: Optional[CDS
             a list of lists, each sublist being a unique ordering of the
             provided CDSFeatures
     """
-    assert cds_features
+    assert len(cds_features) < 11, "input too large, function is O(n!)"
     assert start_cds is None or isinstance(start_cds, CDSFeature)
     assert end_cds is None or isinstance(end_cds, CDSFeature)
     if start_cds or end_cds:

--- a/antismash/modules/nrps_pks/orderfinder.py
+++ b/antismash/modules/nrps_pks/orderfinder.py
@@ -248,7 +248,7 @@ def find_possible_orders(cds_features: List[CDSFeature], start_cds: Optional[CDS
     end = []  # type: List[CDSFeature]
     if end_cds:
         end = [end_cds]
-    for order in list(itertools.permutations(cds_to_order, len(cds_to_order))):
+    for order in itertools.permutations(cds_to_order, len(cds_to_order)):
         possible_orders.append(start + list(order) + end)
     # ensure the list of possible orders is itself ordered for reliability
     return sorted(possible_orders, key=lambda x: [g.location.start for g in x])

--- a/antismash/modules/nrps_pks/orderfinder.py
+++ b/antismash/modules/nrps_pks/orderfinder.py
@@ -49,7 +49,10 @@ def analyse_biosynthetic_order(nrps_pks_features: List[CDSFeature],
         # If more than three PKS cds features, use dock_dom_analysis if possible to identify order
         if 3 < pks_count < 11 and not nrps_count and not hybrid_count:
             logging.debug("SuperCluster %d monomer ordering method: domain docking analysis", supercluster_number)
-            geneorder = perform_docking_domain_analysis(cds_in_supercluster)
+            # since this will grow as n!, limit to only the relevant CDSes
+            pks_cdses = list(filter(lambda cds: "PKS" in cds.nrps_pks.type, cds_in_supercluster))
+            assert 3 < len(pks_cdses) < 11
+            geneorder = perform_docking_domain_analysis(pks_cdses)
             docking = True
         else:
             logging.debug("SuperCluster %d monomer ordering method: colinear", supercluster_number)

--- a/antismash/modules/nrps_pks/test/test_orderfinder.py
+++ b/antismash/modules/nrps_pks/test/test_orderfinder.py
@@ -259,6 +259,11 @@ class TestOrdering(unittest.TestCase):
         best = [gene.get_name() for gene in best]
         assert best == ['STAUR_3983', 'STAUR_3972', 'STAUR_3984', 'STAUR_3985', 'STAUR_3982']
 
+    def test_order_finding_size(self):
+        cdss = [DummyCDS() for i in range(11)]
+        with self.assertRaisesRegex(AssertionError, "input too large"):
+            orderfinder.find_possible_orders(cdss, None, None)
+
 
 class TestEnzymeCounter(unittest.TestCase):
     def run_finder(self, names, all_domains, types=None):


### PR DESCRIPTION
Strictly enforces limits the size of inputs to itertools.permutations, since that's O(n!).

Some timings from a run of the maximum size from my machine:
nrps_pks module total, including non-relevant sections: 153s  (with profiling active, 101s without)
generation of orders (with itertools): 17s  (of which sorting them is 13s)
ranking the generated orders: 108s

The ranking can easily be parallelised in the future when we have a little more time, but for now this will prevent hitting swap and crashing.