### PR TITLE
sec_met/gene_functions annotation cleanup

### DIFF
--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -51,7 +51,7 @@ class CDSResults:
 
         # and add all detected domains as ADDITIONAL if not CORE
         for secmet_domain in self.cds.sec_met.domains:
-            if secmet_domain.query_id in all_matching:
+            if secmet_domain.name in all_matching:
                 continue
             self.cds.gene_functions.add(GeneFunction.ADDITIONAL, secmet_domain.tool,
                                         str(secmet_domain))

--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -54,7 +54,7 @@ class CDSResults:
             if secmet_domain.name in all_matching:
                 continue
             self.cds.gene_functions.add(GeneFunction.ADDITIONAL, secmet_domain.tool,
-                                        str(secmet_domain))
+                                        secmet_domain.name)
 
     def to_json(self) -> Dict[str, Any]:
         """ Constructs a JSON representation of a CDSResults instance"""

--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -40,10 +40,9 @@ class CDSResults:
         """ Annotates a CDSFeature with the results gathered """
         all_matching = set()
         if not self.cds.sec_met:
-            self.cds.sec_met = SecMetQualifier(set(self.definition_domains), self.domains)
+            self.cds.sec_met = SecMetQualifier(self.domains)
         else:
             all_matching.update(set(self.cds.sec_met.domain_ids))
-            self.cds.sec_met.add_products({product})
             self.cds.sec_met.add_domains(self.domains)
         for cluster_type, matching_domains in self.definition_domains.items():
             all_matching.update(matching_domains)

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -17,6 +17,7 @@ from helperlibs.bio import seqio
 
 from antismash.common import gff_parser
 from antismash.common.secmet import Record
+from antismash.common.secmet.qualifiers import SecMetQualifier
 from antismash.config import get_config, update_config, ConfigType
 from antismash.custom_typing import AntismashModule
 
@@ -88,7 +89,7 @@ def strip_record(record: Record) -> None:
 
     # clean up antiSMASH annotations in CDS features
     for feature in record.get_cds_features():
-        feature.sec_met = None
+        feature.sec_met = SecMetQualifier()
         feature.gene_functions.clear()
 
 

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -197,9 +197,8 @@ class CDSFeature(Feature):
         if self._gene_functions:
             mine["gene_functions"] = list(map(str, self._gene_functions))
             mine["gene_kind"] = [str(self.gene_function)]
-        # since it's already a list
         if self.sec_met:
-            mine["sec_met"] = self.sec_met
+            mine["sec_met_domain"] = list(map(str, self.sec_met))
         # respect qualifiers given to us
         if qualifiers:
             mine.update(qualifiers)

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -172,7 +172,7 @@ class CDSFeature(Feature):
 
         # grab optional qualifiers
         feature.product = leftovers.pop("product", [""])[0]
-        sec_met = leftovers.pop("sec_met", None)
+        sec_met = leftovers.pop("sec_met_domain", None)
         if sec_met:
             feature.sec_met = SecMetQualifier.from_biopython(sec_met)
         gene_functions = leftovers.pop("gene_functions", [])

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -60,7 +60,7 @@ class CDSFeature(Feature):
             raise TypeError("product must be a string, not %s", type(product))
         self.product = product
         self.transl_table = int(translation_table)
-        self._sec_met = None  # type: Optional[SecMetQualifier]
+        self._sec_met = SecMetQualifier()
         self._nrps_pks = NRPSPKSQualifier(self.location.strand)
 
         self.motifs = []  # type: List[features.CDSMotif]

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -196,6 +196,7 @@ class CDSFeature(Feature):
                 mine[attr] = [str(val)]
         if self._gene_functions:
             mine["gene_functions"] = list(map(str, self._gene_functions))
+            mine["gene_kind"] = [str(self.gene_function)]
         # since it's already a list
         if self.sec_met:
             mine["sec_met"] = self.sec_met

--- a/antismash/common/secmet/features/test/test_cds_feature.py
+++ b/antismash/common/secmet/features/test/test_cds_feature.py
@@ -69,6 +69,7 @@ class TestCDSBiopythonConversion(unittest.TestCase):
     def test_without_genefunctions(self):
         bio = self.convert()
         assert "gene_functions" not in bio.qualifiers
+        assert "gene_kind" not in bio.qualifiers
 
         regen = CDSFeature.from_biopython(bio)
         assert not regen.gene_functions
@@ -77,6 +78,7 @@ class TestCDSBiopythonConversion(unittest.TestCase):
         self.cds.gene_functions.add(GeneFunction.ADDITIONAL, "testtool", "dummy")
         bio = self.convert()
         assert "gene_functions" in bio.qualifiers
+        assert bio.qualifiers["gene_kind"] == [str(self.cds.gene_function)] == ["biosynthetic-additional"]
 
         regen = CDSFeature.from_biopython(bio)
         assert regen.gene_function == self.cds.gene_function

--- a/antismash/common/secmet/features/test/test_supercluster.py
+++ b/antismash/common/secmet/features/test/test_supercluster.py
@@ -21,7 +21,7 @@ from antismash.common.secmet.test.helpers import DummyCDS
 
 def create_cds(start, end, products):
     cds = DummyCDS(start, end, locus_tag="%s-%s-%s" % (start, end, "-".join(products)))
-    cds.sec_met = SecMetQualifier(set(products), [])
+    cds.sec_met = SecMetQualifier([])
     for product in products:
         cds.gene_functions.add(GeneFunction.CORE, "test", "dummy", product)
     return cds

--- a/antismash/common/secmet/features/test/test_supercluster.py
+++ b/antismash/common/secmet/features/test/test_supercluster.py
@@ -15,13 +15,12 @@ from antismash.common.secmet.features.supercluster import (
     TemporarySuperCluster,
     create_superclusters_from_clusters as creator,
 )
-from antismash.common.secmet.qualifiers import SecMetQualifier, GeneFunction
+from antismash.common.secmet.qualifiers import GeneFunction
 from antismash.common.secmet.test.helpers import DummyCDS
 
 
 def create_cds(start, end, products):
     cds = DummyCDS(start, end, locus_tag="%s-%s-%s" % (start, end, "-".join(products)))
-    cds.sec_met = SecMetQualifier([])
     for product in products:
         cds.gene_functions.add(GeneFunction.CORE, "test", "dummy", product)
     return cds

--- a/antismash/common/secmet/qualifiers/secmet.py
+++ b/antismash/common/secmet/qualifiers/secmet.py
@@ -127,8 +127,6 @@ class SecMetQualifier:
         domains = []
         for value in qualifier:
             domains.append(SecMetQualifier.Domain.from_string(value))
-        if not domains:
-            raise ValueError("Cannot parse qualifier: %s" % qualifier)
         return SecMetQualifier(domains)
 
     def __len__(self) -> int:

--- a/antismash/common/secmet/qualifiers/secmet.py
+++ b/antismash/common/secmet/qualifiers/secmet.py
@@ -56,7 +56,7 @@ class SecMetQualifier:
 
         def __init__(self, name: str, evalue: float, bitscore: float, nseeds: int,
                      tool: str) -> None:
-            self.query_id = str(name)
+            self.name = str(name)
             self.evalue = float(evalue)
             self.bitscore = float(bitscore)
             self.nseeds = int(nseeds)
@@ -66,13 +66,13 @@ class SecMetQualifier:
             return str(self)
 
         def __str__(self) -> str:
-            return self.qualifier_label.format(self.query_id, self.evalue,
+            return self.qualifier_label.format(self.name, self.evalue,
                                                self.bitscore, self.nseeds, self.tool)
 
         def __eq__(self, other: Any) -> bool:
             if not isinstance(other, type(self)):
                 return False
-            return (self.query_id == other.query_id
+            return (self.name == other.name
                     and self.evalue == other.evalue
                     and self.bitscore == other.bitscore
                     and self.nseeds == other.nseeds
@@ -80,7 +80,7 @@ class SecMetQualifier:
 
         def to_json(self) -> List[Union[str, float, int]]:
             """ Constructs a JSON-friendly representation of a Domain """
-            return [self.query_id, self.evalue, self.bitscore, self.nseeds, self.tool]
+            return [self.name, self.evalue, self.bitscore, self.nseeds, self.tool]
 
         @classmethod
         def from_string(cls, line: str) -> "SecMetQualifier.Domain":
@@ -110,11 +110,11 @@ class SecMetQualifier:
         unique = []
         for domain in domains:
             assert isinstance(domain, SecMetQualifier.Domain)
-            if domain.query_id in self.unique_domain_ids:
+            if domain.name in self.unique_domain_ids:
                 continue  # no sense keeping duplicates
-            self.unique_domain_ids.add(domain.query_id)
+            self.unique_domain_ids.add(domain.name)
             unique.append(domain)
-            self.domain_ids.append(domain.query_id)
+            self.domain_ids.append(domain.name)
         self._domains.extend(unique)
 
     @property

--- a/antismash/common/secmet/qualifiers/secmet.py
+++ b/antismash/common/secmet/qualifiers/secmet.py
@@ -85,6 +85,7 @@ class SecMetQualifier:
         @classmethod
         def from_string(cls, line: str) -> "SecMetQualifier.Domain":
             """ Rebuilds a Domain from a string (e.g. from a genbank file) """
+            assert isinstance(line, str), type(line)
             return cls.from_json(_parse_format(cls.qualifier_label, line))
 
         @classmethod
@@ -100,8 +101,8 @@ class SecMetQualifier:
         self.add_domains(domains)
         super().__init__()
 
-    def __iter__(self) -> Iterator[str]:
-        yield "; ".join(map(str, self._domains))
+    def __iter__(self) -> Iterator["SecMetQualifier.Domain"]:
+        return iter(self._domains)
 
     def add_domains(self, domains: List["SecMetQualifier.Domain"]) -> None:
         """ Add a group of Domains to the the qualifier """
@@ -124,15 +125,11 @@ class SecMetQualifier:
     def from_biopython(qualifier: List[str]) -> "SecMetQualifier":
         """ Converts a BioPython style qualifier into a SecMetQualifier. """
         domains = []
-        if len(qualifier) != 1:
-            raise ValueError("Cannot parse qualifier: %s" % qualifier)
         for value in qualifier:
-            domain_strings = value.split("; ")
-            for domain_string in domain_strings:
-                domains.append(SecMetQualifier.Domain.from_string(domain_string))
+            domains.append(SecMetQualifier.Domain.from_string(value))
         if not domains:
             raise ValueError("Cannot parse qualifier: %s" % qualifier)
         return SecMetQualifier(domains)
 
     def __len__(self) -> int:
-        return 1
+        return len(self._domains)

--- a/antismash/common/secmet/qualifiers/secmet.py
+++ b/antismash/common/secmet/qualifiers/secmet.py
@@ -94,11 +94,12 @@ class SecMetQualifier:
             assert len(json) == 5, json
             return cls(str(json[0]), float(json[1]), float(json[2]), int(json[3]), str(json[4]))
 
-    def __init__(self, domains: List["SecMetQualifier.Domain"]) -> None:
+    def __init__(self, domains: List["SecMetQualifier.Domain"] = None) -> None:
         self._domains = []  # type: List["SecMetQualifier.Domain"]
         self.domain_ids = []  # type: List[str]
         self.unique_domain_ids = set()  # type: Set[str]
-        self.add_domains(domains)
+        if domains is not None:
+            self.add_domains(domains)
         super().__init__()
 
     def __iter__(self) -> Iterator["SecMetQualifier.Domain"]:

--- a/antismash/common/secmet/qualifiers/secmet.py
+++ b/antismash/common/secmet/qualifiers/secmet.py
@@ -46,11 +46,9 @@ def _parse_format(fmt: str, data: str) -> Sequence[str]:
     return res.groups()
 
 
-class SecMetQualifier(list):
+class SecMetQualifier:
     """ A qualifier for tracking various secondary metabolite information about
         a CDS.
-
-        Can be directly used as a qualifier for BioPython's SeqFeature.
     """
     class Domain:
         """ A simple container for the information needed to create a domain """
@@ -104,15 +102,6 @@ class SecMetQualifier(list):
 
     def __iter__(self) -> Iterator[str]:
         yield "; ".join(map(str, self._domains))
-
-    def __getitem__(self, selection: Union[slice, int]) -> str:  # type: ignore
-        return str(list(self)[selection])
-
-    def append(self, _item: Any) -> None:
-        raise NotImplementedError("Appending to this list won't work")
-
-    def extend(self, _items: Iterable[Any]) -> None:
-        raise NotImplementedError("Extending this list won't work")
 
     def add_domains(self, domains: List["SecMetQualifier.Domain"]) -> None:
         """ Add a group of Domains to the the qualifier """

--- a/antismash/common/secmet/qualifiers/secmet.py
+++ b/antismash/common/secmet/qualifiers/secmet.py
@@ -100,12 +100,10 @@ class SecMetQualifier(list):
         self.domain_ids = []  # type: List[str]
         self.unique_domain_ids = set()  # type: Set[str]
         self.add_domains(domains)
-        self.kind = "biosynthetic"
         super().__init__()
 
     def __iter__(self) -> Iterator[str]:
         yield "; ".join(map(str, self._domains))
-        yield "Kind: %s" % self.kind
 
     def __getitem__(self, selection: Union[slice, int]) -> str:  # type: ignore
         return str(list(self)[selection])
@@ -137,20 +135,15 @@ class SecMetQualifier(list):
     def from_biopython(qualifier: List[str]) -> "SecMetQualifier":
         """ Converts a BioPython style qualifier into a SecMetQualifier. """
         domains = []
-        kind = "biosynthetic"
-        if len(qualifier) != 2:
+        if len(qualifier) != 1:
             raise ValueError("Cannot parse qualifier: %s" % qualifier)
         for value in qualifier:
-            if value.startswith("Kind: "):
-                kind = value.split("Kind: ", 1)[1]
-                assert kind == "biosynthetic", kind  # since it's the only kind we have
-            else:
-                domain_strings = value.split("; ")
-                for domain_string in domain_strings:
-                    domains.append(SecMetQualifier.Domain.from_string(domain_string))
-        if not (domains and kind):
+            domain_strings = value.split("; ")
+            for domain_string in domain_strings:
+                domains.append(SecMetQualifier.Domain.from_string(domain_string))
+        if not domains:
             raise ValueError("Cannot parse qualifier: %s" % qualifier)
         return SecMetQualifier(domains)
 
     def __len__(self) -> int:
-        return 2
+        return 1

--- a/antismash/common/secmet/qualifiers/test/test_secmet.py
+++ b/antismash/common/secmet/qualifiers/test/test_secmet.py
@@ -128,23 +128,21 @@ class TestSecMetQualifier(unittest.TestCase):
         assert len(qual.domains) == 3
         assert qual.domain_ids == ["test name", "name test", "new name"]
 
-    def test_biopython_suitability(self):
-        # must behave as a list of strings or have conversion methods used
+    def test_iter(self):
         qual = SecMetQualifier(self.domains)
         for item in qual:
-            assert isinstance(item, str)
-        assert len(qual) == 1
-        assert list(qual)[0] == "; ".join(map(str, self.domains))
+            assert isinstance(item, SecMetQualifier.Domain)
+        for itered, direct in zip(qual, qual.domains):
+            assert itered is direct
 
     def test_regeneration(self):
         qual = SecMetQualifier(self.domains)
-        bio = list(qual)
+        bio = list(map(str, qual))
         new = SecMetQualifier.from_biopython(bio)
-        assert list(new) == bio
         for domain in new.domains:
             assert isinstance(domain, SecMetQualifier.Domain)
         assert new.domains == qual.domains
         assert new.domain_ids == qual.domain_ids
 
-        with self.assertRaisesRegex(ValueError, "Cannot parse qualifier"):
+        with self.assertRaisesRegex(ValueError, "could not match format"):
             SecMetQualifier.from_biopython(bio + ["something else"])

--- a/antismash/common/secmet/qualifiers/test/test_secmet.py
+++ b/antismash/common/secmet/qualifiers/test/test_secmet.py
@@ -118,7 +118,7 @@ class TestSecMetQualifier(unittest.TestCase):
         assert qual.domains is not self.domains
 
     def test_add_domains(self):
-        qual = SecMetQualifier([])
+        qual = SecMetQualifier()
         qual.add_domains(self.domains)
         assert qual.domains == self.domains
         qual.add_domains(self.domains)  # duplicates ignored

--- a/antismash/common/secmet/qualifiers/test/test_secmet.py
+++ b/antismash/common/secmet/qualifiers/test/test_secmet.py
@@ -113,14 +113,12 @@ class TestSecMetQualifier(unittest.TestCase):
         self.domains.append(SecMetQualifier.Domain("name test", 5e-235, 20.17, 30, "tool test"))
 
     def test_basics(self):
-        qual = SecMetQualifier({"prodB", "prodA"}, self.domains)
-        assert qual.products == ["prodA", "prodB"]
-        assert qual.clustertype == "prodA-prodB"
+        qual = SecMetQualifier(self.domains)
         assert qual.domains == self.domains
         assert qual.domains is not self.domains
 
     def test_add_domains(self):
-        qual = SecMetQualifier({"prodB", "prodA"}, [])
+        qual = SecMetQualifier([])
         qual.add_domains(self.domains)
         assert qual.domains == self.domains
         qual.add_domains(self.domains)  # duplicates ignored
@@ -132,26 +130,23 @@ class TestSecMetQualifier(unittest.TestCase):
 
     def test_biopython_suitability(self):
         # must behave as a list of strings or have conversion methods used
-        qual = SecMetQualifier({"prodA", "prodB"}, self.domains)
+        qual = SecMetQualifier(self.domains)
         assert isinstance(qual, list)
         for item in qual:
             assert isinstance(item, str)
-        assert len(qual) == 3
-        assert qual[0] == "Type: prodA-prodB"
-        assert qual[1] == "; ".join(map(str, self.domains))
-        assert qual[2] == "Kind: biosynthetic"
+        assert len(qual) == 2
+        assert qual[0] == "; ".join(map(str, self.domains))
+        assert qual[1] == "Kind: biosynthetic"
 
     def test_regeneration(self):
-        qual = SecMetQualifier({"prodB", "prodA"}, self.domains)
+        qual = SecMetQualifier(self.domains)
         bio = list(qual)
         new = SecMetQualifier.from_biopython(bio)
         assert list(new) == bio
-        assert new.products == ["prodA", "prodB"]
         for domain in new.domains:
             assert isinstance(domain, SecMetQualifier.Domain)
         assert new.domains == qual.domains
         assert new.domain_ids == qual.domain_ids
-        assert new.clustertype == qual.clustertype
 
         with self.assertRaisesRegex(ValueError, "Cannot parse qualifier"):
             SecMetQualifier.from_biopython(bio + ["something else"])

--- a/antismash/common/secmet/qualifiers/test/test_secmet.py
+++ b/antismash/common/secmet/qualifiers/test/test_secmet.py
@@ -53,7 +53,7 @@ class TestReverseParse(unittest.TestCase):
 class TestDomain(unittest.TestCase):
     def test_construction(self):
         dom = SecMetQualifier.Domain("test name", 1e-5, 120.7, 57, "test tool")
-        assert dom.query_id == "test name"
+        assert dom.name == "test name"
         assert dom.evalue == 1e-5
         assert dom.bitscore == 120.7
         assert dom.nseeds == 57
@@ -63,7 +63,7 @@ class TestDomain(unittest.TestCase):
         old = SecMetQualifier.Domain("test name", 1e-5, 120.7, 57, "test tool")
         dump = json.dumps(old.to_json())
         new = SecMetQualifier.Domain.from_json(json.loads(dump))
-        assert new.query_id == old.query_id == "test name"
+        assert new.name == old.name == "test name"
         assert new.evalue == old.evalue == 1e-5
         assert new.bitscore == old.bitscore == 120.7
         assert new.nseeds == old.nseeds == 57
@@ -74,7 +74,7 @@ class TestDomain(unittest.TestCase):
         assert repr(old) == str(old)
         dump = str(old)
         new = SecMetQualifier.Domain.from_string(dump)
-        assert new.query_id == old.query_id == "name test"
+        assert new.name == old.name == "name test"
         assert new.evalue == old.evalue == 5e-235
         assert new.bitscore == old.bitscore == 20.17
         assert new.nseeds == old.nseeds == 30
@@ -85,9 +85,9 @@ class TestDomain(unittest.TestCase):
         second = SecMetQualifier.Domain("name test", 5e-235, 20.17, 30, "tool test")
 
         assert first == second
-        second.query_id = "tmp"
+        second.name = "tmp"
         assert first != second
-        second.query_id = first.query_id
+        second.name = first.name
 
         assert first == second
         second.evalue = 1e-5
@@ -123,7 +123,7 @@ class TestSecMetQualifier(unittest.TestCase):
         assert qual.domains == self.domains
         qual.add_domains(self.domains)  # duplicates ignored
         assert qual.domains == self.domains
-        self.domains[0].query_id = "new name"
+        self.domains[0].name = "new name"
         qual.add_domains(self.domains)  # non-duplicate now
         assert len(qual.domains) == 3
         assert qual.domain_ids == ["test name", "name test", "new name"]

--- a/antismash/common/secmet/qualifiers/test/test_secmet.py
+++ b/antismash/common/secmet/qualifiers/test/test_secmet.py
@@ -131,11 +131,10 @@ class TestSecMetQualifier(unittest.TestCase):
     def test_biopython_suitability(self):
         # must behave as a list of strings or have conversion methods used
         qual = SecMetQualifier(self.domains)
-        assert isinstance(qual, list)
         for item in qual:
             assert isinstance(item, str)
         assert len(qual) == 1
-        assert qual[0] == "; ".join(map(str, self.domains))
+        assert list(qual)[0] == "; ".join(map(str, self.domains))
 
     def test_regeneration(self):
         qual = SecMetQualifier(self.domains)

--- a/antismash/common/secmet/qualifiers/test/test_secmet.py
+++ b/antismash/common/secmet/qualifiers/test/test_secmet.py
@@ -134,9 +134,8 @@ class TestSecMetQualifier(unittest.TestCase):
         assert isinstance(qual, list)
         for item in qual:
             assert isinstance(item, str)
-        assert len(qual) == 2
+        assert len(qual) == 1
         assert qual[0] == "; ".join(map(str, self.domains))
-        assert qual[1] == "Kind: biosynthetic"
 
     def test_regeneration(self):
         qual = SecMetQualifier(self.domains)

--- a/antismash/detection/cassis/test/test_cassis.py
+++ b/antismash/detection/cassis/test/test_cassis.py
@@ -45,7 +45,7 @@ def create_fake_record():
         seq_record.add_cds_feature(cds)
         seq_record.add_gene(secmet.Gene(locations[i], locus_tag="gene" + str(i+1)))
         if i == 3 or i == 5:
-            cds.sec_met = secmet.qualifiers.SecMetQualifier({"faked"}, [])
+            cds.sec_met = secmet.qualifiers.SecMetQualifier([])
             cds.gene_functions.add(secmet.qualifiers.GeneFunction.CORE, "testtool", "dummy", "product")
 
     return seq_record

--- a/antismash/detection/cassis/test/test_cassis.py
+++ b/antismash/detection/cassis/test/test_cassis.py
@@ -45,7 +45,6 @@ def create_fake_record():
         seq_record.add_cds_feature(cds)
         seq_record.add_gene(secmet.Gene(locations[i], locus_tag="gene" + str(i+1)))
         if i == 3 or i == 5:
-            cds.sec_met = secmet.qualifiers.SecMetQualifier([])
             cds.gene_functions.add(secmet.qualifiers.GeneFunction.CORE, "testtool", "dummy", "product")
 
     return seq_record

--- a/antismash/detection/genefunctions/test/integration_smcogs.py
+++ b/antismash/detection/genefunctions/test/integration_smcogs.py
@@ -87,6 +87,6 @@ class TestSMCOGs(unittest.TestCase):
         results.add_to_record(self.record)
 
         for cds in self.record.get_cds_features():
-            if cds.sec_met:
+            if cds.gene_functions.get_by_tool("rule-based-clusters"):
                 continue
             assert cds.gene_function == results.function_mapping.get(cds.get_name(), GeneFunction.OTHER)

--- a/antismash/modules/sactipeptides/specific_analysis.py
+++ b/antismash/modules/sactipeptides/specific_analysis.py
@@ -563,7 +563,7 @@ def annotate_orfs(cds_features: List[secmet.CDSFeature], hmm_results: Dict[str, 
     for cds in cds_features:
         domains = domains_by_feature[cds.get_name()]
         if domains:
-            cds.sec_met = SecMetQualifier(set(), domains)
+            cds.sec_met = SecMetQualifier(domains)
 
 
 def specific_analysis(record: secmet.Record) -> SactiResults:

--- a/antismash/modules/smcog_trees/test/integration_smcogs.py
+++ b/antismash/modules/smcog_trees/test/integration_smcogs.py
@@ -76,7 +76,7 @@ class TestTreeGeneration(Base):
 
         results.add_to_record(self.record)
         for cds in self.record.get_cds_features():
-            if cds.sec_met:
+            if cds.gene_functions.get_by_tool("rule-based-clusters"):
                 continue  # no sense checking, because we don't do anything with it
             if not cds.gene_functions.get_by_tool("smcogs"):
                 continue


### PR DESCRIPTION
Cleans up the last of the antiSMASH 4 style `sec_met` annotations.

`/sec_met="Kind: biosynthetic"` never changed, so it was removed and replaced with `/gene_kind="..."`, containing the `GeneFunction` type as provided by `CDSFeature.gene_function`. The name might be better as something else. The related attribute was also removed from `SecMetQualifier`.

`/sec_met="Type: ..."` was misleading, since a CDS doesn't have a type in the way that it was used. Since all information that was contained in this is contained in the `/gene_functions` annotation, this was  dropped and removed from `SecMetQualifier`.

`/sec_met="Domains detected: ..."` was very noisy, but since it's the only remaining annotation from `SecMetQualifier`, it has been changed have each domain in a list of `/sec_met_domain` annotations to reduce that noise.

Since the domain scoring info from rule based clusters was in both gene function and secmet annotations, the scores and other details have been removed from the gene function annotations (this only affected the `biosynthetic-additional` results, as the `biosynthetic` already did this).

There are also some quality of life changes for the `SecMetQualifier` in line with its new usage.