### PR TITLE
secmet: get x in "/sec_met: Type: x" tags from the core domains annotated on that CDS

### DIFF
--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -43,11 +43,11 @@ class CDSResults:
             self.cds.sec_met = SecMetQualifier(set(self.definition_domains), self.domains)
         else:
             all_matching.update(set(self.cds.sec_met.domain_ids))
-            self.cds.sec_met.add_products({product})
             self.cds.sec_met.add_domains(self.domains)
         for cluster_type, matching_domains in self.definition_domains.items():
             all_matching.update(matching_domains)
             for domain in matching_domains:
+                self.cds.sec_met.add_products({cluster_type})
                 self.cds.gene_functions.add(GeneFunction.CORE, tool, domain, cluster_type)
 
         # and add all detected domains as ADDITIONAL if not CORE


### PR DESCRIPTION
instead of cluster type that overlap CDS. For example, a pure nrps CDS was annotated as nrps-t1pks if an t1pks clusters overlapped it. See NC_021658, location 3653023-3667491