### PR TITLE
secmet: move pseudo tag to feature class and make sure it is None in biopython

### DIFF
--- a/antismash/common/secmet/features/gene.py
+++ b/antismash/common/secmet/features/gene.py
@@ -12,10 +12,10 @@ from .feature import Feature, FeatureLocation
 
 class Gene(Feature):
     """ A feature representing a Gene (more general than a CDS) """
-    __slots__ = ["_pseudo", "locus_tag", "gene_name"]
+    __slots__ = ["locus_tag", "gene_name"]
 
     def __init__(self, location: FeatureLocation, locus_tag: Optional[str] = None,
-                 gene_name: Optional[str] = None, pseudo_gene: bool = False,
+                 gene_name: Optional[str] = None,
                  created_by_antismash: bool = False, qualifiers: Optional[Dict[str, List[str]]] = None) -> None:
         super().__init__(location, feature_type="gene",
                          created_by_antismash=created_by_antismash)
@@ -23,9 +23,6 @@ class Gene(Feature):
         self.gene_name = str(gene_name) if gene_name else None
         if not self.locus_tag and not self.gene_name:
             raise ValueError("Gene instances must have a locus tag or name")
-        self._pseudo = bool(pseudo_gene)
-        if self._pseudo:
-            assert not created_by_antismash, "pseudo genes can only come from input files"
         if qualifiers:
             assert isinstance(qualifiers, dict)
             self._qualifiers.update(qualifiers)
@@ -38,10 +35,6 @@ class Gene(Feature):
             return self.gene_name
         raise ValueError("names removed after construction")
 
-    def is_pseudo_gene(self) -> bool:
-        """ Was the gene marked as a pseudo-gene """
-        return self._pseudo
-
     def to_biopython(self, qualifiers: Dict[str, Any] = None) -> SeqFeature:
         """ Construct a matching SeqFeature for this Gene """
         if not qualifiers:
@@ -50,8 +43,6 @@ class Gene(Feature):
             qualifiers["locus_tag"] = [self.locus_tag]
         if self.gene_name:
             qualifiers["gene"] = [self.gene_name]
-        if self._pseudo:
-            qualifiers["pseudo"] = []
         return super().to_biopython(qualifiers)
 
     @staticmethod
@@ -64,9 +55,6 @@ class Gene(Feature):
         name = leftovers.pop("gene", [""])[0] or None
         if not (locus or name):
             name = "gene%s_%s" % (bio_feature.location.start, bio_feature.location.end)
-        pseudo = "pseudo" in leftovers
-        if pseudo:
-            leftovers.pop("pseudo")
-        feature = Gene(bio_feature.location, locus_tag=locus, gene_name=name, pseudo_gene=pseudo)
+        feature = Gene(bio_feature.location, locus_tag=locus, gene_name=name)
         super(Gene, feature).from_biopython(bio_feature, feature=feature, leftovers=leftovers)
         return feature


### PR DESCRIPTION
At the moment, only gene features can be pseudogenes. A simple generalization here to all features.