### PR TITLE
Handle bad reference protein lines in clusterblast

### DIFF
--- a/antismash/modules/clusterblast/core.py
+++ b/antismash/modules/clusterblast/core.py
@@ -174,14 +174,15 @@ def load_reference_proteins(accessions: Set[str], searchtype: str) -> Dict[str, 
             line = line.rstrip("\n")
             if not line or line[0] != ">":
                 continue
-            tabs = line.split("|")
+            # some lines are malformed, so always split the name off the annotation
+            # e.g. >x|y|1-2|-|z|Urea_carboxylase_{ECO:0000313|EMBL:CCF11062.1}|CRH36422
+            tabs = line.split("|", 5)
+            annotations, name = tabs[5].rsplit("|", 1)
             locustag = tabs[4]
             if locustag in accessions:
                 locustag = "h_" + locustag  # TODO: needs to be actually unique
             location = tabs[2]
             strand = tabs[3]
-            annotations = tabs[5]
-            name = tabs[6]
             proteins[name] = Protein(name, locustag, location, strand, annotations)
     return proteins
 


### PR DESCRIPTION
The clusterblast reference protein list is meant to be 6 fields separated by pipe characters. However, some of the annotation fields in the list contain pipe characters and caused part of the annotation field to be included in the name, which then broke after hits were detected using the real name.

This PR adds support for (and tests for) pipe characters within the annotation field.

When the clusterblast database is next regenerated, this might be made redundant.