### PR TITLE
Combine Stachelhaus predictions in NRPS consensus

### DIFF
--- a/antismash/modules/nrps_pks/html_output.py
+++ b/antismash/modules/nrps_pks/html_output.py
@@ -129,7 +129,7 @@ class SuperClusterLayer:
         i = 1
         nrpslist = []
         for monomers_per_protein in monomers_per_protein_list:
-            monomers = monomers_per_protein[1:-1].split("-")
+            monomers = monomers_per_protein[1:-1].split(" - ")
 
             if be_strict:
                 monomers = [map_as_name_to_norine(element.lower())

--- a/antismash/modules/nrps_pks/orderfinder.py
+++ b/antismash/modules/nrps_pks/orderfinder.py
@@ -109,7 +109,7 @@ def generate_substrates_order(geneorder: List[CDSFeature], consensus_predictions
             if consensus:
                 consensuses.append(consensus)
         if consensuses:
-            predictions.append("(%s)" % ("-".join(consensuses)))
+            predictions.append("(%s)" % (" - ".join(consensuses)))
 
     if not predictions:
         return ""

--- a/antismash/modules/nrps_pks/parsers.py
+++ b/antismash/modules/nrps_pks/parsers.py
@@ -22,7 +22,7 @@ LONG_TO_SHORT = {'Malonyl-CoA': 'mal', 'Methylmalonyl-CoA': 'mmal', 'Methoxymalo
                  'inactive': 'inactive'}
 SHORT_TO_LONG = {val: key for key, val in LONG_TO_SHORT.items()}
 
-ALLOWABLE_PREDICTION_CHARACTERS = set(string.ascii_letters).union({'-'})
+ALLOWABLE_PREDICTION_CHARACTERS = set(string.ascii_letters + string.digits).union(set('-,()'))
 
 AVAILABLE_SMILES_PARTS = {'GLY', 'ALA', 'VAL', 'LEU', 'ILE', 'MET', 'PRO', 'PHE', 'TRP', 'SER', 'THR', 'ASN', 'GLN',
                           'TYR', 'CYS', 'LYS', 'ARG',

--- a/antismash/modules/nrps_pks/smiles_generator.py
+++ b/antismash/modules/nrps_pks/smiles_generator.py
@@ -14,7 +14,7 @@ import antismash.common.path as path
 def gen_smiles_from_pksnrps(compound_pred: str) -> str:
     """ Generates the SMILES string for a specific compound prediction """
     smiles = ""
-    residues = compound_pred.replace("(", "").replace(")", "").replace(" + ", " ").replace("-", " ").split(" ")
+    residues = compound_pred.replace("(", "").replace(")", "").replace(" + ", " ").replace(" - ", " ").split()
     # Counts the number of malonate and its derivatives in polyketides
     mal_count = 0
     for i in residues:

--- a/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
+++ b/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
@@ -75,7 +75,7 @@ class IntegrationNRPSPKS(unittest.TestCase):
         assert len(results.region_predictions[1]) == 2
         # as does this, though it still won't use domain docking
         pred = results.region_predictions[1][0]
-        monomers = '(leu-bht-asn) + (hpg-hpg-bht) + (dhpg) + (tyr) + (pk)'
+        monomers = '(leu - bht - asn) + (hpg - hpg - bht) + (dhpg) + (tyr) + (pk)'
         assert pred.polymer == monomers
         assert not pred.domain_docking_used
 
@@ -100,7 +100,7 @@ class IntegrationNRPSPKS(unittest.TestCase):
         assert len(results.region_predictions[1]) == 1
         # check the gene ordering and, in this case, that it used domain docking
         sc_pred = results.region_predictions[1][0]
-        assert sc_pred.polymer == '(ccmmal) + (ccmmal) + (mmal-pk) + (ohmmal)'
+        assert sc_pred.polymer == '(ccmmal) + (ccmmal) + (mmal - pk) + (ohmmal)'
         assert sc_pred.domain_docking_used
         assert len(results.domain_predictions) == 10
         expected_domains = {'nrpspksdomains_STAUR_3982_PKS_AT.1',


### PR DESCRIPTION
Calculates how good a match the stach prediction is and combines it with the SVM prediction when at least 80% of a match to the predicted monomer.

Also allows for multiple predictions from the stach section instead of treating pipe-joined combinations as a single prediction and stops `-` always being treated as a joining character between monomers.