### PR TITLE
all_orf: change naming scheme of allorfs

### DIFF
--- a/antismash/modules/lanthipeptides/specific_analysis.py
+++ b/antismash/modules/lanthipeptides/specific_analysis.py
@@ -89,7 +89,7 @@ class LanthiResults(module_results.ModuleResults):
                 results.motifs_by_locus[locus].append(Prepeptide.from_json(motif))
         results.clusters = {int(key): set(val) for key, val in json["clusters"].items()}
         for location, name in json["new_cds_features"]:
-            cds = all_orfs.create_feature_from_location(record, location, label=name)
+            cds = all_orfs.create_feature_from_location(record, location, name)
             results.new_cds_features.add(cds)
         return results
 

--- a/antismash/modules/lassopeptides/specific_analysis.py
+++ b/antismash/modules/lassopeptides/specific_analysis.py
@@ -66,7 +66,7 @@ class LassoResults(module_results.ModuleResults):
         results.clusters = {int(key): set(val) for key, val in json["clusters"].items()}
         for location, name in json["new_cds_features"]:
             loc = location_from_string(location)
-            cds = all_orfs.create_feature_from_location(record, loc, label=name)
+            cds = all_orfs.create_feature_from_location(record, loc, name)
             results.new_cds_features.add(cds)
         return results
 

--- a/antismash/modules/sactipeptides/specific_analysis.py
+++ b/antismash/modules/sactipeptides/specific_analysis.py
@@ -67,7 +67,7 @@ class SactiResults(module_results.ModuleResults):
         results.clusters = {int(key): set(val) for key, val in json["clusters"].items()}
         for location, name in json["new_cds_features"]:
             loc = location_from_string(location)
-            cds = all_orfs.create_feature_from_location(record, loc, label=name)
+            cds = all_orfs.create_feature_from_location(record, loc, name)
             results.new_cds_features.add(cds)
         return results
 

--- a/antismash/modules/sactipeptides/test/integration_sactipeptides.py
+++ b/antismash/modules/sactipeptides/test/integration_sactipeptides.py
@@ -42,11 +42,11 @@ class IntegrationSactipeptides(unittest.TestCase):
         # make sure that unannotated orfs are found if they are the precursor
         result = self.run_analyis("AP012495.1_c14_missing_precursor.gbk")
         assert isinstance(result, SactiResults)
-        assert list(result.motifs_by_locus) == ["allorf041"]
-        prepeptide = result.motifs_by_locus["allorf041"][0]
+        assert list(result.motifs_by_locus) == ["allorf_9736_9867"]
+        prepeptide = result.motifs_by_locus["allorf_9736_9867"][0]
         assert prepeptide.location.start == 9735
         assert prepeptide.location.end == 9867
-        assert prepeptide.get_name() == "allorf041"
+        assert prepeptide.get_name() == "allorf_9736_9867"
         assert prepeptide.leader == "MKKAVIVENK"
         assert prepeptide.core == "GCATCSIGAACLVDGPIPDFEIAGATGLFGLWG"
         self.assertAlmostEqual(prepeptide.score, 31.)

--- a/antismash/modules/thiopeptides/specific_analysis.py
+++ b/antismash/modules/thiopeptides/specific_analysis.py
@@ -54,7 +54,7 @@ class ThioResults(module_results.ModuleResults):
             results.clusters_with_motifs.add(record.get_cluster(cluster))
         for cluster, features in json["cds_features"]:
             for location, name in features:
-                cds = all_orfs.create_feature_from_location(record, location, label=name)
+                cds = all_orfs.create_feature_from_location(record, location, name)
                 results.cds_features[cluster].append(cds)
         return results
 


### PR DESCRIPTION
changed the naming scheme for allorfs as the current one fails in case two of the detection modules accept orfs with same counters (e.g. allorf004). We suggest using allorf_X_Y, where X is start and Y is end of this potential CDS candidate. Because you are checking if any new potential CDS overlaps any of the existing (or accepted by other modules, hence also existing, here i am not sure yet?), this should guarantee that there is no name collision.
Also removed the counter and made the label mandatory instead.