### PR TITLE
Run full analyses in RiPP tests

### DIFF
--- a/antismash/modules/lanthipeptides/test/data/epicidin_280.gbk
+++ b/antismash/modules/lanthipeptides/test/data/epicidin_280.gbk
@@ -22,10 +22,6 @@ REFERENCE   2  (bases 1 to 7358)
   JOURNAL   Submitted (21-JUN-1997) Heidrich C., Abteilung Prof. Sahl, Institut
             fuer Medizinische Mikrobiologie und Immunologie, Sigmund-Freud-Str.
             25; 53105 Bonn 53105, GERMANY
-COMMENT     ##antiSMASH-Data-START##
-            Version      :: 5.0.0alpha-43c8f43
-            Run date     :: 2018-08-20 16:34:19
-            ##antiSMASH-Data-END##
 FEATURES             Location/Qualifiers
      gene            complement(<1..30)
                      /gene="tnp1"
@@ -44,68 +40,6 @@ FEATURES             Location/Qualifiers
                      /organism="Staphylococcus epidermidis"
                      /plasmid="pCH01"
                      /strain="BN 280"
-     cluster         1..7358
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /core_location="[873:7191]"
-                     /cutoff="20000"
-                     /detection_rule="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="lanthipeptide"
-                     /tool="antismash"
-     cluster_core    874..7191
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /cutoff="20000"
-                     /detection_rule="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="lanthipeptide"
-     supercluster    1..7358
-                     /child_cluster="1"
-                     /detection_rules="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /kind="single"
-                     /product="lanthipeptide"
-                     /supercluster_number="1"
-                     /tool="antismash"
-     region          1..7358
-                     /product="lanthipeptide"
-                     /region_number="1"
-                     /rules="((LANC_like and (Flavoprotein or Trp_halogenase or
-                     p450 or Lant_dehyd_N or Lant_dehyd_C or Lant_dehydr_C or
-                     tsrC or adh_short or adh_short_C2) or cds(LANC_like and
-                     (Pkinase or DUF4135)) or TIGR03731 or Antimicr18 or
-                     Gallidermin or L_biotic_A or leader_d or leader_eh or
-                     leader_abc or mature_d or mature_ab or mature_a or mature_b
-                     or mature_ha or mature_h_beta or lacticin_l or lacticin_mat
-                     or LD_lanti_pre or strep_PEQAXS) and not YcaO)"
-                     /supercluster_numbers="1"
-                     /tool="antismash"
      repeat_region   60..87
                      /rpt_type=INVERTED
      gene            874..1617
@@ -120,49 +54,15 @@ FEATURES             Location/Qualifiers
                      /db_xref="InterPro:IPR020904"
                      /db_xref="UniProtKB/TrEMBL:O54218"
                      /gene="eciO"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: adh_short_C2"
                      /locus_tag="eciO"
                      /product="oxidoreductase"
                      /protein_id="CAA74346.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="adh_short_C2 (E-value: 3.8e-35, bitscore: 110.9,
-                     seeds: 47, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MGRTVLITGGCKNIGKQIAQVFAENNYNVIVTSRNNNNKSIITYF
                      KKKNLKVFFYTLNVENEDEVVNVFKEINNDIGKIDILINNAGISQGNTLLEDSKTEDFK
                      SMINTNILGSYYCMKHVIPYMKRNRYGVIINIVSIAALRGIPYSILYGSTKNAVIALTK
                      GAAIENANNGIRVNAIAPGIIKTESLNTEIQNSEDELNEQTIAAIHPMQILGEEKDVAN
                      TAYFIANSSFMTGSIVNLDGGYTAQ"
-     CDS_motif       883..978
-                     /aSTool="pksnrpsmotif"
-                     /database="abmotifs"
-                     /detection="hmmscan"
-                     /domain_id="nrpspksmotif_eciO_0001"
-                     /evalue="1.10E-03"
-                     /label="PKSI-KR_m1"
-                     /locus_tag="eciO"
-                     /motif="PKSI-KR_m1"
-                     /note="NRPS/PKS Motif: PKSI-KR_m1 (e-value: 0.0011,
-                     bit-score: 11.6)"
-                     /score="11.6"
-                     /tool="antismash"
-                     /translation="TVLITGGCKNIGKQIAQVFAENNYNVIVTSRN"
-     aSDomain        883..1215
-                     /aSTool="nrps_pks_domains"
-                     /aSDomain="PKS_KR"
-                     /database="nrpspksdomains.hmm"
-                     /detection="hmmscan"
-                     /domain_id="nrpspksdomains_eciO_KR1"
-                     /evalue="1.20E-09"
-                     /label="eciO_KR1"
-                     /locus_tag="eciO"
-                     /score="29.9"
-                     /tool="antismash"
-                     /translation="TVLITGGCKNIGKQIAQVFAENNYNVIVTSRNNNNKSIITYFKKK
-                     NLKVFFYTLNVENEDEVVNVFKEINNDIGKIDILINNAGISQGNTLLEDSKTEDFKSMI
-                     NTNILGS"
      gene            1690..1878
                      /gene="eciI"
      CDS             1690..1878
@@ -182,15 +82,9 @@ FEATURES             Location/Qualifiers
                      /db_xref="UniProtKB/TrEMBL:O54220"
                      /function="antimicrobial"
                      /gene="eciA"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Antimicr18"
                      /locus_tag="eciA"
                      /product="epicidin 280"
                      /protein_id="CAA74348.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="Antimicr18 (E-value: 6.6e-40, bitscore: 124.1,
-                     seeds: 2, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MENKKDLFDLEIKKDNMENNNELEAQSLGPAIKATRQVCPKATRF
                      VTVSCKKSDCQ"
@@ -211,17 +105,10 @@ FEATURES             Location/Qualifiers
                      /db_xref="InterPro:IPR015500"
                      /db_xref="UniProtKB/TrEMBL:O54221"
                      /gene="eciP"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) Peptidase_S8 (E-value: 5.2e-20,
-                     bitscore: 60.7, seeds: 43, tool: rule-based-clusters)"
                      /locus_tag="eciP"
                      /note="subtilisin-like leader peptidase"
                      /product="protease"
                      /protein_id="CAA74349.1"
-                     /sec_met="Type: "
-                     /sec_met="Peptidase_S8 (E-value: 5.2e-20, bitscore: 60.7,
-                     seeds: 43, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MTNSDYINYTYDDRDFFEKILFIDSGCDYNHSELKNNIDLKNCKS
                      FVDNNLNDYTGHGTQIISVLTGKIYLRGLIPNASIVVYKVTDYRGKTSIEKIYKALSQG
@@ -237,22 +124,9 @@ FEATURES             Location/Qualifiers
                      /db_xref="InterPro:IPR006827"
                      /db_xref="UniProtKB/TrEMBL:O54222"
                      /gene="eciB"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehydr_C"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehyd_C"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehyd_N"
                      /locus_tag="eciB"
                      /product="EciB protein"
                      /protein_id="CAA74350.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="Lant_dehyd_N (E-value: 3.6e-25, bitscore: 77.1,
-                     seeds: 38, tool: rule-based-clusters); Lant_dehyd_C
-                     (E-value: 1.2e-108, bitscore: 352.5, seeds: 37, tool:
-                     rule-based-clusters); Lant_dehydr_C (E-value: 9.3e-20,
-                     bitscore: 60.2, seeds: 35, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MHLFKWYMIREPILEINKLEDIQERRDNNEDKYLNKLIDFIFDNE
                      LALPLYHANSNLFNMINNYKRKELSKKKKKNLILSLYNYITRMIFRATPFGFMSSINIG
@@ -277,15 +151,9 @@ FEATURES             Location/Qualifiers
                      /db_xref="InterPro:IPR020434"
                      /db_xref="UniProtKB/TrEMBL:O54223"
                      /gene="eciC"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: LANC_like"
                      /locus_tag="eciC"
                      /product="EciC protein"
                      /protein_id="CAA74351.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="LANC_like (E-value: 1e-82, bitscore: 266.6,
-                     seeds: 47, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MQQFLEAYIKKVENIDIVDDYIHRAYGKEPIYKVSLITGYPGIAM
                      TLFSIYQHTKNFKYYKLANKYLEKTIDLISSVPIYSTSLFEGAFGVIFSLLICSDLGNN

--- a/antismash/modules/lanthipeptides/test/data/epidermin.gbk
+++ b/antismash/modules/lanthipeptides/test/data/epidermin.gbk
@@ -26,10 +26,6 @@ REFERENCE   3  (bases 1 to 8700)
   JOURNAL   Submitted (18-DEC-1991) G. Engelke, Institut f. Mikrobiologie,
             Theodor-Stern Kai 7, Haus 75a, 6Frankfurt 70, FRG
 COMMENT     On Jun 21, 2005 this sequence version replaced gi:245669.
-            ##antiSMASH-Data-START##
-            Version      :: 5.0.0alpha-43c8f43
-            Run date     :: 2018-08-20 16:33:29
-            ##antiSMASH-Data-END##
 FEATURES             Location/Qualifiers
      gene            complement(<1..827)
                      /gene="epiY'"
@@ -60,68 +56,6 @@ FEATURES             Location/Qualifiers
                      /mol_type="genomic DNA"
                      /organism="Staphylococcus epidermidis"
                      /strain="Tu 3298"
-     cluster         1..8700
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /core_location="[1380:6369]"
-                     /cutoff="20000"
-                     /detection_rule="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="lanthipeptide"
-                     /tool="antismash"
-     cluster_core    1381..6369
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /cutoff="20000"
-                     /detection_rule="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="lanthipeptide"
-     supercluster    1..8700
-                     /child_cluster="1"
-                     /detection_rules="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /kind="single"
-                     /product="lanthipeptide"
-                     /supercluster_number="1"
-                     /tool="antismash"
-     region          1..8700
-                     /product="lanthipeptide"
-                     /region_number="1"
-                     /rules="((LANC_like and (Flavoprotein or Trp_halogenase or
-                     p450 or Lant_dehyd_N or Lant_dehyd_C or Lant_dehydr_C or
-                     tsrC or adh_short or adh_short_C2) or cds(LANC_like and
-                     (Pkinase or DUF4135)) or TIGR03731 or Antimicr18 or
-                     Gallidermin or L_biotic_A or leader_d or leader_eh or
-                     leader_abc or mature_d or mature_ab or mature_a or mature_b
-                     or mature_ha or mature_h_beta or lacticin_l or lacticin_mat
-                     or LD_lanti_pre or strep_PEQAXS) and not YcaO)"
-                     /supercluster_numbers="1"
-                     /tool="antismash"
      gene            complement(781..1227)
                      /gene="epiY"
      CDS             complement(781..1227)
@@ -152,19 +86,9 @@ FEATURES             Location/Qualifiers
                      /db_xref="PDB:1G5Q"
                      /db_xref="UniProtKB/Swiss-Prot:P08136"
                      /gene="epiA"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Gallidermin"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: mature_b"
                      /locus_tag="epiA"
                      /product="Epidermin prepeptide"
                      /protein_id="CAA44252.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="Gallidermin (E-value: 4.7e-40, bitscore: 125.0,
-                     seeds: 3, tool: rule-based-clusters); mature_b (E-value:
-                     7.5e-16, bitscore: 46.8, seeds: 5, tool:
-                     rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MEAVKEKNDLFNLDVKVNAKESNDSGAEPRIASKFICTPGCAKTG
                      SFNSYCC"
@@ -178,22 +102,9 @@ FEATURES             Location/Qualifiers
                      /db_xref="UniProtKB/Swiss-Prot:P30195"
                      /function="modifying enzyme"
                      /gene="epiB"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehyd_C"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehydr_C"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehyd_N"
                      /locus_tag="epiB"
                      /product="epiB"
                      /protein_id="CAA44253.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="Lant_dehyd_N (E-value: 1.9e-28, bitscore: 87.8,
-                     seeds: 38, tool: rule-based-clusters); Lant_dehyd_C
-                     (E-value: 2.2e-130, bitscore: 424.4, seeds: 37, tool:
-                     rule-based-clusters); Lant_dehydr_C (E-value: 3.9e-19,
-                     bitscore: 58.3, seeds: 35, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MDNIFVPSNIYMVRTPIFSIELYNQFLKSDNIDYDLILQNDIFKE
                      SIMTTTYNLYQSIGKIDWEKDNKKTRNVKESLLKYLIRMSTRSTPYGMLSGVALGEFSE
@@ -221,15 +132,9 @@ FEATURES             Location/Qualifiers
                      /db_xref="UniProtKB/Swiss-Prot:P30196"
                      /function="modifying enzyme"
                      /gene="epiC"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: LANC_like"
                      /locus_tag="epiC"
                      /product="epiC"
                      /protein_id="CAA44254.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="LANC_like (E-value: 1.5e-85, bitscore: 276.1,
-                     seeds: 47, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MAVLYTCVVIEYSVLILKKKNLFYLFLMKLQKLKNIGMVVININN
                      IKKILENKITFLSDIEKATYIIENQSEYWDPYTLSHGYPGIILFLSASEKVFHKDLEKV
@@ -250,15 +155,9 @@ FEATURES             Location/Qualifiers
                      /db_xref="UniProtKB/Swiss-Prot:P30197"
                      /function="modifying enzyme"
                      /gene="epiD"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Flavoprotein"
                      /locus_tag="epiD"
                      /product="epiD"
                      /protein_id="CAA44255.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="Flavoprotein (E-value: 3.8e-28, bitscore: 87.1,
-                     seeds: 143, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MYGKLLICATASINVININHYIVELKQHFDEVNILFSPSSKNFIN
                      TDVLKLFCDNLYDEIKDPLLNHINIVENHEYILVLPASANTINKIANGICDNLLTTVCL
@@ -295,16 +194,9 @@ FEATURES             Location/Qualifiers
                      /db_xref="UniProtKB/Swiss-Prot:P30199"
                      /function="serine protease"
                      /gene="epiP"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) Peptidase_S8 (E-value: 5.1e-50,
-                     bitscore: 159.4, seeds: 43, tool: rule-based-clusters)"
                      /locus_tag="epiP"
                      /product="epiP"
                      /protein_id="CAA44257.1"
-                     /sec_met="Type: "
-                     /sec_met="Peptidase_S8 (E-value: 5.1e-50, bitscore: 159.4,
-                     seeds: 43, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MNKFKFFIVFLILSLVFLQNEYAFGSSLNEELSYYSVEYDNAKTF
                      KESIKQKNIELTYKIPELHTAQIKTSKSKLNSLIKSNKNVKFVNPTCSTCVVEKSVKTG

--- a/antismash/modules/lanthipeptides/test/data/labyrinthopeptin.gbk
+++ b/antismash/modules/lanthipeptides/test/data/labyrinthopeptin.gbk
@@ -12,10 +12,6 @@ REFERENCE   1  (bases 1 to 6400)
   TITLE     Direct Submission
   JOURNAL   Submitted (21-FEB-2009) TU Berlin, Strasse des 17. Juni 124, 10623
             Berlin, Germany
-COMMENT     ##antiSMASH-Data-START##
-            Version      :: 5.0.0alpha-43c8f43
-            Run date     :: 2018-08-20 16:32:29
-            ##antiSMASH-Data-END##
 FEATURES             Location/Qualifiers
      gene            1..2589
                      /gene="labKC"
@@ -29,20 +25,10 @@ FEATURES             Location/Qualifiers
                      /db_xref="InterPro:IPR020636"
                      /db_xref="UniProtKB/TrEMBL:C0MP58"
                      /gene="labKC"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Pkinase"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: LANC_like"
                      /locus_tag="labKC"
                      /note="contains C-terminal lanC-domain"
                      /product="serine/threonine kinase"
                      /protein_id="CAX48971.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="LANC_like (E-value: 5.3e-11, bitscore: 30.2,
-                     seeds: 47, tool: rule-based-clusters); Pkinase (E-value:
-                     4.4e-15, bitscore: 44.1, seeds: 54, tool:
-                     rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MDLRYHAYAMADPVFYDSPSSDTRETDGYSDDLPLPDGWERRRVG
                      VWVMQGHDGLTMPDQGWKIHVSAGLDNAWPVLELVAKYCVEQEMPFKFLRSRRTLLARS
@@ -63,68 +49,6 @@ FEATURES             Location/Qualifiers
                      /db_xref="taxon:182080"
                      /mol_type="genomic DNA"
                      /organism="Actinomadura namibiensis"
-     cluster         1..6400
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /core_location="[0:2589](+)"
-                     /cutoff="20000"
-                     /detection_rule="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="lanthipeptide"
-                     /tool="antismash"
-     cluster_core    1..2589
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /cutoff="20000"
-                     /detection_rule="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="lanthipeptide"
-     supercluster    1..6400
-                     /child_cluster="1"
-                     /detection_rules="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /kind="single"
-                     /product="lanthipeptide"
-                     /supercluster_number="1"
-                     /tool="antismash"
-     region          1..6400
-                     /product="lanthipeptide"
-                     /region_number="1"
-                     /rules="((LANC_like and (Flavoprotein or Trp_halogenase or
-                     p450 or Lant_dehyd_N or Lant_dehyd_C or Lant_dehydr_C or
-                     tsrC or adh_short or adh_short_C2) or cds(LANC_like and
-                     (Pkinase or DUF4135)) or TIGR03731 or Antimicr18 or
-                     Gallidermin or L_biotic_A or leader_d or leader_eh or
-                     leader_abc or mature_d or mature_ab or mature_a or mature_b
-                     or mature_ha or mature_h_beta or lacticin_l or lacticin_mat
-                     or LD_lanti_pre or strep_PEQAXS) and not YcaO)"
-                     /supercluster_numbers="1"
-                     /tool="antismash"
      gene            2599..2721
                      /gene="labA1"
      CDS             2599..2721

--- a/antismash/modules/lanthipeptides/test/data/lactocin_s.gbk
+++ b/antismash/modules/lanthipeptides/test/data/lactocin_s.gbk
@@ -60,10 +60,6 @@ REFERENCE   7  (bases 1 to 15996)
   JOURNAL   Submitted (21-FEB-2001) Morten Skaugen, Agricultural University of
             Norway, Chemistry and Biotechnology, P.O.Box 5051, N-1432 As, Norway
 COMMENT     On Mar 11, 2001 this sequence version replaced gi:1150478.
-            ##antiSMASH-Data-START##
-            Version      :: 5.0.0alpha-43c8f43
-            Run date     :: 2018-08-20 16:31:27
-            ##antiSMASH-Data-END##
 FEATURES             Location/Qualifiers
      CDS             <1..237
                      /codon_start=1
@@ -81,68 +77,6 @@ FEATURES             Location/Qualifiers
                      /mol_type="genomic DNA"
                      /organism="Lactobacillus sakei"
                      /strain="L45"
-     cluster         1..15996
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /core_location="[6884:9662](+)"
-                     /cutoff="20000"
-                     /detection_rule="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="lanthipeptide"
-                     /tool="antismash"
-     cluster_core    6885..9662
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /cutoff="20000"
-                     /detection_rule="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="lanthipeptide"
-     supercluster    1..15996
-                     /child_cluster="1"
-                     /detection_rules="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /kind="single"
-                     /product="lanthipeptide"
-                     /supercluster_number="1"
-                     /tool="antismash"
-     region          1..15996
-                     /product="lanthipeptide"
-                     /region_number="1"
-                     /rules="((LANC_like and (Flavoprotein or Trp_halogenase or
-                     p450 or Lant_dehyd_N or Lant_dehyd_C or Lant_dehydr_C or
-                     tsrC or adh_short or adh_short_C2) or cds(LANC_like and
-                     (Pkinase or DUF4135)) or TIGR03731 or Antimicr18 or
-                     Gallidermin or L_biotic_A or leader_d or leader_eh or
-                     leader_abc or mature_d or mature_ab or mature_a or mature_b
-                     or mature_ha or mature_h_beta or lacticin_l or lacticin_mat
-                     or LD_lanti_pre or strep_PEQAXS) and not YcaO)"
-                     /supercluster_numbers="1"
-                     /tool="antismash"
      regulatory      217..222
                      /note="ORF116"
                      /regulatory_class="ribosome_binding_site"
@@ -384,21 +318,11 @@ FEATURES             Location/Qualifiers
                      /db_xref="InterPro:IPR017146"
                      /db_xref="UniProtKB/TrEMBL:Q48849"
                      /gene="lasM"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: DUF4135"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: LANC_like"
                      /locus_tag="lasM"
                      /note="essential for lactocin S production; probably
                      involved in post-translational peptide modification"
                      /product="hypothetical protein"
                      /protein_id="CAA91110.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="LANC_like (E-value: 1.2e-24, bitscore: 77.0,
-                     seeds: 47, tool: rule-based-clusters); DUF4135 (E-value:
-                     2.5e-62, bitscore: 201.5, seeds: 79, tool:
-                     rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MNEFEKKINELCFHYTLNLIFKDNLINLKKELNKFNNKNEIKMNL
                      YFSISQSIIYPFTDILLDLYHTELKTNSMLGNNSSERLKSFVSEFEQDHWEKINLTYPV
@@ -528,17 +452,10 @@ FEATURES             Location/Qualifiers
                      /db_xref="InterPro:IPR015500"
                      /db_xref="UniProtKB/TrEMBL:Q48854"
                      /gene="lasP"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) Peptidase_S8 (E-value: 3.3e-15,
-                     bitscore: 46.3, seeds: 43, tool: rule-based-clusters)"
                      /locus_tag="lasP"
                      /note="probably involved in pre-lactocin S processing"
                      /product="serine protease"
                      /protein_id="CAA91115.1"
-                     /sec_met="Type: "
-                     /sec_met="Peptidase_S8 (E-value: 3.3e-15, bitscore: 46.3,
-                     seeds: 43, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MTVLLRDINSAILTEYRLHMYSSRYTSSIALLDENINTTHSYLQK
                      HFSSISGHNNTASIHGTAMAGVLSIASLSKQKLTVFNTLDKYHQRTRKSVISALKMAII

--- a/antismash/modules/lanthipeptides/test/data/lanthipeptide.gbk
+++ b/antismash/modules/lanthipeptides/test/data/lanthipeptide.gbk
@@ -1,5 +1,5 @@
 LOCUS       BGC0000535.1           15016 bp    DNA              UNK 01-JAN-1980
-DEFINITION  Nisin A biosynthetic gene cluster
+DEFINITION  Nisin A biosynthetic gene cluster.
 ACCESSION   BGC0000535
 VERSION     BGC0000535.1
 KEYWORDS    .
@@ -16,30 +16,6 @@ FEATURES             Location/Qualifiers
                      /isolation_source="raw milk"
                      /strain="M78"
                      /organism="Lactococcus lactis subsp. lactis"
-     cluster         1..15016
-                     /note="Cluster number: 1"
-                     /note="Detection rule(s) for this cluster type:
-                     lanthipeptide: (cluster(LANC_like,Flavoprotein) or
-                     cluster(LANC_like,Trp_halogenase) or
-                     cluster(LANC_like,p450) or (LANC_like & Pkinase) or
-                     (LANC_like & DUF4135) or cluster(LANC_like,Lant_dehyd_N) or
-                     cluster(LANC_like,Lant_dehyd_C) or
-                     cluster(LANC_like,adh_short) or
-                     cluster(LANC_like,adh_short_C2) or TIGR03731 or Antimicr18
-                     or Gallidermin or L_biotic_A or TIGR03731 or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or
-                     strep_PEQAXS);"
-                     /cutoff=20000
-                     /product="lanthipeptide"
-                     /contig_edge="True"
-                     /extension=10000
-     CDS_motif       828..896
-                     /note="leader peptide"
-                     /note="lanthipeptide"
-                     /note="predicted leader seq: MSTKDFNLDLVSVSKKDSGASPR"
-                     /locus_tag="nisA"
      gene            828..1001
                      /gene="nisA"
      CDS             828..1001
@@ -48,30 +24,12 @@ FEATURES             Location/Qualifiers
                      /transl_table=11
                      /note="prenisin; nisin A structural protein"
                      /db_xref="GI:299832737"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="Domains detected: TIGR03731 (E-value: 1.3e-24,
-                     bitscore: 75.6, seeds: 23); mature_a (E-value: 6.5e-08,
-                     bitscore: 21.5, seeds: 5)"
-                     /sec_met="Kind: biosynthetic"
                      /translation="MSTKDFNLDLVSVSKKDSGASPRITSISLCTPGCKTGALMGCNMK
                      TATCHCSIHVSK"
                      /gene="nisA"
                      /protein_id="ADJ56352.1"
      misc_feature    828..14152
                      /note="nisin biosynthetic gene cluster"
-     CDS_motif       897..1001
-                     /note="core peptide"
-                     /note="lanthipeptide"
-                     /note="monoisotopic mass: 3333.6"
-                     /note="molecular weight: 3336.0"
-                     /note="alternative weights: 3354.0; 3372.1; 3390.1; 3408.1"
-                     /note="number of bridges: 5"
-                     /note="predicted core seq:
-                     ITSISLCTPGCKTGALMGCNMKTATCHCSIHVSK"
-                     /note="predicted class: Class-I"
-                     /note="score: 26.70"
-                     /note="RODEO score: 32"
-                     /locus_tag="nisA"
      gene            1109..4090
                      /gene="nisB"
      CDS             1109..4090
@@ -80,16 +38,7 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /transl_table=11
                      /note="nisin biosynthesis protein"
-                     /note="smCOG:
-                     SMCOG1155:Lantibiotic_dehydratase_domain_protein (Score:
-                     859.9; E-value: 3.6e-260);"
                      /db_xref="GI:299832738"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="Domains detected: Lant_dehyd_N (E-value: 4.5e-25,
-                     bitscore: 77.4, seeds: 38); Lant_dehyd_C (E-value:
-                     6.8e-120, bitscore: 390.3, seeds: 37); Lant_dehydr_C
-                     (E-value: 2.8e-18, bitscore: 56.0, seeds: ?)"
-                     /sec_met="Kind: biosynthetic"
                      /translation="MIKSSFKAQPFLVRNTILSPNDKRSFTEYTQVIETVSKNKVFLEQ
                      LLLANPKLYDVMQKYNAGLLKKKRVKKLFESIYKYYKRSYLRSTPFGLFSETSIGVFSK
                      SSQYKLMGKTTKGIRLDTQWLIRLVHKMEVDFSKKLSFTRNNANYKFGDRVFQVYTINS
@@ -118,8 +67,6 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /transl_table=11
                      /note="nisin transport ATP-binding protein"
-                     /note="smCOG: SMCOG1000:ABC_transporter_ATP-binding_protein
-                     (Score: 163.7; E-value: 9.5e-50);"
                      /db_xref="GI:299832739"
                      /translation="MDEVKEFTSKQFFNTLLTLPSTLKLIFQLEKRYAIYLIVLNAITA
                      FVPLASLFIYQDLINSVLGSGRHLINIIIIYFIVQVITTVLGQLESYVSGKFDMRLSYS
@@ -142,14 +89,7 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /transl_table=11
                      /note="nisin biosynthesis protein"
-                     /note="smCOG:
-                     SMCOG1140:Lanthionine_synthetase_C_family_protein (Score:
-                     337.0; E-value: 2.6e-102);"
                      /db_xref="GI:299832740"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="Domains detected: LANC_like (E-value: 8.3e-76,
-                     bitscore: 244.5, seeds: 47)"
-                     /sec_met="Kind: biosynthetic"
                      /translation="MNKKNIKRNVEKIIAQWDERTRKNKENFDFGELTLSTGLPGIILM
                      LAELKNKDNSKIYQKKIDNYIEYIVSKLSTYGLLTGSLYSGAAGIALSILHLREDDEKY
                      KNLLDSLNRYIEYFVREKIEGFNLENITPPDYDVIEGLSGILSYLLLINDEQYDDLKIL
@@ -184,14 +124,7 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /transl_table=11
                      /note="nisin leader peptide-processing serine protease"
-                     /note="smCOG:
-                     SMCOG1075:alkaline_serine_protease,_subtilase_family
-                     (Score: 249.7; E-value: 1.2e-75);"
                      /db_xref="GI:299832742"
-                     /sec_met="Type: none"
-                     /sec_met="Domains detected: Peptidase_S8 (E-value: 2.3e-50,
-                     bitscore: 161.0, seeds: ?)"
-                     /sec_met="Kind: biosynthetic"
                      /translation="MKKILGFLFIVCSLGLSATVHGETTNSQQLLSNNINTELINHNSN
                      AILSSTEGSTTDSINLGAQSPAVKSTTRTELDVTGAAKTLLQTSAVQKEMKVSLQETQV
                      SSEFSKRDSVTNKEAVPVSKDELLEQSEVVVSTSSIQKNKILDNKKNRANFVTSSPLIK
@@ -215,8 +148,6 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /transl_table=11
                      /note="nisin biosynthesis regulatory protein"
-                     /note="smCOG: SMCOG1008:response_regulator (Score: 180.3;
-                     E-value: 6.6e-55);"
                      /db_xref="GI:299832743"
                      /translation="MYKILIVDDDQEILKLMKTALEMRNYEVAMHQNISLPLDITDFQG
                      FDLILLDIMMSNIEGTEICKRIRREISTPIIFVSAKDTEEDIINGLGIGGDDYITKPFS
@@ -234,8 +165,6 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /transl_table=11
                      /note="nisin biosynthesis sensor protein"
-                     /note="smCOG: SMCOG1003:sensor_histidine_kinase (Score:
-                     102.5; E-value: 5e-31);"
                      /db_xref="GI:299832744"
                      /translation="MGKKYSMRRRIWQAVIEIIIGTCLLILLLLGLTFFLRQIGQISGS
                      ETIRLSLDSDNLTISDIERDMKHYPYDYIIFDNDTSKILGGHYVKSDVPSFVASKQSSH
@@ -256,8 +185,6 @@ FEATURES             Location/Qualifiers
                      /transl_table=11
                      /note="nisin transport/immunity protein; component of
                      ABC-transporter"
-                     /note="smCOG: SMCOG1000:ABC_transporter_ATP-binding_protein
-                     (Score: 173.7; E-value: 8.2e-53);"
                      /db_xref="GI:299832745"
                      /translation="MQVKIQNLSKTYKEKQVLQDISFDIKSGTVCGLLGVNGAGKSTLM
                      KILFGLISADTGKIFFDGQEKTNNQLGALIEAPAIYMNLSAFDNLKTKALLFGISDKRI

--- a/antismash/modules/lanthipeptides/test/data/microbisporicin.gbk
+++ b/antismash/modules/lanthipeptides/test/data/microbisporicin.gbk
@@ -25,73 +25,7 @@ REFERENCE   2  (bases 1 to 36668)
   TITLE     Direct Submission
   JOURNAL   Submitted (14-JUN-2010) Department of Molecular Microbiology, The
             John Innes Centre, Colney Lane, Norwich, Norfolk NR4 7UH, UK
-COMMENT     ##antiSMASH-Data-START##
-            Version      :: 5.0.0alpha-43c8f43
-            Run date     :: 2018-08-20 16:30:05
-            ##antiSMASH-Data-END##
 FEATURES             Location/Qualifiers
-     cluster         1..31228
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /core_location="[3962:21228]"
-                     /cutoff="20000"
-                     /detection_rule="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="lanthipeptide"
-                     /tool="antismash"
-     cluster_core    3963..21228
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /cutoff="20000"
-                     /detection_rule="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="lanthipeptide"
-     supercluster    1..31228
-                     /child_cluster="1"
-                     /detection_rules="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /kind="single"
-                     /product="lanthipeptide"
-                     /supercluster_number="1"
-                     /tool="antismash"
-     region          1..31228
-                     /product="lanthipeptide"
-                     /region_number="1"
-                     /rules="((LANC_like and (Flavoprotein or Trp_halogenase or
-                     p450 or Lant_dehyd_N or Lant_dehyd_C or Lant_dehydr_C or
-                     tsrC or adh_short or adh_short_C2) or cds(LANC_like and
-                     (Pkinase or DUF4135)) or TIGR03731 or Antimicr18 or
-                     Gallidermin or L_biotic_A or leader_d or leader_eh or
-                     leader_abc or mature_d or mature_ab or mature_a or mature_b
-                     or mature_ha or mature_h_beta or lacticin_l or lacticin_mat
-                     or LD_lanti_pre or strep_PEQAXS) and not YcaO)"
-                     /supercluster_numbers="1"
-                     /tool="antismash"
      source          1..36668
                      /db_xref="taxon:83302"
                      /mol_type="genomic DNA"
@@ -161,16 +95,10 @@ FEATURES             Location/Qualifiers
      CDS             3963..5207
                      /codon_start=1
                      /gene="mibO"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: p450"
                      /locus_tag="mibO"
                      /note="MibO"
                      /product="cytochrome P450"
                      /protein_id="ADK32549.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="p450 (E-value: 1.8e-24, bitscore: 77.4, seeds:
-                     50, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MIFGPDFHRDPYPVYRRLRDEAPCHHEPALGLYALSRYEDVLAAL
                      RQPTVFSSAARAVASSAAGAGPYRGADTVSPERETAAEGPARSLLFLDPPEHQVLRQAV
@@ -243,16 +171,10 @@ FEATURES             Location/Qualifiers
      CDS             8616..8789
                      /codon_start=1
                      /gene="mibA"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: TIGR03731"
                      /locus_tag="mibA"
                      /note="MibA"
                      /product="microbisporicin structural preproprotein"
                      /protein_id="ADK32554.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="TIGR03731 (E-value: 1.2e-11, bitscore: 35.6,
-                     seeds: 23, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MPADILETRTSETEDLLDLDLSIGVEEITAGPAVTSWSLCTPGCT
                      SPGGGSNCSFCC"
@@ -261,23 +183,10 @@ FEATURES             Location/Qualifiers
      CDS             8907..12254
                      /codon_start=1
                      /gene="mibB"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehyd_N"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehyd_C"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehydr_C"
                      /locus_tag="mibB"
                      /note="MibB"
                      /product="lantibiotic dehydratase"
                      /protein_id="ADK32555.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="Lant_dehyd_N (E-value: 4.1e-23, bitscore: 72.7,
-                     seeds: 38, tool: rule-based-clusters); Lant_dehyd_C
-                     (E-value: 4e-115, bitscore: 376.1, seeds: 37, tool:
-                     rule-based-clusters); Lant_dehydr_C (E-value: 4.7e-32,
-                     bitscore: 102.8, seeds: 35, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MTDSPFRAWDVFMVRTPVGYAYPTPLSNSGFDSPASSPGFGEGEF
                      PPDAPVPSDVSGHGAGSSEASVRASGRPPAGDHLSLLRAACEDGPLMEAVELASPSLAG
@@ -304,16 +213,10 @@ FEATURES             Location/Qualifiers
      CDS             12251..13708
                      /codon_start=1
                      /gene="mibC"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: LANC_like"
                      /locus_tag="mibC"
                      /note="MibC"
                      /product="lantibiotic cyclase"
                      /protein_id="ADK32556.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="LANC_like (E-value: 4.2e-49, bitscore: 158.2,
-                     seeds: 47, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MTTVGRTSCGVTSDRHPARFLRGSAARRAARLVRLVAERLADPDA
                      VAGIAARPGNSVPVNGLSMWSPATLSHGFPGIAVFYAELGRIDPAWSAFAHRHLRAAAA
@@ -329,16 +232,10 @@ FEATURES             Location/Qualifiers
      CDS             13737..14420
                      /codon_start=1
                      /gene="mibD"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Flavoprotein"
                      /locus_tag="mibD"
                      /note="MibD"
                      /product="flavoprotein decarboxylase"
                      /protein_id="ADK32557.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="Flavoprotein (E-value: 4.2e-25, bitscore: 79.3,
-                     seeds: 143, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MTAHSDAGGDPRPPERLLLGVSGSVAALNLPAYIYAFRAAGVARL
                      AVVLTPAAEGFLPAGALRPIVDAVHTEHDQGKGHVALSRWAQHLLVLPATANLLGCAAS
@@ -431,16 +328,10 @@ FEATURES             Location/Qualifiers
      CDS             19522..21228
                      /codon_start=1
                      /gene="mibH"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Trp_halogenase"
                      /locus_tag="mibH"
                      /note="MibH"
                      /product="tryptophan-5-halogenase"
                      /protein_id="ADK32563.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="Trp_halogenase (E-value: 8e-115, bitscore: 375.2,
-                     seeds: 23, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MARSEESNTLARLFDVLGDDAAAAREWVTEPHRLIASNERLGTAP
                      EAPADDDPEAIRTVGVIGGGTAGYLTALALKAKRPWLDVALVESADIPIIGVGEATVSY
@@ -543,17 +434,10 @@ FEATURES             Location/Qualifiers
                      TTAPVDAPWGERYAEIVDPYGYAWKFFQLLPEPPQESLRAAYDVWFT"
      CDS             complement(26998..28380)
                      /codon_start=1
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) Peptidase_S9 (E-value: 8.5e-12,
-                     bitscore: 36.1, seeds: 64, tool: rule-based-clusters)"
                      /locus_tag="ADK32571.1"
                      /note="PHB depolymerase family protein; orf-27"
                      /product="esterase"
                      /protein_id="ADK32571.1"
-                     /sec_met="Type: "
-                     /sec_met="Peptidase_S9 (E-value: 8.5e-12, bitscore: 36.1,
-                     seeds: 64, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MIRRLKVIVAAVALSLVAAGVLVGAQTASAASLTRVTNFGTNPTN
                      LNMYIYVPDRVAAHPALLVLVHYCSGSASGIFNGNGHDYVTAADRYGYIIVLPEATRSG

--- a/antismash/modules/lanthipeptides/test/data/nisin.gbk
+++ b/antismash/modules/lanthipeptides/test/data/nisin.gbk
@@ -36,16 +36,6 @@ FEATURES             Location/Qualifiers
                      /isolation_source="raw milk"
                      /strain="M78"
                      /organism="Lactococcus lactis subsp. lactis"
-     cluster         1..15016
-                     /note="Cluster number: 1"
-                     /note="Detection rule(s) for this cluster type:
-                     lantipeptide: (LANC_like or (Lant_dehyd_N & Lant_dehyd_C)
-                     or TIGR03731 or Antimicr18 or Gallidermin or L_biotic_A or
-                     TIGR03731 or leader_d or leader_eh or leader_abc or
-                     mature_d or mature_ab or mature_a or mature_b or mature_ha
-                     or mature_h_beta or lacticin_l or lacticin_mat or
-                     LD_lanti_pre or strep_PEQAXS);"
-                     /product="lantipeptide"
      gene            828..1001
                      /gene="nisA"
      CDS             828..1001
@@ -54,23 +44,12 @@ FEATURES             Location/Qualifiers
                      /transl_table=11
                      /note="prenisin; nisin A structural protein"
                      /db_xref="GI:299832737"
-                     /sec_met="Type: lantipeptide"
-                     /sec_met="Domains detected: TIGR03731 (E-value: 1.3e-24,
-                     bitscore: 75.6, seeds: 23); mature_a (E-value: 6.5e-08,
-                     bitscore: 21.5, seeds: 5)"
-                     /sec_met="Kind: biosynthetic"
                      /translation="MSTKDFNLDLVSVSKKDSGASPRITSISLCTPGCKTGALMGCNMK
                      TATCHCSIHVSK"
                      /gene="nisA"
                      /protein_id="ADJ56352.1"
      misc_feature    828..14152
                      /note="nisin biosynthetic gene cluster"
-     CDS_motif       840..940
-                     /note="Gallidermin"
-                     /note="Pfam-A.hmm-Hit: Gallidermin. Score: 33.4. E-value:
-                     2.7e-08. Domain range: 10..46."
-                     /note="PFAM-Id: PF02052"
-                     /label="nisA"
      gene            1109..4090
                      /gene="nisB"
      CDS             1109..4090
@@ -80,11 +59,6 @@ FEATURES             Location/Qualifiers
                      /transl_table=11
                      /note="nisin biosynthesis protein"
                      /db_xref="GI:299832738"
-                     /sec_met="Type: lantipeptide"
-                     /sec_met="Domains detected: Lant_dehyd_N (E-value: 4.5e-25,
-                     bitscore: 77.4, seeds: 38); Lant_dehyd_C (E-value:
-                     6.8e-120, bitscore: 390.3, seeds: 37)"
-                     /sec_met="Kind: biosynthetic"
                      /translation="MIKSSFKAQPFLVRNTILSPNDKRSFTEYTQVIETVSKNKVFLEQ
                      LLLANPKLYDVMQKYNAGLLKKKRVKKLFESIYKYYKRSYLRSTPFGLFSETSIGVFSK
                      SSQYKLMGKTTKGIRLDTQWLIRLVHKMEVDFSKKLSFTRNNANYKFGDRVFQVYTINS
@@ -105,18 +79,6 @@ FEATURES             Location/Qualifiers
                      EYMK"
                      /gene="nisB"
                      /protein_id="ADJ56353.1"
-     CDS_motif       1229..1506
-                     /note="Lantibiotic dehydratase, N terminus"
-                     /note="Pfam-A.hmm-Hit: Lant_dehyd_N. Score: 77.4. E-value:
-                     4.8e-22. Domain range: 0..96."
-                     /note="PFAM-Id: PF04737"
-                     /label="nisB"
-     CDS_motif       1673..3126
-                     /note="Lantibiotic dehydratase, C terminus"
-                     /note="Pfam-A.hmm-Hit: Lant_dehyd_C. Score: 390.3. E-value:
-                     7.3e-117. Domain range: 1..497."
-                     /note="PFAM-Id: PF04738"
-                     /label="nisB"
      gene            4101..5903
                      /gene="nisT"
      CDS             4101..5903
@@ -139,18 +101,6 @@ FEATURES             Location/Qualifiers
                      DVLLRRCQYYQELYYSEQYEDNDE"
                      /gene="nisT"
                      /protein_id="ADJ56354.1"
-     CDS_motif       5196..5797
-                     /note="RecF/RecN/SMC N terminal domain"
-                     /note="Pfam-A.hmm-Hit: SMC_N. Score: 41.6. E-value:
-                     6.1e-11. Domain range: 12..212."
-                     /note="PFAM-Id: PF02463"
-                     /label="nisT"
-     CDS_motif       5274..5665
-                     /note="ABC transporter"
-                     /note="Pfam-A.hmm-Hit: ABC_tran. Score: 86.4. E-value:
-                     1.4e-24. Domain range: 0..117."
-                     /note="PFAM-Id: PF00005"
-                     /label="nisT"
      gene            5896..7140
                      /gene="nisC"
      CDS             5896..7140
@@ -160,10 +110,6 @@ FEATURES             Location/Qualifiers
                      /transl_table=11
                      /note="nisin biosynthesis protein"
                      /db_xref="GI:299832740"
-                     /sec_met="Type: lantipeptide"
-                     /sec_met="Domains detected: LANC_like (E-value: 8.3e-76,
-                     bitscore: 244.5, seeds: 47)"
-                     /sec_met="Kind: biosynthetic"
                      /translation="MNKKNIKRNVEKIIAQWDERTRKNKENFDFGELTLSTGLPGIILM
                      LAELKNKDNSKIYQKKIDNYIEYIVSKLSTYGLLTGSLYSGAAGIALSILHLREDDEKY
                      KNLLDSLNRYIEYFVREKIEGFNLENITPPDYDVIEGLSGILSYLLLINDEQYDDLKIL
@@ -174,12 +120,6 @@ FEATURES             Location/Qualifiers
                      ALLLFDDFLKGGKRK"
                      /gene="nisC"
                      /protein_id="ADJ56355.1"
-     CDS_motif       5980..7076
-                     /note="Lanthionine synthetase C-like protein"
-                     /note="Pfam-A.hmm-Hit: LANC_like. Score: 244.5. E-value:
-                     9e-73. Domain range: 1..341."
-                     /note="PFAM-Id: PF05147"
-                     /label="nisC"
      gene            7137..7874
                      /gene="nisI"
      CDS             7137..7874
@@ -219,12 +159,6 @@ FEATURES             Location/Qualifiers
                      NNRNSRGAVSVRSQEILPVTGDGEDFLPALGIVCISILGILKRKTKN"
                      /gene="nisP"
                      /protein_id="ADJ56357.1"
-     CDS_motif       8575..9485
-                     /note="Subtilase family"
-                     /note="Pfam-A.hmm-Hit: Peptidase_S8. Score: 188.0. E-value:
-                     1.7e-55. Domain range: 2..284."
-                     /note="PFAM-Id: PF00082"
-                     /label="nisP"
      gene            9993..10679
                      /gene="nisR"
      CDS             9993..10679
@@ -242,18 +176,6 @@ FEATURES             Location/Qualifiers
                      GYQWHG"
                      /gene="nisR"
                      /protein_id="ADJ56358.1"
-     CDS_motif       9999..10327
-                     /note="Response regulator receiver domain"
-                     /note="Pfam-A.hmm-Hit: Response_reg. Score: 97.9. E-value:
-                     2.6e-28. Domain range: 0..111."
-                     /note="PFAM-Id: PF00072"
-                     /label="nisR"
-     CDS_motif       10443..10666
-                     /note="Transcriptional regulatory protein, C terminal"
-                     /note="Pfam-A.hmm-Hit: Trans_reg_C. Score: 58.0. E-value:
-                     5e-16. Domain range: 0..76."
-                     /note="PFAM-Id: PF00486"
-                     /label="nisR"
      gene            10672..12015
                      /gene="nisK"
      CDS             10672..12015
@@ -274,18 +196,6 @@ FEATURES             Location/Qualifiers
                      FTEDTGRSGKHYGIGLSFAQGVALKHQGNLILSNPQKGGAEVILKIKK"
                      /gene="nisK"
                      /protein_id="ADJ56359.1"
-     CDS_motif       11362..11537
-                     /note="His Kinase A (phosphoacceptor) domain"
-                     /note="Pfam-A.hmm-Hit: HisKA. Score: 35.7. E-value:
-                     4.9e-09. Domain range: 4..64."
-                     /note="PFAM-Id: PF00512"
-                     /label="nisK"
-     CDS_motif       11689..12008
-                     /note="Histidine kinase-, DNA gyrase B-, and HSP90-like A"
-                     /note="Pfam-A.hmm-Hit: HATPase_c. Score: 45.6. E-value:
-                     3.6e-12. Domain range: 3..109."
-                     /note="PFAM-Id: PF02518"
-                     /label="nisK"
      gene            12114..12791
                      /gene="nisF"
      CDS             12114..12791
@@ -303,18 +213,6 @@ FEATURES             Location/Qualifiers
                      GGM"
                      /gene="nisF"
                      /protein_id="ADJ56360.1"
-     CDS_motif       12120..12289
-                     /note="Protein of unknown function, DUF258"
-                     /note="Pfam-A.hmm-Hit: DUF258. Score: 17.9. E-value: 0.001.
-                     Domain range: 11..66."
-                     /note="PFAM-Id: PF03193"
-                     /label="nisF"
-     CDS_motif       12234..12568
-                     /note="ABC transporter"
-                     /note="Pfam-A.hmm-Hit: ABC_tran. Score: 63.0. E-value:
-                     2.4e-17. Domain range: 0..118."
-                     /note="PFAM-Id: PF00005"
-                     /label="nisF"
      gene            12793..13521
                      /gene="nisE"
      CDS             12793..13521

--- a/antismash/modules/lanthipeptides/test/data/sco_cluster3.gbk
+++ b/antismash/modules/lanthipeptides/test/data/sco_cluster3.gbk
@@ -3,76 +3,10 @@ DEFINITION  Streptomyces coelicolor A3(2) chromosome, complete genome.
 ACCESSION   NC_003888
 VERSION     NC_003888.3
 KEYWORDS    .
-SOURCE      .
+SOURCE      
   ORGANISM  .
             .
-COMMENT     ##antiSMASH-Data-START##
-            Version      :: 5.0.0alpha-43c8f43
-            Run date     :: 2018-08-20 16:11:10
-            ##antiSMASH-Data-END##
 FEATURES             Location/Qualifiers
-     cluster         1..35098
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /core_location="[9999:25098]"
-                     /cutoff="20000"
-                     /detection_rule="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="lanthipeptide"
-                     /tool="antismash"
-     cluster_core    10000..25098
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /cutoff="20000"
-                     /detection_rule="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="lanthipeptide"
-     supercluster    1..35098
-                     /child_cluster="1"
-                     /detection_rules="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /kind="single"
-                     /product="lanthipeptide"
-                     /supercluster_number="1"
-                     /tool="antismash"
-     region          1..35098
-                     /product="lanthipeptide"
-                     /region_number="1"
-                     /rules="((LANC_like and (Flavoprotein or Trp_halogenase or
-                     p450 or Lant_dehyd_N or Lant_dehyd_C or Lant_dehydr_C or
-                     tsrC or adh_short or adh_short_C2) or cds(LANC_like and
-                     (Pkinase or DUF4135)) or TIGR03731 or Antimicr18 or
-                     Gallidermin or L_biotic_A or leader_d or leader_eh or
-                     leader_abc or mature_d or mature_ab or mature_a or mature_b
-                     or mature_ha or mature_h_beta or lacticin_l or lacticin_mat
-                     or LD_lanti_pre or strep_PEQAXS) and not YcaO)"
-                     /supercluster_numbers="1"
-                     /tool="antismash"
      gene            796..1821
                      /db_xref="GeneID:1095671"
                      /gene_synonym="SCJ9A.26"
@@ -383,8 +317,6 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:21218808"
                      /db_xref="GeneID:1095680"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: adh_short"
                      /gene_synonym="SCF20.02"
                      /locus_tag="SCO0256"
                      /note="SCF20.02, possible short chain oxidoreductase, len:
@@ -399,10 +331,6 @@ FEATURES             Location/Qualifiers
                      family signature"
                      /product="short chain oxidoreductase"
                      /protein_id="NP_624587.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="adh_short (E-value: 3.1e-34, bitscore: 109.6,
-                     seeds: 230, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MTSVDNATPRTAVVTGAARGIGRGIAERLAEDGLDVVVADLPSMA
                      EELSAVAAGIEKTGRRALAVHADVTSKEQTDALVAAAADRFGRIDVYVANAGIARVTPL
@@ -414,34 +342,6 @@ FEATURES             Location/Qualifiers
                      /locus_tag="SCO0256"
                      /note="Pfam match to entry PF00106 adh_short, short chain
                      dehydrogenase, score 245.80, E-value 6e-70"
-     aSDomain        10030..10371
-                     /aSTool="nrps_pks_domains"
-                     /aSDomain="PKS_KR"
-                     /database="nrpspksdomains.hmm"
-                     /detection="hmmscan"
-                     /domain_id="nrpspksdomains_SCO0256_KR1"
-                     /evalue="5.60E-11"
-                     /label="SCO0256_KR1"
-                     /locus_tag="SCO0256"
-                     /score="34.2"
-                     /tool="antismash"
-                     /translation="TAVVTGAARGIGRGIAERLAEDGLDVVVADLPSMAEELSAVAAGI
-                     EKTGRRALAVHADVTSKEQTDALVAAAADRFGRIDVYVANAGIARVTPLLETDLDEFEQ
-                     VMAVNLRGVF"
-     CDS_motif       10036..10098
-                     /aSTool="pksnrpsmotif"
-                     /database="abmotifs"
-                     /detection="hmmscan"
-                     /domain_id="nrpspksmotif_SCO0256_0001"
-                     /evalue="1.50E-04"
-                     /label="PKSI-KR_m1"
-                     /locus_tag="SCO0256"
-                     /motif="PKSI-KR_m1"
-                     /note="NRPS/PKS Motif: PKSI-KR_m1 (e-value: 0.00015,
-                     bit-score: 14.5)"
-                     /score="14.5"
-                     /tool="antismash"
-                     /translation="VVTGAARGIGRGIAERLAEDG"
      misc_feature    10441..10527
                      /gene_synonym="SCF20.02"
                      /locus_tag="SCO0256"
@@ -549,20 +449,6 @@ FEATURES             Location/Qualifiers
                      /locus_tag="SCO0259"
                      /note="PS00059 Zinc-containing alcohol dehydrogenases
                      signature."
-     aSDomain        13048..13422
-                     /aSTool="nrps_pks_domains"
-                     /aSDomain="PKS_ER"
-                     /database="nrpspksdomains.hmm"
-                     /detection="hmmscan"
-                     /domain_id="nrpspksdomains_SCO0259_Xdom1"
-                     /evalue="3.50E-09"
-                     /label="SCO0259_Xdom1"
-                     /locus_tag="SCO0259"
-                     /score="27.7"
-                     /tool="antismash"
-                     /translation="GGYAEYLKTSARSVVRLDDSLEPADVAALADAGLTAYHAAAKAAR
-                     RLRPGDRCVVIGAGGLGHIGIQVLGALTAAEIVVVDRNPDAVDLAVSVGADHGVLADGG
-                     HVDRVRELTGGHGAEAVIDFV"
      gene            13769..14098
                      /db_xref="GeneID:1095684"
                      /gene_synonym="SCF1.02"
@@ -793,12 +679,6 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:21218818"
                      /db_xref="GeneID:1095691"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) PF12697 (E-value: 4.1e-21, bitscore:
-                     67.6, seeds: 465, tool: rule-based-clusters)"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) PF00561 (E-value: 5.7e-17, bitscore:
-                     53.2, seeds: 48, tool: rule-based-clusters)"
                      /gene_synonym="SCF1.09"
                      /locus_tag="SCO0267"
                      /note="SCF1.09, possible hydrolase, len: 258 aa; similar to
@@ -809,51 +689,17 @@ FEATURES             Location/Qualifiers
                      entry PF00561 abhydrolase, alpha/beta hydrolase fold"
                      /product="hydrolase"
                      /protein_id="NP_624597.1"
-                     /sec_met="Type: "
-                     /sec_met="PF12697 (E-value: 4.1e-21, bitscore: 67.6, seeds:
-                     465, tool: rule-based-clusters); PF00561 (E-value: 5.7e-17,
-                     bitscore: 53.2, seeds: 48, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MSTTQHTLVPVYDHRTGTGPTLVFLHYWGGSARTWDLVVDRLPGR
                      AVVAVDFRGWGRSRALPGPYTLGRFADDTLAVLADAGITDYVLVGHSMGGKVAQLVAAT
                      RPAGLRAIVLVGSGPAKPAARVTPEYREALSHAYDSAESVAGARDHVLTATELPAALKA
                      RIVTDSRNVTDAARIEWPLRGIAQDITEHTRRIDVPALVVAGEHDQVEPAGVLRDNLVP
                      YLARADFVVVPRTGHLIPLEAPADLADAVTAFATAV"
-     aSDomain        19385..19915
-                     /aSTool="nrps_pks_domains"
-                     /aSDomain="Thioesterase"
-                     /database="nrpspksdomains.hmm"
-                     /detection="hmmscan"
-                     /domain_id="nrpspksdomains_SCO0267_Xdom1"
-                     /evalue="7.20E-10"
-                     /label="SCO0267_Xdom1"
-                     /locus_tag="SCO0267"
-                     /score="31.2"
-                     /tool="antismash"
-                     /translation="TLVFLHYWGGSARTWDLVVDRLPGRAVVAVDFRGWGRSRALPGPY
-                     TLGRFADDTLAVLADAGITDYVLVGHSMGGKVAQLVAATRPAGLRAIVLVGSGPAKPAA
-                     RVTPEYREALSHAYDSAESVAGARDHVLTATELPAALKARIVTDSRNVTDAARIEWPLR
-                     GIAQDITEHTRRID"
      misc_feature    19457..20089
                      /gene_synonym="SCF1.09"
                      /locus_tag="SCO0267"
                      /note="Pfam match to entry PF00561 abhydrolase, alpha/beta
                      hydrolase fold, score 82.90, E-value 6.7e-21"
-     CDS_motif       19580..19633
-                     /aSTool="pksnrpsmotif"
-                     /database="abmotifs"
-                     /detection="hmmscan"
-                     /domain_id="nrpspksmotif_SCO0267_0001"
-                     /evalue="4.90E-07"
-                     /label="NRPS-te1"
-                     /locus_tag="SCO0267"
-                     /motif="NRPS-te1"
-                     /note="NRPS/PKS Motif: NRPS-te1 (e-value: 4.9e-07,
-                     bit-score: 22.3)"
-                     /score="22.3"
-                     /tool="antismash"
-                     /translation="YVLVGHSMGGKVAQLVAA"
      gene            20295..20456
                      /db_xref="GeneID:1095692"
                      /gene_synonym="SCF1.10"
@@ -862,17 +708,11 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:21218819"
                      /db_xref="GeneID:1095692"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: strep_PEQAXS"
                      /gene_synonym="SCF1.10"
                      /locus_tag="SCO0268"
                      /note="SCF1.10, unknown, len:53 aa"
                      /product="hypothetical protein"
                      /protein_id="NP_624598.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="strep_PEQAXS (E-value: 5.2e-43, bitscore: 136.0,
-                     seeds: 4, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MRTEIVLSHEAPELDLDLDLRVSDLPEQAASFGEGTFTSPSSYAI
                      GTRCPICC"
@@ -884,12 +724,6 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:21218820"
                      /db_xref="GeneID:1095693"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehyd_C"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehydr_C"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehyd_N"
                      /gene_synonym="SCF1.11"
                      /locus_tag="SCO0269"
                      /note="SCF1.11, unknown, len: 1053aa; similar to large
@@ -900,13 +734,6 @@ FEATURES             Location/Qualifiers
                      identity in 1041 aa overlap)."
                      /product="hypothetical protein"
                      /protein_id="NP_624599.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="Lant_dehyd_N (E-value: 1e-17, bitscore: 55.3,
-                     seeds: 38, tool: rule-based-clusters); Lant_dehyd_C
-                     (E-value: 1.2e-119, bitscore: 390.9, seeds: 37, tool:
-                     rule-based-clusters); Lant_dehydr_C (E-value: 3.3e-35,
-                     bitscore: 113.1, seeds: 35, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MAAESEAHRAAAVFEVREPVLVRMASRPRGAAPATVDAAEPVSGA
                      RQLAADPLLGQAVRVASGSLAHSLARLTTDEGASALGRKRTLSAARTLTRYARRAGARP
@@ -935,8 +762,6 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:21218821"
                      /db_xref="GeneID:1095694"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: LANC_like"
                      /gene_synonym="SCF1.12"
                      /locus_tag="SCO0270"
                      /note="SCF1.12, unknown, len: 466 aa; similar to proteins
@@ -946,10 +771,6 @@ FEATURES             Location/Qualifiers
                      E(): 3.2e-23, (28.9% identity in 405 aa overlap)"
                      /product="hypothetical protein"
                      /protein_id="NP_624600.1"
-                     /sec_met="Type: lanthipeptide"
-                     /sec_met="LANC_like (E-value: 8.4e-65, bitscore: 209.8,
-                     seeds: 47, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MSGTTEGGSPEHTMDGFSGSGTREAPAGESPRALRERAGAVSAEI
                      LDRLADPAATVAATRIPAQAADDGVAEPIWAELTLGSGSPGLALAFAGASRDAARQVPR

--- a/antismash/modules/lanthipeptides/test/integration_lanthipeptides.py
+++ b/antismash/modules/lanthipeptides/test/integration_lanthipeptides.py
@@ -4,12 +4,8 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=no-self-use,protected-access,missing-docstring
 
-import json
 import os
 import unittest
-
-from helperlibs.bio import seqio
-from helperlibs.wrappers.io import TemporaryDirectory
 
 import antismash
 from antismash.common import path
@@ -17,7 +13,6 @@ from antismash.common.test import helpers
 from antismash.common.secmet import Record
 from antismash.config import build_config, update_config, destroy_config
 from antismash.modules import lanthipeptides
-from antismash.modules.lanthipeptides import run_specific_analysis, LanthiResults
 import antismash.modules.lanthipeptides.config as lanthi_config
 
 
@@ -41,29 +36,32 @@ class IntegrationLanthipeptides(unittest.TestCase):
                 motifs.extend(result.motifs_by_locus[locus])
         return motifs
 
-    def test_nisin_end_to_end(self):
-        # skip fimo being disabled for this, we already test the computational
-        # side elsewhere
-        if self.options.without_fimo:
-            return
-        nisin = helpers.get_path_to_nisin_genbank()
-        result = helpers.run_and_regenerate_results_for_module(nisin, lanthipeptides, self.options)
-        assert list(result.motifs_by_locus) == ["nisB"]
-        prepeptide = result.motifs_by_locus["nisB"][0]
-        self.assertAlmostEqual(3336.0, prepeptide.molecular_weight, delta=0.05)
+    def run_lanthi(self, genbank, html_snippet, expected_motifs=1):
+        def callback(output_dir):
+            with open(os.path.join(output_dir, "index.html")) as handle:
+                content = handle.read()
+                assert html_snippet in content
+
+        rec = Record.from_genbank(genbank, taxon="bacteria")[0]
+        assert not rec.get_cds_motifs()
+        result = helpers.run_and_regenerate_results_for_module(genbank, lanthipeptides,
+                                                               self.options, callback=callback)
+        assert len(result.clusters) == 1
+        motifs = self.gather_all_motifs(result)
+        assert len(motifs) == expected_motifs
+
+        result.add_to_record(rec)
+        assert len(rec.get_cds_motifs()) == expected_motifs
+
+        return rec, result
 
     def test_nisin(self):
         "Test lanthipeptide prediction for nisin A"
-        rec = Record.from_biopython(seqio.read(helpers.get_path_to_nisin_with_detection()), taxon="bacteria")
-        assert not rec.get_cds_motifs()
-        result = run_specific_analysis(rec)
-        assert len(result.clusters) == 1
-        motifs = self.gather_all_motifs(result)
-        assert len(motifs) == 1
-        assert not rec.get_cds_motifs()
-        result.add_to_record(rec)
-        assert len(rec.get_cds_motifs()) == 1
-        prepeptide = motifs[0]
+        expected_html_snippet = "nisA leader / core peptide"
+        genbank = helpers.get_path_to_nisin_genbank()
+        rec, _ = self.run_lanthi(genbank, expected_html_snippet)
+
+        prepeptide = rec.get_cds_motifs()[0]
         # real monoisotopic mass is 3351.51, but we overpredict a Dha
         self.assertAlmostEqual(3333.6, prepeptide.monoisotopic_mass, delta=0.05)
         # real mw is 3354.5, see above
@@ -76,39 +74,13 @@ class IntegrationLanthipeptides(unittest.TestCase):
         self.assertEqual("ITSISLCTPGCKTGALMGCNMKTATCHCSIHVSK", prepeptide.core)
         self.assertEqual('Class I', prepeptide.peptide_subclass)
 
-        initial_json = json.dumps(result.to_json())
-        regenerated = LanthiResults.from_json(json.loads(initial_json), rec)
-        assert list(result.motifs_by_locus) == ["nisB"]
-        assert str(result.motifs_by_locus) == str(regenerated.motifs_by_locus)
-        regenned_motifs = self.gather_all_motifs(regenerated)
-        assert len(regenned_motifs) == 1
-        assert regenned_motifs[0].detailed_information.lan_bridges == 5
-        assert result.clusters == regenerated.clusters
-        assert initial_json == json.dumps(regenerated.to_json())
-
-    def test_nisin_complete(self):
-        with TemporaryDirectory() as output_dir:
-            args = ["run_antismash.py", "--minimal", "--enable-lanthipeptides", "--output-dir", output_dir]
-            options = build_config(args, isolated=True, modules=antismash.get_all_modules())
-            antismash.run_antismash(helpers.get_path_to_nisin_genbank(), options)
-
-            # make sure the html_output section was tested
-            with open(os.path.join(output_dir, "index.html")) as handle:
-                content = handle.read()
-                assert "nisA leader / core peptide" in content
-
     def test_epidermin(self):
         "Test lanthipeptide prediction for epidermin"
         filename = path.get_full_path(__file__, 'data', 'epidermin.gbk')
-        rec = Record.from_biopython(seqio.read(filename), taxon="bacteria")
-        assert not rec.get_cds_motifs()
-        result = run_specific_analysis(rec)
-        motifs = self.gather_all_motifs(result)
-        assert len(motifs) == 1
-        assert not rec.get_cds_motifs()
-        result.add_to_record(rec)
-        assert len(rec.get_cds_motifs()) == 1
-        prepeptide = motifs[0]
+        expected_html_snippet = "Lanthipeptide(s) for epiB - Putative Class I"
+        rec, _ = self.run_lanthi(filename, expected_html_snippet)
+
+        prepeptide = rec.get_cds_motifs()[0]
         self.assertAlmostEqual(2164, prepeptide.monoisotopic_mass, delta=0.5)
         self.assertAlmostEqual(2165.6, prepeptide.molecular_weight, delta=0.5)
         self.assertEqual(3, prepeptide.detailed_information.lan_bridges)
@@ -120,16 +92,10 @@ class IntegrationLanthipeptides(unittest.TestCase):
     def test_microbisporicin(self):
         "Test lanthipeptide prediction for microbisporicin"
         filename = path.get_full_path(__file__, 'data', 'microbisporicin.gbk')
-        rec = Record.from_biopython(seqio.read(filename), taxon="bacteria")
-        assert not rec.get_cds_motifs()
-        result = run_specific_analysis(rec)
-        motifs = self.gather_all_motifs(result)
-        assert len(motifs) == 1
-        assert not rec.get_cds_motifs()
-        result.add_to_record(rec)
-        assert len(rec.get_cds_motifs()) == 1
+        expected_snippet = "Lanthipeptide(s) for mibB - Putative Class I"
+        rec, _ = self.run_lanthi(filename, expected_snippet)
 
-        prepeptide = motifs[0]
+        prepeptide = rec.get_cds_motifs()[0]
         # NOTE: this is not the correct weight for microbisporicin
         # there are some additional modifications we do not predict yet
         self.assertAlmostEqual(2212.9, prepeptide.monoisotopic_mass, delta=0.5)
@@ -143,16 +109,9 @@ class IntegrationLanthipeptides(unittest.TestCase):
     def test_epicidin(self):
         "Test lanthipeptide prediction for epicidin 280"
         filename = path.get_full_path(__file__, 'data', 'epicidin_280.gbk')
-        rec = Record.from_biopython(seqio.read(filename), taxon="bacteria")
-        assert len(rec.get_cds_motifs()) == 1
-        result = run_specific_analysis(rec)
-        motifs = self.gather_all_motifs(result)
-        assert len(motifs) == 1
-        assert len(rec.get_cds_motifs()) == 1
-        result.add_to_record(rec)
-        assert len(rec.get_cds_motifs()) == 2
-
-        prepeptide = motifs[0]
+        expected_html_snippet = "Lanthipeptide(s) for eciB - Putative Class I"
+        _, result = self.run_lanthi(filename, expected_html_snippet)
+        prepeptide = self.gather_all_motifs(result)[0]
         self.assertAlmostEqual(3115.7, prepeptide.monoisotopic_mass, delta=0.5)
         self.assertAlmostEqual(3117.7, prepeptide.molecular_weight, delta=0.5)
         for expected, calculated in zip([3135.7, 3153.7, 3171.7],
@@ -167,49 +126,41 @@ class IntegrationLanthipeptides(unittest.TestCase):
     def test_labyrinthopeptin(self):
         "Test lanthipeptide prediction for labyrinthopeptin"
         filename = path.get_full_path(__file__, 'data', 'labyrinthopeptin.gbk')
-        rec = Record.from_biopython(seqio.read(filename), taxon="bacteria")
-        assert not rec.get_cds_motifs()
-        result = run_specific_analysis(rec)
-        motifs = self.gather_all_motifs(result)
-        assert len(motifs) == 2
-        assert not rec.get_cds_motifs()
-        result.add_to_record(rec)
-        assert len(rec.get_cds_motifs()) == 2
+        expected_snippet = "Lanthipeptide(s) for labKC - Putative Class III"
+        rec, _ = self.run_lanthi(filename, expected_snippet, expected_motifs=2)
+        motifs = sorted(rec.get_cds_motifs(), key=lambda x: x.locus_tag)
+
+        assert motifs[0].locus_tag == "labA1"
+        assert motifs[0].detailed_information.lan_bridges == 4
+        self.assertAlmostEqual(motifs[0].molecular_weight, 2059.3, delta=0.5)
+
+        assert motifs[1].locus_tag == "labA2"
+        assert motifs[1].detailed_information.lan_bridges == 4
+        self.assertAlmostEqual(motifs[1].molecular_weight, 1908.1, delta=0.5)
 
     def test_sco_cluster3(self):
         "Test lanthipeptide prediction for SCO cluster #3"
         filename = path.get_full_path(__file__, 'data', 'sco_cluster3.gbk')
-        rec = Record.from_biopython(seqio.read(filename), taxon="bacteria")
-        for motif in rec.get_cds_motifs():
-            assert motif.tool == "pksnrpsmotif"
-        existing_count = len(rec.get_cds_motifs())
-        result = run_specific_analysis(rec)
-        motifs = self.gather_all_motifs(result)
-        assert len(motifs) == 1
+        expected_snippet = "Lanthipeptide(s) for SCO0269 - Putative Class I"
+        rec, _ = self.run_lanthi(filename, expected_snippet)
 
-        assert len(rec.get_cds_motifs()) == existing_count
-        result.add_to_record(rec)
-        assert len(rec.get_cds_motifs()) == existing_count + 1
-
-        self.assertEqual('Class I', motifs[0].peptide_subclass)
+        prepeptide = rec.get_cds_motifs()[0]
+        assert prepeptide.peptide_subclass == 'Class I'
+        assert prepeptide.detailed_information.lan_bridges == 3
+        assert prepeptide.detailed_information.rodeo_score == 15
 
     def test_lactocin_s(self):
         """Test lanthipeptide prediction for lactocin S"""
         filename = path.get_full_path(__file__, 'data', 'lactocin_s.gbk')
-        rec = Record.from_biopython(seqio.read(filename), taxon="bacteria")
-        assert not rec.get_cds_motifs()
-        existing_count = len(rec.get_cds_motifs())
-        result = run_specific_analysis(rec)
+        expected_snippet = "Lanthipeptide(s) for lasM - Putative Class II"
+        _, result = self.run_lanthi(filename, expected_snippet)
+
         assert len(result.clusters) == 1
         assert result.clusters[1] == set(["lasM"])
         assert len(result.motifs_by_locus["lasM"]) == 1
         motifs = result.motifs_by_locus["lasM"]
-        assert len(motifs) == 1
-        # ensure not added yet
-        assert len(rec.get_cds_motifs()) == existing_count
-        result.add_to_record(rec)
-        assert len(rec.get_cds_motifs()) == existing_count + 1
-        self.assertEqual('Class II', motifs[0].peptide_subclass)
+
+        assert motifs[0].peptide_subclass == "Class II"
 
     def test_multiple_biosynthetic_enzymes(self):
         # TODO: find/create an input with both class II and class III lanthipeptides

--- a/antismash/modules/lassopeptides/test/data/SSV2083.gbk
+++ b/antismash/modules/lassopeptides/test/data/SSV2083.gbk
@@ -4,7 +4,7 @@ DEFINITION  ENA|CM000951|CM000951.1 Streptomyces sviceus ATCC 29083 chromosome,
 ACCESSION   c00001_ENACM0
 VERSION     c00001_ENACM0
 KEYWORDS    .
-SOURCE      .
+SOURCE      
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers

--- a/antismash/modules/lassopeptides/test/data/burhizin.gbk
+++ b/antismash/modules/lassopeptides/test/data/burhizin.gbk
@@ -7,42 +7,7 @@ KEYWORDS    .
 SOURCE      cluster1 only
   ORGANISM  .
             .
-COMMENT     ##antiSMASH-Data-START##
-            Version      :: 5.0.0alpha-43c8f43
-            Run date     :: 2018-08-20 16:36:54
-            ##antiSMASH-Data-END##
 FEATURES             Location/Qualifiers
-     cluster         1..20844
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /core_location="[8417:10897]"
-                     /cutoff="10000"
-                     /detection_rule="(PF13471 and PF00733 or micJ25 or mcjC)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="lassopeptide"
-                     /tool="antismash"
-     cluster_core    8418..10897
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /cutoff="10000"
-                     /detection_rule="(PF13471 and PF00733 or micJ25 or mcjC)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="lassopeptide"
-     supercluster    1..20844
-                     /child_cluster="1"
-                     /detection_rules="(PF13471 and PF00733 or micJ25 or mcjC)"
-                     /kind="single"
-                     /product="lassopeptide"
-                     /supercluster_number="1"
-                     /tool="antismash"
-     region          1..20844
-                     /product="lassopeptide"
-                     /region_number="1"
-                     /rules="(PF13471 and PF00733 or micJ25 or mcjC)"
-                     /supercluster_numbers="1"
-                     /tool="antismash"
      CDS             138..821
                      /locus_tag="ctg1_orf02098"
                      /note="Glimmer score: 10.32"
@@ -135,15 +100,9 @@ FEATURES             Location/Qualifiers
                      DIFKHLYERYRHTTRLVIAHRLAAIQQADLILVMQEGAIVETGTHRSFWRNRAFMPICG
                      INKLIHRQHDLTASIRQKQSMRR"
      CDS             complement(8418..10160)
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lassopeptide: PF00733"
                      /locus_tag="ctg1_orf02114"
                      /note="Glimmer score: 4.45"
                      /product="ctg1_orf02114"
-                     /sec_met="Type: lassopeptide"
-                     /sec_met="PF00733 (E-value: 2.2e-09, bitscore: 28.1, seeds:
-                     104, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=1
                      /translation="MTLLGIAYPQAQDDWAQKQDWTLVRDPSHRTAGALWHQSEPSTRV
                      LCGRLGTSAYYFYGSAFSKQDHREIQEGELQAMVAEGPARLMAQCWGRYLFISFDLAAK
@@ -157,15 +116,9 @@ FEATURES             Location/Qualifiers
                      LLGLRDHREHVMAVCLEGWLAKAGYIDVARTHDAIQQSSKGNSKHFMDLLHLYAAELFI
                      QSWQ"
      CDS             complement(10157..10897)
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lassopeptide: PF13471"
                      /locus_tag="ctg1_orf02115"
                      /note="Glimmer score: 6.31"
                      /product="ctg1_orf02115"
-                     /sec_met="Type: lassopeptide"
-                     /sec_met="PF13471 (E-value: 5.9e-21, bitscore: 65.5, seeds:
-                     84, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=1
                      /translation="MPHHLMPHVFGACFAQQIILLDVVRDRYAVLTERQSAALAQQLGL
                      SDARFARVEAVQSASILEELKRAQWISVTSFAEADAKLNMLSPSPTTGGMSANGWKLPE

--- a/antismash/modules/sactipeptides/test/data/AP012495.1_c14.gbk
+++ b/antismash/modules/sactipeptides/test/data/AP012495.1_c14.gbk
@@ -3,7 +3,7 @@ DEFINITION  Bacillus subtilis BEST7613 DNA, complete genome.
 ACCESSION   AP012495
 VERSION     AP012495.1
 KEYWORDS    .
-SOURCE      .
+SOURCE      
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers

--- a/antismash/modules/sactipeptides/test/data/AP012495.1_c14_missing_precursor.gbk
+++ b/antismash/modules/sactipeptides/test/data/AP012495.1_c14_missing_precursor.gbk
@@ -3,7 +3,7 @@ DEFINITION  Bacillus subtilis BEST7613 DNA, complete genome.
 ACCESSION   AP012495
 VERSION     AP012495.1
 KEYWORDS    .
-SOURCE      .
+SOURCE      
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers

--- a/antismash/modules/thiopeptides/test/data/CP009369.1.gbk
+++ b/antismash/modules/thiopeptides/test/data/CP009369.1.gbk
@@ -3,7 +3,7 @@ DEFINITION  Bacillus cereus strain FM1, complete genome.
 ACCESSION   CP009369
 VERSION     CP009369.1
 KEYWORDS    .
-SOURCE      .
+SOURCE      
   ORGANISM  .
             .
 FEATURES             Location/Qualifiers
@@ -106,10 +106,6 @@ FEATURES             Location/Qualifiers
                      /locus_tag="BG03_4576"
                      /note="thiopep_ocin: thiopeptide-type bacteriocin
                      biosynthesis domain protein"
-                     /note="smCOG:
-                     SMCOG1155:Lantibiotic_dehydratase_domain_protein (Score:
-                     71.6; E-value: 1.092e-21);"
-                     /note="smCOG tree PNG image: smcogs/BG03_4576.png"
                      /product="thiopeptide-type bacteriocin biosynthesis domain
                      protein"
                      /protein_id="AJG92769.1"
@@ -185,9 +181,6 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:753362163"
                      /locus_tag="BG03_4580"
-                     /note="smCOG: SMCOG1065:ABC-2_type_transporter (Score:
-                     45.0; E-value: 1.3e-13);"
-                     /note="smCOG tree PNG image: smcogs/BG03_4580.png"
                      /product="ABC-2 type transporter family protein"
                      /protein_id="AJG95087.1"
                      /transl_table=11
@@ -202,9 +195,6 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:753361428"
                      /locus_tag="BG03_4581"
-                     /note="smCOG: SMCOG1000:ABC_transporter_ATP-binding_protein
-                     (Score: 179.6; E-value: 1.3e-54);"
-                     /note="smCOG tree PNG image: smcogs/BG03_4581.png"
                      /product="ABC transporter family protein"
                      /protein_id="AJG94352.1"
                      /transl_table=11
@@ -220,10 +210,6 @@ FEATURES             Location/Qualifiers
                      /db_xref="GI:753360026"
                      /locus_tag="BG03_4582"
                      /note="lantibiotic dehydratase, C terminus family protein"
-                     /note="smCOG:
-                     SMCOG1155:Lantibiotic_dehydratase_domain_protein (Score:
-                     53.6; E-value: 2.944e-16);"
-                     /note="smCOG tree PNG image: smcogs/BG03_4582.png"
                      /product="hypothetical protein"
                      /protein_id="AJG92950.1"
                      /transl_table=11
@@ -329,9 +315,6 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:753359520"
                      /locus_tag="BG03_4589"
-                     /note="smCOG: SMCOG1000:ABC_transporter_ATP-binding_protein
-                     (Score: 157.2; E-value: 9.3e-48);"
-                     /note="smCOG tree PNG image: smcogs/BG03_4589.png"
                      /product="ABC transporter family protein"
                      /protein_id="AJG92444.1"
                      /transl_table=11

--- a/antismash/modules/thiopeptides/test/data/lac_before_analysis.gbk
+++ b/antismash/modules/thiopeptides/test/data/lac_before_analysis.gbk
@@ -7,10 +7,6 @@ KEYWORDS    .
 SOURCE      
   ORGANISM  .
             .
-COMMENT     ##antiSMASH-Data-START##
-            Version      :: 5.0.0alpha-43c8f43
-            Run date     :: 2018-08-20 16:53:38
-            ##antiSMASH-Data-END##
 FEATURES             Location/Qualifiers
      gene            1..2574
                      /gene="ltc74"
@@ -18,19 +14,9 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:604722593"
                      /gene="ltc74"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Pkinase"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: LANC_like"
                      /locus_tag="ltc74"
                      /product="serine/threonine protein kinase"
                      /protein_id="BAO57433.1"
-                     /sec_met="Type: lanthipeptide-thiopeptide"
-                     /sec_met="LANC_like (E-value: 3.1e-20, bitscore: 61.4,
-                     seeds: 47, tool: rule-based-clusters); Pkinase (E-value:
-                     1.2e-14, bitscore: 43.5, seeds: 54, tool:
-                     rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MSTPPDPGSAAVLGQEELRRRAEELAARAPGPHRPLRTDGQWWYL
                      PDPRMPELAHGWKLHLSARPEGFAALLDTVLPILLGRVCDVKFAVSAAALWELNSGRHG
@@ -52,103 +38,6 @@ FEATURES             Location/Qualifiers
                      /mol_type="genomic DNA"
                      /organism="Streptomyces lactacystinaeus"
                      /strain="OM-6519"
-     cluster         1..14244
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /core_location="[3370:10983]"
-                     /cutoff="20000"
-                     /detection_rule="(YcaO and ((thio_amide and (PF06968 or
-                     PF04055 or PF07366)) or Lant_dehyd_C or Lant_dehyd_N or
-                     PF07366 or PF06968 or PF04055) or (thiostrepton and tsrC)
-                     or thiostrepton)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="thiopeptide"
-                     /tool="antismash"
-     cluster_core    3371..10983
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /cutoff="20000"
-                     /detection_rule="(YcaO and ((thio_amide and (PF06968 or
-                     PF04055 or PF07366)) or Lant_dehyd_C or Lant_dehyd_N or
-                     PF07366 or PF06968 or PF04055) or (thiostrepton and tsrC)
-                     or thiostrepton)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="thiopeptide"
-     cluster         1..14244
-                     /aStool="rule-based-clusters"
-                     /cluster_number="2"
-                     /core_location="[0:12737]"
-                     /cutoff="20000"
-                     /detection_rule="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="2"
-                     /product="lanthipeptide"
-                     /tool="antismash"
-     cluster_core    1..12737
-                     /aStool="rule-based-clusters"
-                     /cluster_number="2"
-                     /cutoff="20000"
-                     /detection_rule="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="2"
-                     /product="lanthipeptide"
-     supercluster    1..14244
-                     /child_cluster="2"
-                     /child_cluster="1"
-                     /detection_rules="((LANC_like and (Flavoprotein or
-                     Trp_halogenase or p450 or Lant_dehyd_N or Lant_dehyd_C or
-                     Lant_dehydr_C or tsrC or adh_short or adh_short_C2) or
-                     cds(LANC_like and (Pkinase or DUF4135)) or TIGR03731 or
-                     Antimicr18 or Gallidermin or L_biotic_A or leader_d or
-                     leader_eh or leader_abc or mature_d or mature_ab or
-                     mature_a or mature_b or mature_ha or mature_h_beta or
-                     lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
-                     and not YcaO)"
-                     /detection_rules="(YcaO and ((thio_amide and (PF06968 or
-                     PF04055 or PF07366)) or Lant_dehyd_C or Lant_dehyd_N or
-                     PF07366 or PF06968 or PF04055) or (thiostrepton and tsrC)
-                     or thiostrepton)"
-                     /kind="interleaved"
-                     /product="lanthipeptide"
-                     /product="thiopeptide"
-                     /supercluster_number="1"
-                     /tool="antismash"
-     region          1..14244
-                     /product="lanthipeptide"
-                     /product="thiopeptide"
-                     /region_number="1"
-                     /rules="((LANC_like and (Flavoprotein or Trp_halogenase or
-                     p450 or Lant_dehyd_N or Lant_dehyd_C or Lant_dehydr_C or
-                     tsrC or adh_short or adh_short_C2) or cds(LANC_like and
-                     (Pkinase or DUF4135)) or TIGR03731 or Antimicr18 or
-                     Gallidermin or L_biotic_A or leader_d or leader_eh or
-                     leader_abc or mature_d or mature_ab or mature_a or mature_b
-                     or mature_ha or mature_h_beta or lacticin_l or lacticin_mat
-                     or LD_lanti_pre or strep_PEQAXS) and not YcaO)"
-                     /rules="(YcaO and ((thio_amide and (PF06968 or PF04055 or
-                     PF07366)) or Lant_dehyd_C or Lant_dehyd_N or PF07366 or
-                     PF06968 or PF04055) or (thiostrepton and tsrC) or
-                     thiostrepton)"
-                     /supercluster_numbers="1"
-                     /tool="antismash"
      gene            2976..3149
                      /gene="lazA"
      CDS             2976..3149
@@ -167,23 +56,9 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:604722595"
                      /gene="lazB"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: Lant_dehyd_C"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: Lant_dehyd_N"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehyd_C"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehyd_N"
                      /locus_tag="lazB"
                      /product="lantibiotic-type dehydratase"
                      /protein_id="BAO57435.1"
-                     /sec_met="Type: lanthipeptide-thiopeptide"
-                     /sec_met="Lant_dehyd_N (E-value: 2e-08, bitscore: 23.8,
-                     seeds: 38, tool: rule-based-clusters); Lant_dehyd_C
-                     (E-value: 6.6e-30, bitscore: 93.1, seeds: 37, tool:
-                     rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MPNRAAPPRDARAPVPAPAPAAYAARHALVRSTVLAWPAQSAATA
                      HTRALLRDLAAAEAAAEALRPALCDDLYAGRAGHDEEFHRRVVLPLRRDLHNGRTPRAA
@@ -207,15 +82,9 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:604722596"
                      /gene="lazC"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehydr_C"
                      /locus_tag="lazC"
                      /product="lantibiotic-type dehydratase"
                      /protein_id="BAO57436.1"
-                     /sec_met="Type: lanthipeptide-thiopeptide"
-                     /sec_met="Lant_dehydr_C (E-value: 1.1e-17, bitscore: 53.7,
-                     seeds: 35, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MSDPADGRGAVTAWDVVLYHYRPDKARALREAVLPLARQAAAEGL
                      AAHVERHWRFGPHLRLRLRGPEARVAGAAQRAAEALRAWAAAHPSVADRSDEQLLAEAA
@@ -251,15 +120,9 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:604722598"
                      /gene="lazE"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: YcaO"
                      /locus_tag="lazE"
                      /product="cyclodehydratase"
                      /protein_id="BAO57438.1"
-                     /sec_met="Type: thiopeptide"
-                     /sec_met="YcaO (E-value: 3.7e-72, bitscore: 233.0, seeds:
-                     127, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MSELPVLTPVEALAATSGTAVVHLTEWTLGLAARLSRHALAHPVR
                      LVPVREDGALTVVGPVLAPGAPACLACVEYQRLATAGGRVPWQSPALALGGTGTPAFAE
@@ -279,20 +142,9 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:604722599"
                      /gene="lazF"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     lanthipeptide: Lant_dehydr_C"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) PF00881 (E-value: 4e-15, bitscore:
-                     45.5, seeds: 78, tool: rule-based-clusters)"
                      /locus_tag="lazF"
                      /product="dehydrogenase"
                      /protein_id="BAO57439.1"
-                     /sec_met="Type: lanthipeptide-thiopeptide"
-                     /sec_met="PF00881 (E-value: 4e-15, bitscore: 45.5, seeds:
-                     78, tool: rule-based-clusters); Lant_dehydr_C (E-value:
-                     1.5e-48, bitscore: 155.1, seeds: 35, tool:
-                     rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MTTHALPATTWHSLHLALPLPAREADAFLTEDLAPLMDGLAGTDW
                      FFIRYGEGGPHLRIRHRGPGPAPASLAADLTRLATRRTAPDGPFADGHGTVTEVPYEPE

--- a/antismash/modules/thiopeptides/test/data/nosi_before_analysis.gbk
+++ b/antismash/modules/thiopeptides/test/data/nosi_before_analysis.gbk
@@ -6,10 +6,6 @@ KEYWORDS    .
 SOURCE      
   ORGANISM  .
             .
-COMMENT     ##antiSMASH-Data-START##
-            Version      :: 5.0.0alpha-43c8f43
-            Run date     :: 2018-08-20 16:49:26
-            ##antiSMASH-Data-END##
 FEATURES             Location/Qualifiers
      gene            complement(<1..978)
                      /gene="nos1"
@@ -28,49 +24,6 @@ FEATURES             Location/Qualifiers
                      PIVMQLPIGAEADFKGVVDLVRMKALVWSAEATKGEMYDVVDIPATHTEAAEEWRGKLL
                      EAVAENDEEIMELYLEGEEPSEEQLYAAIRRITIASGKGQGTTVTPVFCGTAFKNKGVQ
                      PLLDAVVRYLPSPVDIEAIEGHAVDNAEEVIKRKPSDEEPLAALA"
-     cluster         1..30078
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /core_location="[2248:20078]"
-                     /cutoff="20000"
-                     /detection_rule="(YcaO and ((thio_amide and (PF06968 or
-                     PF04055 or PF07366)) or Lant_dehyd_C or Lant_dehyd_N or
-                     PF07366 or PF06968 or PF04055) or (thiostrepton and tsrC)
-                     or thiostrepton)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="thiopeptide"
-                     /tool="antismash"
-     cluster_core    2249..20078
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /cutoff="20000"
-                     /detection_rule="(YcaO and ((thio_amide and (PF06968 or
-                     PF04055 or PF07366)) or Lant_dehyd_C or Lant_dehyd_N or
-                     PF07366 or PF06968 or PF04055) or (thiostrepton and tsrC)
-                     or thiostrepton)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="thiopeptide"
-     supercluster    1..30078
-                     /child_cluster="1"
-                     /detection_rules="(YcaO and ((thio_amide and (PF06968 or
-                     PF04055 or PF07366)) or Lant_dehyd_C or Lant_dehyd_N or
-                     PF07366 or PF06968 or PF04055) or (thiostrepton and tsrC)
-                     or thiostrepton)"
-                     /kind="single"
-                     /product="thiopeptide"
-                     /supercluster_number="1"
-                     /tool="antismash"
-     region          1..30078
-                     /product="thiopeptide"
-                     /region_number="1"
-                     /rules="(YcaO and ((thio_amide and (PF06968 or PF04055 or
-                     PF07366)) or Lant_dehyd_C or Lant_dehyd_N or PF07366 or
-                     PF06968 or PF04055) or (thiostrepton and tsrC) or
-                     thiostrepton)"
-                     /supercluster_numbers="1"
-                     /tool="antismash"
      misc_feature    <1..34546
                      /note="nosiheptide biosynthetic gene cluster"
      source          1..34713
@@ -113,16 +66,10 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:238626051"
                      /gene="nosA"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: thio_amide"
                      /locus_tag="nosA"
                      /note="hypothetical protein"
                      /product="NosA"
                      /protein_id="ACR48330.1"
-                     /sec_met="Type: thiopeptide"
-                     /sec_met="thio_amide (E-value: 2.5e-37, bitscore: 117.7,
-                     seeds: 5, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MTEHPAQQLYCTVVLWDLSRSAATVASLRAYLRDHAVDAYTTVPG
                      LRQKTWISSTGPEGEQWGAVYLWDSPEAAYGRPPGVSKVVELIGYRPTERRYYSVEAAT
@@ -133,17 +80,10 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:238626052"
                      /gene="nosB"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) p450 (E-value: 2.8e-21, bitscore:
-                     66.4, seeds: 50, tool: rule-based-clusters)"
                      /locus_tag="nosB"
                      /note="cytochrome P450"
                      /product="NosB"
                      /protein_id="ACR48331.1"
-                     /sec_met="Type: "
-                     /sec_met="p450 (E-value: 2.8e-21, bitscore: 66.4, seeds:
-                     50, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MDESPTYPFEQKCPFAPPDELVRRRDEAPVSQIRLANGATAWLVT
                      RHDDVRTVLTDPRFSRAAIRAGALRGGPPGPGGPGGSAEGAPQGGWPGGPGGSAGGAPQ
@@ -159,17 +99,10 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:238626053"
                      /gene="nosC"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) p450 (E-value: 2.8e-32, bitscore:
-                     102.7, seeds: 50, tool: rule-based-clusters)"
                      /locus_tag="nosC"
                      /note="cytochrome P450"
                      /product="NosC"
                      /protein_id="ACR48332.1"
-                     /sec_met="Type: "
-                     /sec_met="p450 (E-value: 2.8e-32, bitscore: 102.7, seeds:
-                     50, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MDIEARTYPFTRHTPFEMPEEFAWLRENRPIAQVRLATGDTAWLI
                      TRYEDVRTALTDPRFSRTINREGAARVDTGFQADADSPVFNFGGSISEPPGHTRWRRLV
@@ -185,17 +118,10 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:238626054"
                      /gene="nosD"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) Lant_dehydr_C (E-value: 3e-54,
-                     bitscore: 175.4, seeds: 35, tool: rule-based-clusters)"
                      /locus_tag="nosD"
                      /note="dehydratase"
                      /product="NosD"
                      /protein_id="ACR48333.1"
-                     /sec_met="Type: "
-                     /sec_met="Lant_dehydr_C (E-value: 3e-54, bitscore: 175.4,
-                     seeds: 35, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MPAPETGPWHSLHLHRYAGQDAFLVDGLAPVLAPLHASGALESSF
                      FLRYWQGGHHIRLRLRPAAHDPEQAARTVREVADRLAGHLAAHPGGYGDLDPEEFREAQ
@@ -210,20 +136,10 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:238626055"
                      /gene="nosE"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: Lant_dehyd_C"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: Lant_dehyd_N"
                      /locus_tag="nosE"
                      /note="dehydratase"
                      /product="NosE"
                      /protein_id="ACR48334.1"
-                     /sec_met="Type: thiopeptide"
-                     /sec_met="Lant_dehyd_N (E-value: 1.6e-07, bitscore: 22.4,
-                     seeds: 38, tool: rule-based-clusters); Lant_dehyd_C
-                     (E-value: 4.4e-51, bitscore: 164.5, seeds: 37, tool:
-                     rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MPGAPDAAGAPDGFSPYYLYRRGTLGPSELAALTPARTWALLAEA
                      EETRQRREELRGRLEDALHAAVPELPADRRHELLRLRRDIHNDRVPGVPDAARLLDPAS
@@ -247,17 +163,10 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:238626056"
                      /gene="nosF"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) PF00881 (E-value: 9e-08, bitscore:
-                     23.1, seeds: 78, tool: rule-based-clusters)"
                      /locus_tag="nosF"
                      /note="NADH oxidase"
                      /product="NosF"
                      /protein_id="ACR48335.1"
-                     /sec_met="Type: "
-                     /sec_met="PF00881 (E-value: 9e-08, bitscore: 23.1, seeds:
-                     78, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MTTDEAYTYTTGLRLDPRSANPDGWRVDWADGPWPVKVYSGARRL
                      PLRPDGPPPLAALHRLLHGGFAVSRIRTDPSGGIAATPADPRPHHGPEVQLRRPVPSGG
@@ -275,16 +184,10 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:238626057"
                      /gene="nosG"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: YcaO"
                      /locus_tag="nosG"
                      /note="putative cyclodehydratase"
                      /product="NosG"
                      /protein_id="ACR48336.1"
-                     /sec_met="Type: thiopeptide"
-                     /sec_met="YcaO (E-value: 3.2e-73, bitscore: 238.0, seeds:
-                     127, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MSTATTPQPRTGPAGPPVVVGRGVLAEHLVRRLGRDDTPDPDGGA
                      RFGRSSGATVLVAGLDGLGEFQDTVVDCLATGRSLLFVGSWRSLVYIGPVWRPGTQGCP
@@ -327,17 +230,10 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:238626059"
                      /gene="nosI"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) AMP-binding (E-value: 4.7e-27,
-                     bitscore: 85.3, seeds: 400, tool: rule-based-clusters)"
                      /locus_tag="nosI"
                      /note="putative acyl-CoA synthetase"
                      /product="NosI"
                      /protein_id="ACR48338.1"
-                     /sec_met="Type: "
-                     /sec_met="AMP-binding (E-value: 4.7e-27, bitscore: 85.3,
-                     seeds: 400, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MGDMGRPAFQRFLTPRHLPAGRAGAVTGVRWGGDFAAWDDLLTAG
                      RDLAAQVRPGGAYAIDPTAGLPALAALFAVATVPDTVLLWASPRTLGVTGREIAPALHA
@@ -347,22 +243,6 @@ FEATURES             Location/Qualifiers
                      GHNRHVGRPIPGKSVWLTGTDERGIGTVAVAGPGCCRRTWRPGSPPSAPADHVTGTDYG
                      RFDADGNLCLEGRLDGAEKLAGVLVRPREIERHVLALDGVSDVRVTVETAPTGLEFLAA
                      TVVGSVDADTVRAHCAALPEQHRPSRISCASEQEAATVYSAHGKL"
-     aSDomain        complement(14946..15749)
-                     /aSTool="nrps_pks_domains"
-                     /aSDomain="AMP-binding"
-                     /database="nrpspksdomains.hmm"
-                     /detection="hmmscan"
-                     /domain_id="nrpspksdomains_nosI_A1"
-                     /evalue="8.30E-27"
-                     /label="nosI_A1"
-                     /locus_tag="nosI"
-                     /score="85.3"
-                     /tool="antismash"
-                     /translation="ERPLWGVCTSGSSGAPKVAVGPADEWEQIALHAEAAMYADAFPAG
-                     PPEALATCLPLGFSAAFFMCVLPALYLKRDLVVHPPHDWSPLYDLARDRRVLALGVPAL
-                     AAAACLSAPAATDLGSVALFLGGGHLSAPRVELIRRHFTGAAVSNLYGTAETGAIALDH
-                     DPGHNRHVGRPIPGKSVWLTGTDERGIGTVAVAGPGCCRRTWRPGSPPSAPADHVTGTD
-                     YGRFDADGNLCLEGRLDGAEKLAGVLVRPREIERHVLALDGVSDVR"
      gene            complement(16058..16297)
                      /gene="nosJ"
      CDS             complement(16058..16297)
@@ -382,21 +262,10 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:238626061"
                      /gene="nosK"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) PF12697 (E-value: 1.7e-16, bitscore:
-                     52.2, seeds: 465, tool: rule-based-clusters)"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) PF00561 (E-value: 2.5e-10, bitscore:
-                     31.2, seeds: 48, tool: rule-based-clusters)"
                      /locus_tag="nosK"
                      /note="putative hydrolase"
                      /product="NosK"
                      /protein_id="ACR48340.1"
-                     /sec_met="Type: "
-                     /sec_met="PF12697 (E-value: 1.7e-16, bitscore: 52.2, seeds:
-                     465, tool: rule-based-clusters); PF00561 (E-value: 2.5e-10,
-                     bitscore: 31.2, seeds: 48, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MDAETPMDTETPRDTETPMHTGMSTGPETPTVYLVHGLLGTGHGH
                      FAAQIRAWHGRLRTVPVDLPGHGRCRRDAAEDYFDDALRYLVAVLERFGPGRLIGASYL
@@ -409,17 +278,11 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:238626062"
                      /gene="nosL"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: PF06968"
                      /locus_tag="nosL"
                      /note="radical SAM:biotin and thiamin synthesis-associated
                      protein"
                      /product="NosL"
                      /protein_id="ACR48341.1"
-                     /sec_met="Type: thiopeptide"
-                     /sec_met="PF06968 (E-value: 6.5e-09, bitscore: 26.7, seeds:
-                     824, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MTQNSQAMTSHAMTGDFVLPELEDVRAEAATVDTRAVLALAEGEE
                      PAESRAAVALALWEDRSIGTAELQAAAEARCGARRPRLHTFVPLYTTNYCDSECKMCSM
@@ -435,16 +298,10 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:238626063"
                      /gene="nosM"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: thiostrepton"
                      /locus_tag="nosM"
                      /note="nosiheptide propeptide"
                      /product="NosM"
                      /protein_id="ACR48342.1"
-                     /sec_met="Type: thiopeptide"
-                     /sec_met="thiostrepton (E-value: 1.5e-15, bitscore: 47.9,
-                     seeds: 4, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MDAAHLSDLDIDALEISEFLDESRLEDSEVVAKVMSASCTTCECC
                      CSCSS"
@@ -454,16 +311,10 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:238626064"
                      /gene="nosN"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: PF04055"
                      /locus_tag="nosN"
                      /note="putative methyltransferase"
                      /product="NosN"
                      /protein_id="ACR48343.1"
-                     /sec_met="Type: thiopeptide"
-                     /sec_met="PF04055 (E-value: 6.6e-19, bitscore: 59.7, seeds:
-                     518, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MRQNLLMIYVHIPFCHSKCTFCDWVQAIPTKDLLRKPGDSVRQKY
                      ISALCAEIAERGAMHRAAGDIPHVLYWGGGTASSLDEQETAAVMEALHSSFDMSTVAEA
@@ -478,17 +329,10 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /db_xref="GI:238626065"
                      /gene="nosO"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) Lant_dehydr_C (E-value: 8.5e-12,
-                     bitscore: 35.9, seeds: 35, tool: rule-based-clusters)"
                      /locus_tag="nosO"
                      /note="hypothetical protein"
                      /product="NosO"
                      /protein_id="ACR48344.1"
-                     /sec_met="Type: "
-                     /sec_met="Lant_dehydr_C (E-value: 8.5e-12, bitscore: 35.9,
-                     seeds: 35, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MTSGPGQAPAEAAHAAGAAWLEIGLDAPADAVPALVAGVVRPLLR
                      EPAEPGAEPVPGFFLRGVGAAQPALVVQLEVTPGTDLAEPYAARARALAAGLGLPVQVA

--- a/antismash/modules/thiopeptides/test/data/thiopeptide.gbk
+++ b/antismash/modules/thiopeptides/test/data/thiopeptide.gbk
@@ -1,9 +1,9 @@
 LOCUS       BGC0001155.1           26287 bp    DNA              UNK 01-JAN-1980
-DEFINITION  GE2270 biosynthetic gene cluster
+DEFINITION  GE2270 biosynthetic gene cluster.
 ACCESSION   BGC0001155
 VERSION     BGC0001155.1
 KEYWORDS    .
-SOURCE      .
+SOURCE      
   ORGANISM  . .
             .
 FEATURES             Location/Qualifiers
@@ -130,8 +130,6 @@ FEATURES             Location/Qualifiers
                      /transl_table=11
                      /note="coproporphyrinogen III oxidase-related Fe-S
                      oxidoreductase"
-                     /note="smCOG: SMCOG1277:Radical_SAM_domain_protein (Score:
-                     57.5; E-value: 1.7e-17);"
                      /db_xref="GI:552968826"
                      /translation="MLIYVNVPFCNSKCHFCDWVTEVPLADLRLTPDSSPRQRYIAALV
                      QQIETHAPVLTGFGYRPEIMYWGGGTASILSIDEIEAVAGALSSRFDMSGLTEATIEGS
@@ -289,8 +287,6 @@ FEATURES             Location/Qualifiers
                      /transl_table=11
                      /note="coproporphyrinogen III oxidase-related Fe-S
                      oxidoreductase"
-                     /note="smCOG: SMCOG1277:Radical_SAM_domain_protein (Score:
-                     56.0; E-value: 4.6e-17);"
                      /db_xref="GI:552968835"
                      /translation="MLLYVNVPFCNSKCHFCDWVVDVPVSDLRLTPVSAGRIDYLEALR
                      TQIRIHAPALREAGYRSEVMYWGGGTATVLTEREIEQTYACLAAELDLSSLAEATIEGS
@@ -308,8 +304,6 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /transl_table=11
                      /note="O-methyl transferase"
-                     /note="smCOG: SMCOG1042:O-methyltransferase (Score: 295.5;
-                     E-value: 8.7e-90);"
                      /db_xref="GI:552968836"
                      /translation="MRTVLAAADLATPMAVRVAATLRLADRIAAGTDSAAALAAAAGAD
                      EAALTRLLRYLVARDIFREPSPGRFALSPAAELLRGDRPERLRDWLDLTGPIGRADLAF
@@ -352,8 +346,6 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /transl_table=11
                      /note="translation elongation factor; GTPase"
-                     /note="smCOG: SMCOG1190:GTP-binding_protein_LepA (Score:
-                     231.0; E-value: 4.9e-70);"
                      /db_xref="GI:552968839"
                      /translation="MATTLDLAKVRNIGIMAHIDAGKTTTTERILFYTGITYKIGEVHE
                      GAATMDWMEQEQERGITITSAATTCEWLGHTINIIDTPGHVDFTIEVERSLRVLDGAVA
@@ -377,8 +369,6 @@ FEATURES             Location/Qualifiers
                      /codon_start=1
                      /transl_table=11
                      /note="translation elongation factor; GTPase"
-                     /note="smCOG: SMCOG1190:GTP-binding_protein_LepA (Score:
-                     354.8; E-value: 7.425e-107);"
                      /db_xref="GI:552968840"
                      /translation="MAKAKFERTKPHMNIGTIGHIDHGKTTLTAAITKVLHDRYPELNK
                      ATPFDKIDKAPEEKARGITISIAHVEYQTEKRHYAHVDCPGHADYVKNMITGAAQMDGA

--- a/antismash/modules/thiopeptides/test/data/thiostrepton_before_analysis.gbk
+++ b/antismash/modules/thiopeptides/test/data/thiostrepton_before_analysis.gbk
@@ -6,14 +6,6 @@ KEYWORDS    .
 SOURCE      
   ORGANISM  .
             .
-COMMENT     ##antiSMASH-Data-START##
-            Version  :: 5.0.0alpha-43c8f43
-            Run date :: 2018-08-20 16:38:32
-            ##antiSMASH-Data-END##
-            ##antiSMASH-Data-START##
-            Version      :: 5.0.0alpha-43c8f43
-            Run date     :: 2018-08-20 17:20:44
-            ##antiSMASH-Data-END##
 FEATURES             Location/Qualifiers
      source          1..29379
                      /culture_collection="ATCC:31255"
@@ -21,49 +13,6 @@ FEATURES             Location/Qualifiers
                      /mol_type="genomic DNA"
                      /organism="Streptomyces laurentii"
                      /strain="ATCC 31255"
-     cluster         1..29379
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /core_location="[2014:28559]"
-                     /cutoff="20000"
-                     /detection_rule="(YcaO and ((thio_amide and (PF06968 or
-                     PF04055 or PF07366)) or Lant_dehyd_C or Lant_dehyd_N or
-                     PF07366 or PF06968 or PF04055) or (thiostrepton and tsrC)
-                     or thiostrepton)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="thiopeptide"
-                     /tool="antismash"
-     cluster_core    2015..28559
-                     /aStool="rule-based-clusters"
-                     /cluster_number="1"
-                     /cutoff="20000"
-                     /detection_rule="(YcaO and ((thio_amide and (PF06968 or
-                     PF04055 or PF07366)) or Lant_dehyd_C or Lant_dehyd_N or
-                     PF07366 or PF06968 or PF04055) or (thiostrepton and tsrC)
-                     or thiostrepton)"
-                     /neighbourhood="10000"
-                     /parent_cluster_number="1"
-                     /product="thiopeptide"
-     supercluster    1..29379
-                     /child_cluster="1"
-                     /detection_rules="(YcaO and ((thio_amide and (PF06968 or
-                     PF04055 or PF07366)) or Lant_dehyd_C or Lant_dehyd_N or
-                     PF07366 or PF06968 or PF04055) or (thiostrepton and tsrC)
-                     or thiostrepton)"
-                     /kind="single"
-                     /product="thiopeptide"
-                     /supercluster_number="1"
-                     /tool="antismash"
-     region          1..29379
-                     /product="thiopeptide"
-                     /region_number="1"
-                     /rules="(YcaO and ((thio_amide and (PF06968 or PF04055 or
-                     PF07366)) or Lant_dehyd_C or Lant_dehyd_N or PF07366 or
-                     PF06968 or PF04055) or (thiostrepton and tsrC) or
-                     thiostrepton)"
-                     /supercluster_numbers="1"
-                     /tool="antismash"
      CDS             complement(16..1104)
                      /codon_start=1
                      /db_xref="GI:224495626"
@@ -81,41 +30,13 @@ FEATURES             Location/Qualifiers
                      EEPVGPAASVEGPTEPGEAPGD"
      misc_feature    16..29374
                      /note="thiostrepton biosynthesis gene cluster"
-     aSDomain        complement(118..1005)
-                     /aSTool="nrps_pks_domains"
-                     /aSDomain="Aminotran_1_2"
-                     /database="nrpspksdomains.hmm"
-                     /detection="hmmscan"
-                     /domain_id="nrpspksdomains_ACN52311_Xdom1"
-                     /evalue="1.10E-46"
-                     /label="ACN52311_Xdom1"
-                     /locus_tag="ACN52311.1"
-                     /score="151.1"
-                     /tool="antismash"
-                     /translation="RDALRGAHRYPDPFARELTAAIAATHSVPEHDVVTGPGSAVILQH
-                     VIQWAAPRRGEVVYARPSFDAYPLAVAAAGATAVEIPLRDHRHDLPRMLAAVTPDTRAL
-                     VVCNPHNPTGTALGADALLAFLRAVPEHVVVVLDEAYREFAGDKDTLDGPDVYRGLPNV
-                     VVLRSFSKAYGLAGLRVGFALARREVADVLRTRLLPFAVGTVAEAAARTVLARRSEVYA
-                     RVDRVVAERDRLTAELRGQGWEVAPSAANFCWLPLGSRSAAFVAAAAREGILVRAVAGE
-                     GVRVTVGDPAANDAV"
      CDS             complement(1126..1956)
                      /codon_start=1
                      /db_xref="GI:224495625"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) PF12697 (E-value: 6.3e-15, bitscore:
-                     46.8, seeds: 465, tool: rule-based-clusters)"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) PF00561 (E-value: 8.4e-21, bitscore:
-                     65.1, seeds: 48, tool: rule-based-clusters)"
                      /locus_tag="ACN52310.1"
                      /note="putative lipase"
                      /product="TsrU"
                      /protein_id="ACN52310.1"
-                     /sec_met="Type: "
-                     /sec_met="PF12697 (E-value: 6.3e-15, bitscore: 46.8, seeds:
-                     465, tool: rule-based-clusters); PF00561 (E-value: 8.4e-21,
-                     bitscore: 65.1, seeds: 48, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MTEETTARRFAGVRHPIHLHVWPPETAPRYLAVFVHGYADHAGRY
                      GRLADALTRHGAAVYAPDHAGSGRSGGARALVTDHDEQVADLATVVERARADHPGLPVV
@@ -125,20 +46,10 @@ FEATURES             Location/Qualifiers
      CDS             complement(2015..3871)
                      /codon_start=1
                      /db_xref="GI:224495624"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: tsrC"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) PF00733 (E-value: 1.5e-67, bitscore:
-                     218.4, seeds: 104, tool: rule-based-clusters)"
                      /locus_tag="ACN52309.1"
                      /note="putative amidotransferase"
                      /product="TsrT"
                      /protein_id="ACN52309.1"
-                     /sec_met="Type: thiopeptide"
-                     /sec_met="tsrC (E-value: 1.4e-45, bitscore: 144.7, seeds:
-                     312, tool: rule-based-clusters); PF00733 (E-value: 1.5e-67,
-                     bitscore: 218.4, seeds: 104, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MCGIAGWVAFGRDLGAERSAVEAMTRTMACRGPDAGGTWYGGPVA
                      LGHRRLAVIDIAGGAQPMLAEENGQVTAALSYSGEIYGFDELRARLVSAGHTFRTRSDT
@@ -154,16 +65,10 @@ FEATURES             Location/Qualifiers
      CDS             complement(4011..4418)
                      /codon_start=1
                      /db_xref="GI:224495623"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: PF07366"
                      /locus_tag="ACN52308.1"
                      /note="putative NTF-2 family protein"
                      /product="TsrS"
                      /protein_id="ACN52308.1"
-                     /sec_met="Type: thiopeptide"
-                     /sec_met="PF07366 (E-value: 2.6e-33, bitscore: 105.0,
-                     seeds: 29, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MDRASVQQLMEHFLAAYNEGDPRHLDHCLHPEYRHPNPAVERGIE
                      GMRAAIRRWASTVEDLSLTLDDLVVEGDKAVARMTFSGRQVGPILGIPASGRRFSVGLI
@@ -213,33 +118,20 @@ FEATURES             Location/Qualifiers
      CDS             7900..8076
                      /codon_start=1
                      /db_xref="GI:224495606"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: thiostrepton"
                      /locus_tag="ACN52291.1"
                      /note="thiostrepton prepeptide"
                      /product="TsrA"
                      /protein_id="ACN52291.1"
-                     /sec_met="Type: thiopeptide"
-                     /sec_met="thiostrepton (E-value: 1.6e-37, bitscore: 118.0,
-                     seeds: 4, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MSNAALEIGVEGLTGLDVDTLEISDYMDETLLDGEDLTVTMIASA
                      SCTTCICTCSCSS"
      CDS             8593..9384
                      /codon_start=1
                      /db_xref="GI:224495607"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) PF12697 (E-value: 1.4e-15, bitscore:
-                     49.0, seeds: 465, tool: rule-based-clusters)"
                      /locus_tag="ACN52292.1"
                      /note="putative alpha-beta hydrolase fold protein"
                      /product="TsrB"
                      /protein_id="ACN52292.1"
-                     /sec_met="Type: "
-                     /sec_met="PF12697 (E-value: 1.4e-15, bitscore: 49.0, seeds:
-                     465, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MRPVILVHGLLGTEDAHYAGCRKWWTRPVTEIRLPGHGTGGEIPP
                      HPAAAAIDRVREAIREQPEPPVVVGLSYLGAAVAFRAAAGFPATVAGIVMSGYSFLVSP
@@ -249,16 +141,10 @@ FEATURES             Location/Qualifiers
      CDS             9377..12178
                      /codon_start=1
                      /db_xref="GI:224495608"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: Lant_dehyd_C"
                      /locus_tag="ACN52293.1"
                      /note="putative lantibiotic dehydratase"
                      /product="TsrC"
                      /protein_id="ACN52293.1"
-                     /sec_met="Type: thiopeptide"
-                     /sec_met="Lant_dehyd_C (E-value: 1.5e-22, bitscore: 70.0,
-                     seeds: 37, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MDSPEITYAGYGVVRVCSQPADIIAQLSSREAARVCDELRDVRRT
                      WQDLAPRVAEELTEVVPLLTDRDERRTVLALRRRLHRAADVPAADLDVLNLAYGTSADG
@@ -280,17 +166,10 @@ FEATURES             Location/Qualifiers
      CDS             12175..13215
                      /codon_start=1
                      /db_xref="GI:224495609"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) Lant_dehydr_C (E-value: 1.3e-64,
-                     bitscore: 209.1, seeds: 35, tool: rule-based-clusters)"
                      /locus_tag="ACN52294.1"
                      /note="similar to lantibiotic biosynthesis protein"
                      /product="TsrD"
                      /protein_id="ACN52294.1"
-                     /sec_met="Type: "
-                     /sec_met="Lant_dehydr_C (E-value: 1.3e-64, bitscore: 209.1,
-                     seeds: 35, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MSTAPAHPWLSCHVFHHGDTDPLIAECLLPLVDDLRRAGRVERHF
                      YLRHWERGPHVRLRMRVPAEHHDAVRAETERRVLDYLGRRPGPVDTDPARLRDALRRLS
@@ -302,17 +181,10 @@ FEATURES             Location/Qualifiers
      CDS             13202..14308
                      /codon_start=1
                      /db_xref="GI:224495610"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) Lant_dehydr_C (E-value: 1.3e-27,
-                     bitscore: 87.5, seeds: 35, tool: rule-based-clusters)"
                      /locus_tag="ACN52295.1"
                      /note="hypothetical protein"
                      /product="TsrE"
                      /protein_id="ACN52295.1"
-                     /sec_met="Type: "
-                     /sec_met="Lant_dehydr_C (E-value: 1.3e-27, bitscore: 87.5,
-                     seeds: 35, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MSTSEQKDLTVSVPWSVQEDLLLDVAAPLLDESVELGETDSWFYL
                      RENHGGRPFLRLRFASRSPSVERRLKSRILAHVGPTIDAGDVFTYQPYNHEHDWLGGTA
@@ -324,17 +196,10 @@ FEATURES             Location/Qualifiers
      CDS             14305..16074
                      /codon_start=1
                      /db_xref="GI:224495611"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) PF00881 (E-value: 1.1e-08, bitscore:
-                     25.7, seeds: 78, tool: rule-based-clusters)"
                      /locus_tag="ACN52296.1"
                      /note="McbC-like protein"
                      /product="TsrF"
                      /protein_id="ACN52296.1"
-                     /sec_met="Type: "
-                     /sec_met="PF00881 (E-value: 1.1e-08, bitscore: 25.7, seeds:
-                     78, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MTAPGTAEATAPVEAAAPAEAAGTGPFDAAGVDGFVRRLRGDFDE
                      VHPDQWQIDWRSIPSPFRWYVDLPRRDLPALSRAAAAGGPAAAAAFAAAGPLGRLGMLL
@@ -369,16 +234,10 @@ FEATURES             Location/Qualifiers
      CDS             17906..19951
                      /codon_start=1
                      /db_xref="GI:224495613"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: YcaO"
                      /locus_tag="ACN52298.1"
                      /note="putative cyclodehydratase"
                      /product="TsrH"
                      /protein_id="ACN52298.1"
-                     /sec_met="Type: thiopeptide"
-                     /sec_met="YcaO (E-value: 2.9e-63, bitscore: 204.9, seeds:
-                     127, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MSAPPTTAPHAPEGVDDTAAELRRLLDDVARVVDTPAAITAAAPL
                      HAGLPAEGDGRPVVLVNLGWDADLSGLPAAGTTVLPVYGLRGRVVVGPVTRPGLPGCPH
@@ -412,17 +271,10 @@ FEATURES             Location/Qualifiers
      CDS             21329..22642
                      /codon_start=1
                      /db_xref="GI:224495615"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) AMP-binding (E-value: 2.4e-27,
-                     bitscore: 85.9, seeds: 400, tool: rule-based-clusters)"
                      /locus_tag="ACN52300.1"
                      /note="acyl-CoA ligase family protein"
                      /product="TsrJ"
                      /protein_id="ACN52300.1"
-                     /sec_met="Type: "
-                     /sec_met="AMP-binding (E-value: 2.4e-27, bitscore: 85.9,
-                     seeds: 400, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MGGLGAWLKQAEPVLRRSRAGVVTERGRHPWPSLLARAERLAAGL
                      PDAPYGWVVPADGGERSIVGLLALGLLGPAPRWVLGDPAAWAADGHKPLGDGELTAAGP
@@ -432,50 +284,13 @@ FEATURES             Location/Qualifiers
                      PLPGKPVWLEDVGPDGVGTLWTRGPDTRFAVTGGRLTTGPDGAVTTGDLAHRADGGGGF
                      VLDGRADDLVKVDGVSVYPREITAAVRALPGVRDASVSVDRSRTGDRLTVIVMGTDAVT
                      EDRVRDACARLPVPVTPHRVLCRPADETAYDARGKVLR"
-     aSDomain        21632..22459
-                     /aSTool="nrps_pks_domains"
-                     /aSDomain="AMP-binding"
-                     /database="nrpspksdomains.hmm"
-                     /detection="hmmscan"
-                     /domain_id="nrpspksdomains_ACN52300.1_A1"
-                     /evalue="5.40E-27"
-                     /label="ACN52300.1_A1"
-                     /locus_tag="ACN52300.1"
-                     /score="85.9"
-                     /tool="antismash"
-                     /translation="AGPQAAPPPEVAGPTYATASSGTTGQPKLLFGRPHAIPSAVRLYA
-                     DGMPEYAAAEVFATCSAIDFAAAFYMVAAPAMTLGRDLVLFRPGSWATAVPELAGRPGV
-                     CLAPPALAALGARTAAGRHDFRGTSFVPAGGGLTPERAGRIRAGFPGCDFLTMLGSTET
-                     GLVTVGRTVRADGHVGAPLPGKPVWLEDVGPDGVGTLWTRGPDTRFAVTGGRLTTGPDG
-                     AVTTGDLAHRADGGGGFVLDGRADDLVKVDGVSVYPREITAAVRALPGVRDASV"
-     CDS_motif       22358..22414
-                     /aSTool="pksnrpsmotif"
-                     /database="abmotifs"
-                     /detection="hmmscan"
-                     /domain_id="nrpspksmotif_ACN52300.1_0001"
-                     /evalue="1.00E-04"
-                     /label="NRPS-A_a8"
-                     /locus_tag="ACN52300.1"
-                     /motif="NRPS-A_a8"
-                     /note="NRPS/PKS Motif: NRPS-A_a8 (e-value: 0.0001,
-                     bit-score: 15.0)"
-                     /score="15.0"
-                     /tool="antismash"
-                     /translation="GRADDLVKVDGVSVYPREI"
      CDS             22752..23942
                      /codon_start=1
                      /db_xref="GI:224495616"
-                     /gene_functions="biosynthetic-additional
-                     (rule-based-clusters) p450 (E-value: 2.5e-08, bitscore:
-                     23.5, seeds: 50, tool: rule-based-clusters)"
                      /locus_tag="ACN52301.1"
                      /note="cytochrome P450"
                      /product="TsrK"
                      /protein_id="ACN52301.1"
-                     /sec_met="Type: "
-                     /sec_met="p450 (E-value: 2.5e-08, bitscore: 23.5, seeds:
-                     50, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MTTTGPSRAAVTEALLKCPAPLYERMRRQGPLVWSRPDRTWVVTG
                      YELARLVLRDPRFSLPGPPPGSQWSADGSHAGFFQSMLLACEGERHARLRRFLGRLFTP
@@ -487,16 +302,10 @@ FEATURES             Location/Qualifiers
      CDS             24005..26743
                      /codon_start=1
                      /db_xref="GI:224495617"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: Lant_dehyd_C"
                      /locus_tag="ACN52302.1"
                      /note="putative lantibiotic dehydratase"
                      /product="TsrL"
                      /protein_id="ACN52302.1"
-                     /sec_met="Type: thiopeptide"
-                     /sec_met="Lant_dehyd_C (E-value: 3.2e-18, bitscore: 55.8,
-                     seeds: 37, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MVRRRCRVPGSVLADLGSDRVWGAAAAWAYAEDAVQRTGTRLADQ
                      VGESVPTVRQEERRDLLRVRRAAFNSRPLPADSGAVLGGPAAALAEEYTRALTARDTNR
@@ -517,16 +326,10 @@ FEATURES             Location/Qualifiers
      CDS             26760..28559
                      /codon_start=1
                      /db_xref="GI:224495618"
-                     /gene_functions="biosynthetic (rule-based-clusters)
-                     thiopeptide: PF04055"
                      /locus_tag="ACN52303.1"
                      /note="putative radical-SAM domain containing protein"
                      /product="TsrM"
                      /protein_id="ACN52303.1"
-                     /sec_met="Type: thiopeptide"
-                     /sec_met="PF04055 (E-value: 1.1e-15, bitscore: 48.9, seeds:
-                     518, tool: rule-based-clusters)"
-                     /sec_met="Kind: biosynthetic"
                      /transl_table=11
                      /translation="MLRKGTVALINPNQIHPPIAPYALDVLTTALEASGFEAHVLDLTF
                      HLDDWRQTLRDYFRAERPLLVGVTCRNTDTVYALEQRPFVDGYKAVIDEVRRLTAAPVV
@@ -552,35 +355,6 @@ FEATURES             Location/Qualifiers
                      VDLLVNNAGLVDQGELPFWEADPERWWEVFETNVRGTVNTCRAVLPEMTRRGSGRVVNV
                      NSRLAVQGDPRYSAYCGSKATLLALDAVAAEPLRDRGVHLFDISPGMVRTDMTLSMAVC
                      AGRDDWTDPALFLAAILRVAHGDLDPLAGRFLHVGADDFDALLSERRLAV"
-     aSDomain        28589..29119
-                     /aSTool="nrps_pks_domains"
-                     /aSDomain="PKS_KR"
-                     /database="nrpspksdomains.hmm"
-                     /detection="hmmscan"
-                     /domain_id="nrpspksdomains_ACN52304.1_KR1"
-                     /evalue="3.50E-11"
-                     /label="ACN52304.1_KR1"
-                     /locus_tag="ACN52304.1"
-                     /score="34.9"
-                     /tool="antismash"
-                     /translation="VALVTGAGRGIGRMVAVALAEAGMTVGLVGRNRRLLDVTARACAA
-                     AREAASGDGSGDGSGGGPEAGVAVAVADVRAPAEIREAAEAVRAALGPVDLLVNNAGLV
-                     DQGELPFWEADPERWWEVFETNVRGTVNTCRAVLPEMTRRGSGRVVNVNSRLAVQGDPR
-                     YSAYCGSKATLLAL"
-     CDS_motif       28595..28681
-                     /aSTool="pksnrpsmotif"
-                     /database="abmotifs"
-                     /detection="hmmscan"
-                     /domain_id="nrpspksmotif_ACN52304.1_0001"
-                     /evalue="8.40E-04"
-                     /label="PKSI-KR_m1"
-                     /locus_tag="ACN52304.1"
-                     /motif="PKSI-KR_m1"
-                     /note="NRPS/PKS Motif: PKSI-KR_m1 (e-value: 0.00084,
-                     bit-score: 12.0)"
-                     /score="12.0"
-                     /tool="antismash"
-                     /translation="LVTGAGRGIGRMVAVALAEAGMTVGLVGR"
 ORIGIN
         1 tctgcgtgtg cccgctcagt ctcccggcgc ctcccccggc tccgtcggcc cctccactga
        61 tgccgccggc cccaccggct cctcgcgctc cttggccaga cgggcggtca gccggaggac


### PR DESCRIPTION
This PR isn't fixing anything, but is necessary for simplifying planned changes to the `sec_met` annotations and any other future detection annotation changes.

Previously the RiPP integration tests used detection annotations in genbanks to avoid failing when detection modules had issues. This causes problems when detection gets out of sync, with the genbanks needing to be regenerated each time detection changes.

This PR removes this shortcut of detection and runs the detection on each cluster. This does make the integration tests take a little longer, but on my machine all RiPP module tests (unit and integration) take a total of 85 seconds, which I think is still reasonable.