### PR TITLE
Fixes from refseq default runs

### DIFF
--- a/antismash/common/secmet/features/antismash_feature.py
+++ b/antismash/common/secmet/features/antismash_feature.py
@@ -42,6 +42,8 @@ class AntismashFeature(Feature):
     @translation.setter
     def translation(self, translation: str) -> None:
         assert isinstance(translation, str)
+        if "*" in translation:
+            raise ValueError("Domain translations cannot contain stop codons")
         if not translation:
             raise ValueError("Domain translation cannot be empty")
         self._translation = translation

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -70,10 +70,17 @@ class Feature:
             raise ValueError("Protein start coordinate must be less than the end coordinate")
 
         dna_start, dna_end = convert_protein_position_to_dna(start, end, self.location)
-
-        if not 0 <= dna_start - self.location.start < self.location.end - 2:
+        if not dna_start < dna_end:
+            raise ValueError("Invalid protein coordinate conversion (start %d, end %d)" % (dna_start, dna_end))
+        if dna_start not in self.location:
             raise ValueError("Protein coordinate start %d (nucl %d) is outside feature %s" % (start, dna_start, self))
-        if not 2 < dna_end - self.location.start - 1 <= self.location.end:
+        # end check is more complicated as 'in' is inclusive and end is exclusive
+        end_contained = dna_end in self.location or dna_end == self.location.end
+        for part in self.location.parts:
+            if dna_end in part or dna_end == part.end:
+                end_contained = True
+                break
+        if not end_contained:
             raise ValueError("Protein coordinate end %d (nucl %d) is outside feature %s" % (end, dna_end, self))
 
         if not isinstance(self.location, CompoundLocation):

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -16,12 +16,42 @@ from antismash.common.secmet.locations import (
 )
 
 
+def _adjust_location_by_offset(location: FeatureLocation, offset: int) -> FeatureLocation:
+    """ Adjusts the given location to account for an offset (e.g. start_codon)
+    """
+    assert -2 <= offset <= 2, "invalid offset %d" % offset
+
+    def adjust_single_location(part: FeatureLocation) -> FeatureLocation:
+        """ only functions on FeatureLocation """
+        assert not isinstance(part, CompoundLocation)
+        start = part.start
+        end = part.end
+        if part.strand == -1:
+            end = type(end)(end + offset)
+        else:
+            start = type(start)(start + offset)
+        return FeatureLocation(start, end, part.strand)
+
+    if isinstance(location, CompoundLocation):
+        part = location.parts[0]
+        if location.strand == -1:
+            assert part.end == location.end
+        else:
+            assert part.start == location.start
+        location = CompoundLocation([adjust_single_location(part)] + location.parts[1:])
+    else:
+        location = adjust_single_location(location)
+
+    return location
+
+
 class Feature:
     """ The base class of any feature. Contains only a location, the label of the
         subclass, the 'notes' qualifier, and other qualifiers not tracked by any
         subclass.
     """
-    __slots__ = ["location", "notes", "type", "_qualifiers", "created_by_antismash"]
+    __slots__ = ["location", "notes", "type", "_qualifiers", "created_by_antismash",
+                 "_original_codon_start"]
 
     def __init__(self, location: FeatureLocation, feature_type: str,
                  created_by_antismash: bool = False) -> None:
@@ -35,6 +65,7 @@ class Feature:
         self.type = str(feature_type)
         self._qualifiers = OrderedDict()  # type: Dict[str, List[str]]
         self.created_by_antismash = bool(created_by_antismash)
+        self._original_codon_start = None  # type: Optional[int]
 
     @property
     def strand(self) -> int:
@@ -164,6 +195,12 @@ class Feature:
             quals["note"] = sorted(notes)
         if self.created_by_antismash:
             quals["tool"] = ["antismash"]
+        if self._original_codon_start is not None:
+            start = int(self._original_codon_start)
+            quals["codon_start"] = [str(start + 1)]
+            # adjust location back if neccessary
+            if self._original_codon_start != 0:
+                feature.location = _adjust_location_by_offset(feature.location, -start)
         # sorted here to match the behaviour of biopython
         for key, val in sorted(quals.items()):
             feature.qualifiers[key] = val
@@ -210,6 +247,15 @@ class Feature:
             assert isinstance(feature, Feature)
         if leftovers:
             feature.created_by_antismash = leftovers.get("tool") == ["antismash"]
+            if "codon_start" in leftovers:
+                codon_start = int(leftovers.pop("codon_start")[0]) - 1
+                if not 0 <= codon_start <= 2:
+                    raise ValueError("invalid codon_start qualifier: %d" % (codon_start + 1))
+                feature._original_codon_start = codon_start  # very much private, so pylint: disable=protected-access
+                if codon_start != 0:
+                    # adjust the location for now until converting back to biopython if required
+                    feature.location = _adjust_location_by_offset(feature.location, codon_start)
+
             feature._qualifiers.update(leftovers)  # shouldn't be a public thing, so pylint: disable=protected-access
         else:
             feature.created_by_antismash = False

--- a/antismash/common/secmet/features/test/test_domain.py
+++ b/antismash/common/secmet/features/test/test_domain.py
@@ -1,0 +1,37 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+# for test files, silence irrelevant and noisy pylint warnings
+# pylint: disable=no-self-use,protected-access,missing-docstring
+
+import unittest
+
+from antismash.common.secmet.features.domain import Domain, FeatureLocation
+
+
+class TestDomain(unittest.TestCase):
+    def test_construction(self):
+        loc = FeatureLocation(1, 15, 1)
+        domain = Domain(loc, "test_type", tool="test")
+        assert domain.type == "test_type"
+        assert domain.location == loc
+        assert domain.created_by_antismash
+        assert domain.tool is "test"
+        assert domain.domain is None
+
+    def test_translation(self):
+        domain = Domain(FeatureLocation(1, 15, 1), "test_type", tool="test")
+        with self.assertRaisesRegex(ValueError, "has no translation"):
+            assert domain.translation is None
+        domain.translation = "AAA"
+        assert domain.translation == "AAA"
+
+        with self.assertRaisesRegex(ValueError, "stop codons"):
+            domain.translation = "A*A"
+
+        for value in [7, None, Domain]:
+            with self.assertRaises(AssertionError):
+                domain.translation = value
+
+        with self.assertRaisesRegex(ValueError, "empty"):
+            domain.translation = ""

--- a/antismash/common/secmet/features/test/test_feature.py
+++ b/antismash/common/secmet/features/test/test_feature.py
@@ -14,8 +14,14 @@ from antismash.common.secmet.features.feature import (
     Feature,
     FeatureLocation,
     SeqFeature,
+    _adjust_location_by_offset as adjust,
 )
 from antismash.common.secmet.features import feature  # mocked, pylint: disable=unused-import
+from antismash.common.secmet.locations import (
+    ExactPosition,
+    BeforePosition,
+    AfterPosition,
+)
 
 
 class TestFeature(unittest.TestCase):
@@ -100,6 +106,69 @@ class TestFeature(unittest.TestCase):
             Feature(CompoundLocation(parts, operator="join"), feature_type="test")
         Feature(CompoundLocation(parts[::-1], operator="join"), feature_type="test")
 
+    def test_conversion_with_codon_start(self):
+        seqf = SeqFeature(FeatureLocation(BeforePosition(5), 12))
+        seqf.type = "test"
+        for codon_start in "123":
+            seqf.qualifiers["codon_start"] = [codon_start]
+            feature = Feature.from_biopython(seqf)
+            assert feature._original_codon_start == int(codon_start) - 1
+            assert feature.location.start == BeforePosition(5 + feature._original_codon_start)
+            new = feature.to_biopython()[0]
+            assert new.qualifiers["codon_start"] == [codon_start]
+
+        for codon_start in ["-1", "4"]:
+            seqf.qualifiers["codon_start"] = [codon_start]
+            with self.assertRaisesRegex(ValueError, "invalid codon_start"):
+                Feature.from_biopython(seqf)
+
+
+class TestLocationAdjustment(unittest.TestCase):
+    def setUp(self):
+        # not all of these really make sense biologically, but they're all valid computationally
+        self.position_types = [ExactPosition, AfterPosition, BeforePosition, int]
+
+    def test_single_forward(self):
+        for position_type in self.position_types:
+            old = FeatureLocation(position_type(5), 12, 1)
+            for offset in range(-2, 3):
+                new = adjust(old, offset)
+                assert isinstance(new.start, position_type)
+                assert new.start == old.start + offset
+                assert new.end is old.end
+
+    def test_single_reverse(self):
+        for position_type in self.position_types:
+            old = FeatureLocation(5, position_type(12), -1)
+            for offset in range(-2, 3):
+                new = adjust(old, offset)
+                assert isinstance(new.end, position_type)
+                assert new.end == old.end + offset
+                assert new.start is old.start
+
+    def test_compound_forward(self):
+        for position_type in self.position_types:
+            old = CompoundLocation([FeatureLocation(position_type(5), 12, 1),
+                                    FeatureLocation(15, 17, 1)])
+            for offset in range(-2, 3):
+                new = adjust(old, offset)
+                assert isinstance(new.start, position_type)
+                assert new.start == old.start + offset
+                assert new.parts[0].end is old.parts[0].end
+                for old_part, new_part in zip(old.parts[1:], new.parts[1:]):
+                    assert old_part is new_part
+
+    def test_compound_reverse(self):
+        for position_type in self.position_types:
+            old = CompoundLocation([FeatureLocation(15, position_type(17), -1),
+                                    FeatureLocation(5, 12, -1)])
+            for offset in range(-2, 3):
+                new = adjust(old, offset)
+                assert isinstance(new.end, position_type)
+                assert new.end == old.end + offset
+                assert new.parts[0].start is old.parts[0].start
+                for old_part, new_part in zip(old.parts[1:], new.parts[1:]):
+                    assert old_part is new_part
 
 class TestSubLocation(unittest.TestCase):
     def setUp(self):

--- a/antismash/common/secmet/features/test/test_feature.py
+++ b/antismash/common/secmet/features/test/test_feature.py
@@ -4,6 +4,7 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=no-self-use,protected-access,missing-docstring
 
+from minimock import mock, restore
 import unittest
 
 from antismash.common.test import helpers
@@ -14,6 +15,7 @@ from antismash.common.secmet.features.feature import (
     FeatureLocation,
     SeqFeature,
 )
+from antismash.common.secmet.features import feature  # mocked, pylint: disable=unused-import
 
 
 class TestFeature(unittest.TestCase):
@@ -97,3 +99,64 @@ class TestFeature(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "bridge the record origin"):
             Feature(CompoundLocation(parts, operator="join"), feature_type="test")
         Feature(CompoundLocation(parts[::-1], operator="join"), feature_type="test")
+
+
+class TestSubLocation(unittest.TestCase):
+    def setUp(self):
+        self.feature = Feature(FeatureLocation(10, 40, 1), feature_type="test")
+        self.get_sub = self.feature.get_sub_location_from_protein_coordinates
+
+    def tearDown(self):
+        restore()
+
+    def test_invalid(self):
+        for bad_start, bad_end in [(-1, 1), (1, -1), (1, 11)]:
+            with self.assertRaisesRegex(ValueError, "must be contained by the feature"):
+                self.get_sub(bad_start, bad_end)
+        for bad_start, bad_end in [("test", 5), (5, "test"), (None, 5)]:
+            with self.assertRaisesRegex(TypeError, "unorderable types"):
+                self.get_sub(bad_start, bad_end)
+        with self.assertRaisesRegex(ValueError, "must be less than the end"):
+            self.get_sub(5, 1)
+        mock("feature.convert_protein_position_to_dna", returns=(9, 15))
+        with self.assertRaisesRegex(ValueError, "Protein coordinate start .* is outside feature"):
+            self.get_sub(1, 5)
+        mock("feature.convert_protein_position_to_dna", returns=(15, 41))
+        with self.assertRaisesRegex(ValueError, "Protein coordinate end .* is outside feature"):
+            self.get_sub(1, 5)
+        mock("feature.convert_protein_position_to_dna", returns=(10, 3))
+        with self.assertRaisesRegex(ValueError, "Invalid protein coordinate conversion"):
+            self.get_sub(1, 5)
+
+    def test_simple_forward(self):
+        assert self.get_sub(0, 1) == FeatureLocation(10, 13, 1)
+        assert self.get_sub(2, 4) == FeatureLocation(16, 22, 1)
+        assert self.get_sub(9, 10) == FeatureLocation(37, 40, 1)
+
+    def test_simple_reverse(self):
+        self.feature.location = FeatureLocation(10, 40, -1)
+        assert self.get_sub(0, 1) == FeatureLocation(37, 40, -1)
+        assert self.get_sub(2, 4) == FeatureLocation(28, 34, -1)
+        assert self.get_sub(9, 10) == FeatureLocation(10, 13, -1)
+
+    def test_compound_reverse(self):
+        self.feature.location = CompoundLocation([FeatureLocation(21, 27, -1),
+                                                  FeatureLocation(12, 15, -1),
+                                                  FeatureLocation(0, 6, -1)])
+        assert self.get_sub(2, 3) == FeatureLocation(12, 15, -1)
+
+    def test_compound_overlap_forward(self):
+        self.feature.location = CompoundLocation([FeatureLocation(10, 16, 1),
+                                                  FeatureLocation(15, 24, 1)])
+        assert self.get_sub(0, 1) == FeatureLocation(10, 13, 1)
+        assert self.get_sub(1, 3) == CompoundLocation([FeatureLocation(13, 16, 1),
+                                                       FeatureLocation(15, 18, 1)])
+        assert self.get_sub(4, 5) == FeatureLocation(21, 24, 1)
+
+    def test_compound_overlap_reverse(self):
+        self.feature.location = CompoundLocation([FeatureLocation(15, 24, -1),
+                                                  FeatureLocation(10, 16, -1)])
+        assert self.get_sub(0, 1) == FeatureLocation(21, 24, -1)
+        assert self.get_sub(2, 4) == CompoundLocation([FeatureLocation(15, 18, -1),
+                                                       FeatureLocation(13, 16, -1)])
+        assert self.get_sub(4, 5) == FeatureLocation(10, 13, -1)

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -146,13 +146,13 @@ def split_origin_bridging_location(location: CompoundLocation) -> Tuple[
     upper = []  # type: List[FeatureLocation]
     if location.strand == 1:
         for part in location.parts:
-            if not upper or part.start > upper[-1].end:
+            if not upper or part.start > upper[-1].start:
                 upper.append(part)
             else:
                 lower.append(part)
     elif location.strand == -1:
         for part in location.parts:
-            if not lower or part.start < lower[-1].end:
+            if not lower or part.start < lower[-1].start:
                 lower.append(part)
             else:
                 upper.append(part)

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -236,6 +236,12 @@ class TestBridgedSplit(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Cannot separate bridged location without a valid strand"):
             print(splitter(loc))
 
+    def test_frameshifts(self):
+        loc = build_compound([(4772224, 4772573), (4772572, 4773186), (0, 258)], 1)
+        low, high = splitter(loc)
+        assert low == loc.parts[2:]
+        assert high == loc.parts[0:2]
+
 
 class TestLocationSerialiser(unittest.TestCase):
     def convert(self, location, expected_type=FeatureLocation):

--- a/antismash/download_databases.py
+++ b/antismash/download_databases.py
@@ -84,7 +84,7 @@ def download_file(url: str, filename: str) -> str:
         raise DownloadError("ERROR: File not found on server.\nPlease check your internet connection.")
 
     # use 1 because we want to divide by the expected size, can't use 0
-    expected_size = int(req.info().get("Content-Length", "1"))  # type: ignore
+    expected_size = int(req.info().get("Content-Length", "1"))
 
     basename = os.path.basename(filename)
     dirname = os.path.dirname(filename)

--- a/antismash/modules/sactipeptides/specific_analysis.py
+++ b/antismash/modules/sactipeptides/specific_analysis.py
@@ -109,6 +109,8 @@ def get_detected_domains(cluster: secmet.Cluster) -> Dict[str, int]:
 
 def run_non_biosynthetic_phmms(cluster_fasta: str) -> Dict[str, List[HSP]]:
     """ Try to identify cleavage site using pHMM """
+    if not cluster_fasta:
+        return {}
     with open(path.get_full_path(__file__, "data", "non_biosyn_hmms", "hmmdetails.txt"), "r") as handle:
         hmmdetails = [line.split("\t") for line in handle.read().splitlines() if line.count("\t") == 3]
     signature_profiles = [HmmSignature(details[0], details[1], int(details[2]), details[3]) for details in hmmdetails]

--- a/antismash/modules/t2pks/t2pks_analysis.py
+++ b/antismash/modules/t2pks/t2pks_analysis.py
@@ -80,7 +80,8 @@ def get_cds_predictions_by_protein_type(cds_predictions: Dict[str, List[CDSPredi
                                         ) -> Dict[str, List[CDSPrediction]]:
     """ Generates a new dictionary of CDS name to CDSPredictions, removing all
         CDS entries that do not have at least one prediction with a desired
-        protein type.
+        protein type. All predictions with protein types not in the given list
+        will be removed.
 
         Arguments:
             cds_predictions: a dictionary mapping CDS name to a
@@ -94,9 +95,12 @@ def get_cds_predictions_by_protein_type(cds_predictions: Dict[str, List[CDSPredi
     ret = {}
     desired = set(protein_types)
     for cds, predictions in cds_predictions.items():
-        cds_predicted_protein_types = {pred.ptype for pred in predictions}
-        if desired.intersection(cds_predicted_protein_types):
-            ret[cds] = predictions
+        applicable = []
+        for pred in predictions:
+            if pred.ptype in desired:
+                applicable.append(pred)
+        if applicable:
+            ret[cds] = applicable
     return ret
 
 


### PR DESCRIPTION
Fixes a few small issues:
- t2pks wasn't filtering correctly, so features with interesting domain combinations could cause KeyErrors
- there was an off-by-one error with sublocation bounds checks
- AntismashFeatures/Domains could be created with translations that contained stop codons
- sactipeptides would attempt to run hmmsearch on nothing, which hmmsearch doesn't like

The lack of codon start for translation creation and sequence extraction caused some issues. NCBI's genbank examples codon_start Looking at how biopython's `SeqFeature.translate()` [here](https://github.com/biopython/biopython/blob/c1f0f643a58db1b2fbf057d6875e8e41e6c0a73a/Bio/SeqFeature.py#L340) handles the `codon_start` qualifier, I've gone with simply trimming the offset from the start of the location for the duration of analyses. This makes the location an 'effective' location for the purposes of secmet and antiSMASH. This will affect the copy of DNA sequences to clipboard/blastp search for CDSs in the HTML output, but I think they give misleading results for these cases anyway.