### PR TITLE
Fixes from refseq minimal runs

### DIFF
--- a/antismash/common/logs.py
+++ b/antismash/common/logs.py
@@ -1,0 +1,85 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+""" Logging related code too involved to inline into other parts of the code. """
+
+import contextlib
+import logging
+import os
+import sys
+from typing import Any, Generator
+from typing import Dict  # comment hints, pylint: disable=unused-import
+
+
+@contextlib.contextmanager
+def changed_logging(logfile: str = None, verbose: bool = False, debug: bool = False) -> Generator:
+    """ Changes logging setup for the duration of the context
+        e.g.:
+
+        with changed_logging(logfile="test.log", debug=True):
+            logging.warning("warning")  # will appear on console and in test.log
+            logging.debug("debug")  # will appear on console and in test.log
+        logging.warning("warning")  # will appear on console only
+        logging.debug("debug")  # will not appear in either
+
+        Arguments:
+            logfile: None or the path to a file to write logging messages to
+            verbose: whether to show INFO level messages and above
+            debug: whether to show DEBUG level messages and above
+
+        Returns:
+            None
+    """
+    try:
+        def new_critical(*args: Any) -> None:
+            """ make critical messages yellow and without the normal timestamp """
+            msg = "\033[1;33m{}\033[0m".format(args[0])
+            print(msg % args[1:], file=sys.stderr)
+        logging.critical = new_critical  # type: ignore
+
+        log_level = logging.WARNING
+        if debug:
+            log_level = logging.DEBUG
+        elif verbose:
+            log_level = logging.INFO
+
+        log_format = '%(levelname)-8s %(asctime)s   %(message)s'
+        date_format = "%d/%m %H:%M:%S"
+        logging.basicConfig(format=log_format, datefmt=date_format)
+        logger = logging.getLogger()
+        original_log_level = logger.getEffectiveLevel()
+        logger.setLevel(log_level)
+
+        handler = None
+        original_levels = {}  # type: Dict[logging.Handler, int]
+
+        if logfile:
+            # since INFO is always wanted in the logfile, set the global level to that
+            if log_level > logging.INFO:
+                logger.setLevel(logging.INFO)
+                # and make sure the existing handlers are more restrictive
+                for stream in logger.handlers:
+                    original_levels[stream] = stream.level
+                    stream.setLevel(log_level)
+
+            # create any container directory if required
+            dirname = os.path.dirname(logfile)
+            if dirname and not os.path.exists(dirname):
+                os.makedirs(dirname)
+            handler = logging.FileHandler(logfile)
+            # always treat the logfile as at least verbose
+            handler.setLevel(min(log_level, logging.INFO))
+            handler.setFormatter(logging.Formatter(fmt=log_format, datefmt=date_format))
+            logger.addHandler(handler)
+        yield
+    finally:
+        # put things back into original condition
+        logger.setLevel(original_log_level)
+        if handler:
+            # remove the file handler and ensure it's closed
+            logger.removeHandler(handler)
+            handler.flush()
+            handler.close()
+            # and set all other handlers back to their original level
+            for stream, original_level in original_levels.items():
+                stream.setLevel(original_level)

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -28,7 +28,7 @@ class Feature:
         assert isinstance(location, (FeatureLocation, CompoundLocation)), type(location)
         if location_bridges_origin(location):
             raise ValueError("Features that bridge the record origin cannot be directly created: %s" % location)
-        assert location.start < location.end, "Feature location invalid"
+        assert location.start <= location.end, "Feature location invalid: %s" % location
         self.location = location
         self.notes = []  # type: List[str]
         assert feature_type

--- a/antismash/common/secmet/features/test/test_cds_feature.py
+++ b/antismash/common/secmet/features/test/test_cds_feature.py
@@ -157,6 +157,23 @@ class TestCDSProteinLocation(unittest.TestCase):
         assert new.parts[1].end == 6
         assert new.extract(self.magic_split).translate() == self.translation[2:4]
 
+    def test_frameshifted_location(self):
+        location = CompoundLocation([FeatureLocation(3, 9, 1), FeatureLocation(8, 14, 1)])
+        assert len(location) == 12
+        seq = Seq("ATGATGAGCCCTCGTCTAGACTACAATGA")
+        extracted = location.extract(seq)
+        assert extracted == "ATGAGCCCCTCG"
+        assert len(extracted) == len(location)
+        translation = extracted.translate()
+        assert translation == "MSPS"
+
+        cds = CDSFeature(location, locus_tag="test", translation=translation)
+        new = cds.get_sub_location_from_protein_coordinates(1, 3)
+        assert isinstance(new, CompoundLocation)
+        assert len(new.parts) == 2
+        assert new.start == 6
+        assert new.end == 11
+
     def test_complicated(self):
         parts = [FeatureLocation(121124, 122061, 1), FeatureLocation(122339, 122383, 1),
                  FeatureLocation(122559, 122666, 1), FeatureLocation(122712, 122874, 1),

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -119,12 +119,14 @@ def location_bridges_origin(location: CompoundLocation) -> bool:
         return False
 
     for i, part in enumerate(location.parts[1:]):
+        prev = location.parts[i]
         if location.strand == 1:
-            if part.start <= location.parts[i].end:
+            if prev.start > part.start:
                 return True
         else:
-            if part.start >= location.parts[i].end:
+            if part.end > prev.end:
                 return True
+
     return False
 
 

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -642,7 +642,10 @@ class Record:
                         feature.qualifiers["gene"] = [gene_name + "_UPPER"]
                     if locus_tag:
                         feature.qualifiers["locus_tag"] = [locus_tag + "_UPPER"]
-                record.add_biopython_feature(feature)
+
+                # since CDSs need translations, skip if too small or not a CDS
+                if feature.type != "CDS" or len(feature) >= 3:
+                    record.add_biopython_feature(feature)
 
                 # adjust the current feature to only be the lower section
                 if len(lower) > 1:
@@ -656,9 +659,13 @@ class Record:
                         feature.qualifiers["locus_tag"] = [locus_tag + "_LOWER"]
 
             if feature.type in postponed_features:
-                postponed_features[feature.type].append(feature)
+                # again, since CDSs need translations, skip if too small or not a CDS
+                if feature.type != "CDS" or len(feature) >= 3:
+                    postponed_features[feature.type].append(feature)
                 continue
-            record.add_biopython_feature(feature)
+            # again, since CDSs need translations, skip if too small or not a CDS
+            if feature.type != "CDS" or len(feature) >= 3:
+                record.add_biopython_feature(feature)
 
             # reset back to how the feature looked originally
             if locations_adjusted:

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -175,6 +175,10 @@ class TestBridgeDetection(unittest.TestCase):
         assert is_bridged(build_compound(pairs, 1))
         assert not is_bridged(build_compound(pairs, None))
 
+    def test_not_bridged(self):
+        assert not is_bridged(build_compound([(1, 6), (5, 10)], 1))
+        assert not is_bridged(build_compound([(5, 10), (1, 6)], -1))
+
 
 class TestBridgedSplit(unittest.TestCase):
     def check_pairs(self, parts, pairs):

--- a/antismash/common/test/test_logs.py
+++ b/antismash/common/test/test_logs.py
@@ -1,0 +1,119 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+# for test files, silence irrelevant and noisy pylint warnings
+# pylint: disable=no-self-use,protected-access,missing-docstring
+
+import logging
+import os
+import pytest
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+import unittest
+
+from antismash.common.logs import changed_logging
+
+
+
+class LogTest(unittest.TestCase):
+    def setUp(self):
+        self.logger = logging.getLogger()
+        assert self.logger.getEffectiveLevel() == logging.WARNING
+
+    # grab the pytest logging capture fixture
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        caplog.set_level(logging.WARNING)
+        self.caplog = caplog  # pylint: disable=attribute-defined-outside-init
+
+    def test_debug(self):
+        logging.debug("before")
+        with changed_logging(debug=True):
+            assert self.logger.getEffectiveLevel() == logging.DEBUG
+            logging.debug("during")
+        assert self.logger.getEffectiveLevel() == logging.WARNING
+        logging.debug("after")
+        for _, level, msg in self.caplog.record_tuples:
+            assert level == logging.DEBUG
+            assert "during" in msg
+
+    def test_verbose(self):
+        logging.info("before")
+        with changed_logging(verbose=True):
+            logging.debug("during")
+            logging.info("during")
+            assert self.logger.getEffectiveLevel() == logging.INFO
+        logging.info("after")
+        assert self.logger.getEffectiveLevel() == logging.WARNING
+        for _, level, msg in self.caplog.record_tuples:
+            assert level == logging.INFO
+            assert "during" in msg
+
+    def test_default(self):
+        logging.warning("before")
+        with changed_logging():
+            logging.warning("during")
+            logging.info("during")
+            logging.debug("during")
+            assert self.logger.getEffectiveLevel() == logging.WARNING
+        logging.warning("after")
+        assert self.logger.getEffectiveLevel() == logging.WARNING
+        assert len(self.caplog.records) == 3
+        for _, level, _ in self.caplog.record_tuples:
+            assert level == logging.WARNING
+
+    def test_debug_file(self):
+        with NamedTemporaryFile() as logfile:
+            with changed_logging(logfile=logfile.name, debug=True):
+                logging.debug("during")
+            logging.debug("after")
+
+            with open(logfile.name) as handle:
+                content = handle.read()
+            assert "during" in content
+            assert "after" not in content
+
+    def test_logfile_always_verbose(self):
+        with NamedTemporaryFile() as logfile:
+            with changed_logging(logfile=logfile.name):
+                logging.info("during")
+                logging.debug("debug")
+            logging.info("after")
+
+            with open(logfile.name) as handle:
+                content = handle.read()
+            assert "during" in content
+            assert "debug" not in content
+            assert "after" not in content
+
+    def test_logfile_default(self):
+        with NamedTemporaryFile() as logfile:
+            with changed_logging(logfile=logfile.name):
+                logging.warning("during")
+                logging.debug("debug")
+            logging.warning("after")
+
+            with open(logfile.name) as handle:
+                content = handle.read()
+            assert "during" in content
+            assert "debug" not in content
+            assert "after" not in content
+
+    def test_logfile_debug(self):
+        with NamedTemporaryFile() as logfile:
+            with changed_logging(logfile=logfile.name, debug=True):
+                logging.debug("during")
+            logging.debug("after")
+
+            with open(logfile.name) as handle:
+                content = handle.read()
+            assert "during" in content
+            assert "after" not in content
+
+    def test_logfile_nested_dirs(self):
+        with TemporaryDirectory() as temp_dir:
+            child = os.path.join(temp_dir, "child")
+            assert not os.path.exists(child)
+            logfile = os.path.join(child, "nested", "logfile")
+            with changed_logging(logfile=logfile):
+                logging.warning("during")
+            assert os.path.exists(logfile)


### PR DESCRIPTION
For 6,000 refseq assemblies run, the vast majority of errors were due to some unexpected locations:
- point locations where the start and end are the same are now allowed (e.g. `138^139`)
- the cross-origin feature split has been tweaked to avoid fragments with less than three bases (e.g. `join(2813..2849, 1)`
- programmed frameshifts backwards into the previous location part (e.g. `join(156..168, 168..200)`) no longer are mistakenly detected as crossing the origin (this was the only issue, location operations on these worked fine)

Another issue was that using logfiles in sequential runs within the same process caused file descriptor leaks, so logging setup has been reworked into a context manager to ensure it properly cleans up the changes it made and the open log file handler.