### PR TITLE
 prepeptide: avoid motif name conflicts when multiple RIPP modules target the same precursor CDS

### DIFF
--- a/antismash/common/secmet/features/prepeptide.py
+++ b/antismash/common/secmet/features/prepeptide.py
@@ -101,12 +101,10 @@ class Prepeptide(CDSMotif):  # pylint: disable=too-many-instance-attributes
         self._tail = tail
 
     def get_name(self) -> str:
-        """ Returns the locus tag of the parent CDS.
-
-            Uses the same function name as the CDSFeature for consistency.
-        """
+        """ Returns the name of the motif. """
+        assert isinstance(self.tool, str) and self.tool
         assert isinstance(self.locus_tag, str) and self.locus_tag
-        return self.locus_tag
+        return "%s_%s" % (self.tool, self.locus_tag)
 
     def to_biopython(self, qualifiers: Dict[str, List] = None) -> List[SeqFeature]:
         """ Generates up to three SeqFeatures, depending if leader and tail exist.

--- a/antismash/modules/sactipeptides/test/integration_sactipeptides.py
+++ b/antismash/modules/sactipeptides/test/integration_sactipeptides.py
@@ -33,7 +33,7 @@ class IntegrationSactipeptides(unittest.TestCase):
         prepeptide = result.motifs_by_locus["BEST7613_6887"][0]
         assert prepeptide.location.start == 9735
         assert prepeptide.location.end == 9867
-        assert prepeptide.get_name() == "BEST7613_6887"
+        assert prepeptide.get_name() == "sactipeptides_BEST7613_6887"
         assert prepeptide.leader == "MKKAVIVENK"
         assert prepeptide.core == "GCATCSIGAACLVDGPIPDFEIAGATGLFGLWG"
         self.assertAlmostEqual(prepeptide.score, 31.)
@@ -46,7 +46,7 @@ class IntegrationSactipeptides(unittest.TestCase):
         prepeptide = result.motifs_by_locus["allorf041"][0]
         assert prepeptide.location.start == 9735
         assert prepeptide.location.end == 9867
-        assert prepeptide.get_name() == "allorf041"
+        assert prepeptide.get_name() == "sactipeptides_allorf041"
         assert prepeptide.leader == "MKKAVIVENK"
         assert prepeptide.core == "GCATCSIGAACLVDGPIPDFEIAGATGLFGLWG"
         self.assertAlmostEqual(prepeptide.score, 31.)


### PR DESCRIPTION
examples of records affected:
NZ_OBMJ01000001
NZ_LIPD01000006
NZ_QVIG01000001
NZ_LJJF01000001
NZ_JOHO01000002
NZ_RBXE01000001
