### PR TITLE
nrps_pks: remove assert on comma

### DIFF
--- a/antismash/modules/nrps_pks/nrps_predictor.py
+++ b/antismash/modules/nrps_pks/nrps_predictor.py
@@ -40,7 +40,6 @@ class PredictorSVMResult(Prediction):
         self.single_amino_pred = str(single_amino_pred)
         assert ',' not in self.single_amino_pred
         self.stachelhaus_code = str(stachelhaus_code)
-        assert ',' not in self.stachelhaus_code
         self.uncertain = bool(uncertain)
 
     def get_classification(self) -> List[str]:


### PR DESCRIPTION
fails on N-(1,1-dimethyl-1-allyl)Trp which is in antismash/modules/nrps_pks/external/NRPSPredictor2/data/labeled_sig