### PR TITLE
Secmet fixes

### DIFF
--- a/antismash/common/secmet/errors.py
+++ b/antismash/common/secmet/errors.py
@@ -1,0 +1,13 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+""" Contains Exception subclasses for more specific communication of issues """
+
+
+class SecmetInvalidInputError(ValueError):
+    """ An error for when input is invalid or contains unsupported content.
+
+        Not intended to replace TypeError/ValueError in functions not directly
+        parsing or converting input files.
+    """
+    pass

--- a/antismash/common/secmet/features/antismash_feature.py
+++ b/antismash/common/secmet/features/antismash_feature.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional
 
 from Bio.SeqFeature import SeqFeature
 
+from ..errors import SecmetInvalidInputError
 from .feature import Feature, FeatureLocation
 
 
@@ -101,13 +102,13 @@ class AntismashFeature(Feature):
         if leftovers is None:
             leftovers = Feature.make_qualifiers_copy(bio_feature)
         if not feature:
-            raise ValueError("AntismashFeature shouldn't be instantiated directly")
+            raise SecmetInvalidInputError("AntismashFeature shouldn't be instantiated directly")
         else:
             assert isinstance(feature, AntismashFeature)
 
         # semi-optional qualifiers
         if leftovers.get("tool") == ["antismash"] and not feature.tool:
-            raise ValueError("an AntismashFeature created by antiSMASH must have a tool supplied")
+            raise SecmetInvalidInputError("an AntismashFeature created by antiSMASH must have a tool supplied")
 
         # grab optional qualifiers
         feature.domain_id = leftovers.pop("domain_id", [""])[0] or None

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -58,7 +58,7 @@ class CDSFeature(Feature):
 
         # optional
         if not isinstance(product, str):
-            raise TypeError("product must be a string, not %s", type(product))
+            raise TypeError("product must be a string, not %s" % type(product))
         self.product = product
         self.transl_table = int(translation_table)
         self._sec_met = SecMetQualifier()

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -18,6 +18,7 @@ from antismash.common.secmet.qualifiers import (
     SecMetQualifier,
 )
 
+from ..errors import SecmetInvalidInputError
 from .feature import Feature, FeatureLocation
 
 
@@ -163,7 +164,7 @@ class CDSFeature(Feature):
             translation = ""
         if not translation:
             if not record:
-                raise ValueError("no translation in CDS and no record to generate it with")
+                raise SecmetInvalidInputError("no translation in CDS and no record to generate it with")
             translation = record.get_aa_translation_from_location(bio_feature.location, transl_table)
 
         feature = CDSFeature(bio_feature.location, translation, gene=gene,

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -52,9 +52,9 @@ class CDSFeature(Feature):
         self.protein_id = _sanitise_id_value(protein_id)
         self.locus_tag = _sanitise_id_value(locus_tag)
         self.gene = _sanitise_id_value(gene)
-        if not translation:
+        if not translation or "-" in translation:
             raise ValueError("CDSFeature requires a valid translation, not '%s'" % translation)
-        self.translation = translation
+        self._translation = translation
 
         # optional
         if not isinstance(product, str):

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -15,6 +15,8 @@ from antismash.common.secmet.locations import (
     locations_overlap,
 )
 
+from ..errors import SecmetInvalidInputError
+
 
 def _adjust_location_by_offset(location: FeatureLocation, offset: int) -> FeatureLocation:
     """ Adjusts the given location to account for an offset (e.g. start_codon)
@@ -252,7 +254,7 @@ class Feature:
             if "codon_start" in leftovers:
                 codon_start = int(leftovers.pop("codon_start")[0]) - 1
                 if not 0 <= codon_start <= 2:
-                    raise ValueError("invalid codon_start qualifier: %d" % (codon_start + 1))
+                    raise SecmetInvalidInputError("invalid codon_start qualifier: %d" % (codon_start + 1))
                 if feature.location.strand == -1:
                     codon_start *= -1
                 feature._original_codon_start = codon_start  # very much private, so pylint: disable=protected-access

--- a/antismash/common/secmet/features/pfam_domain.py
+++ b/antismash/common/secmet/features/pfam_domain.py
@@ -10,6 +10,7 @@ from Bio.SeqFeature import SeqFeature
 
 from antismash.common.secmet.qualifiers import GOQualifier
 
+from ..errors import SecmetInvalidInputError
 from .feature import Feature, FeatureLocation
 from .domain import Domain
 
@@ -96,7 +97,7 @@ class PFAMDomain(Domain):
             xref.pop(i)
             break
         if name is None:
-            raise ValueError("PFAMDomain missing identifier")
+            raise SecmetInvalidInputError("PFAMDomain missing identifier")
         tool = leftovers.pop("aSTool")[0]
 
         feature = PFAMDomain(bio_feature.location, description, p_start, p_end,

--- a/antismash/common/secmet/features/prepeptide.py
+++ b/antismash/common/secmet/features/prepeptide.py
@@ -8,6 +8,7 @@ from typing import Optional  # comment hints, pylint: disable=unused-import
 
 from Bio.SeqFeature import SeqFeature
 
+from ..errors import SecmetInvalidInputError
 from .cds_motif import CDSMotif
 from .feature import Feature
 from ..locations import FeatureLocation, build_location_from_others, location_from_string
@@ -190,9 +191,9 @@ class Prepeptide(CDSMotif):  # pylint: disable=too-many-instance-attributes
 
         section = leftovers.pop("prepeptide", [""])[0]
         if not section:
-            raise ValueError("cannot reconstruct Prepeptide from biopython feature %s" % bio_feature)
+            raise SecmetInvalidInputError("cannot reconstruct Prepeptide from biopython feature %s" % bio_feature)
         elif section != "core":
-            raise ValueError("Prepeptide can only be reconstructed from core feature")
+            raise SecmetInvalidInputError("Prepeptide can only be reconstructed from core feature")
         peptide_class = leftovers.pop("peptide")[0]
         core = leftovers.pop("core_sequence")[0]
         alt_weights = [float(weight) for weight in leftovers.pop("alternative_weights", [])]

--- a/antismash/common/secmet/features/prepeptide.py
+++ b/antismash/common/secmet/features/prepeptide.py
@@ -129,7 +129,7 @@ class Prepeptide(CDSMotif):  # pylint: disable=too-many-instance-attributes
                 "prepeptide": ["leader"],
                 "note": [
                     "peptide class: %s" % self.peptide_class,
-                    "predicted sequence: %s", self.leader,
+                    "predicted sequence: %s" % self.leader,
                 ],
                 "locus_tag": [self.locus_tag],
                 "aSTool": [self.tool],

--- a/antismash/common/secmet/features/test/test_feature.py
+++ b/antismash/common/secmet/features/test/test_feature.py
@@ -72,6 +72,7 @@ class TestFeature(unittest.TestCase):
     def test_biopython_conversion(self):
         bio = SeqFeature(FeatureLocation(1, 5))
         bio.qualifiers["foo"] = ["bar"]
+        bio.qualifiers["key_only"] = None
         # check that features without types are caught
         with self.assertRaises(AssertionError):
             sec = Feature.from_biopython(bio)
@@ -79,6 +80,7 @@ class TestFeature(unittest.TestCase):
         sec = Feature.from_biopython(bio)
         assert sec.get_qualifier("foo") == tuple(["bar"])
         assert sec.get_qualifier("bar") is None
+        assert sec.get_qualifier("key_only") is True
 
     def test_created_by_antismash_conversion(self):
         for created in [True, False]:

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -23,6 +23,7 @@ from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, FeatureLocation, CompoundLocation
 from Bio.SeqRecord import SeqRecord
 
+from .errors import SecmetInvalidInputError
 from .features import (
     AntismashDomain,
     CDSFeature,
@@ -488,7 +489,7 @@ class Record:
         self._cds_features.insert(index, cds_feature)
         self._link_cds_to_parent(cds_feature)
         if cds_feature.get_name() in self._cds_by_name:
-            raise ValueError("Multiple CDS features have the same name for mapping: %s" %
+            raise SecmetInvalidInputError("multiple CDS features have the same name for mapping: %s" %
                              cds_feature.get_name())
         self._cds_by_name[cds_feature.get_name()] = cds_feature
 
@@ -498,7 +499,7 @@ class Record:
         self._cds_motifs.append(motif)
         assert motif.get_name(), "motif %s has no identifiers" % motif
         if motif.get_name() in self._domains_by_name:
-            raise ValueError("Multiple Domain features have the same name for mapping: %s" %
+            raise SecmetInvalidInputError("multiple Domain features have the same name for mapping: %s" %
                              motif.get_name())
         self._domains_by_name[motif.get_name()] = motif
         if isinstance(motif, Prepeptide):
@@ -510,7 +511,7 @@ class Record:
         assert pfam_domain.get_name()
         self._pfam_domains.append(pfam_domain)
         if pfam_domain.get_name() in self._domains_by_name:
-            raise ValueError("Multiple Domain features have the same name for mapping: %s" %
+            raise SecmetInvalidInputError("multiple Domain features have the same name for mapping: %s" %
                              pfam_domain.get_name())
         self._domains_by_name[pfam_domain.get_name()] = pfam_domain
         if pfam_domain.locus_tag:
@@ -522,7 +523,7 @@ class Record:
         assert antismash_domain.get_name()
         self._antismash_domains.append(antismash_domain)
         if antismash_domain.get_name() in self._domains_by_name:
-            raise ValueError("Multiple Domain features have the same name for mapping: %s" %
+            raise SecmetInvalidInputError("multiple Domain features have the same name for mapping: %s" %
                              antismash_domain.get_name())
         self._domains_by_name[antismash_domain.get_name()] = antismash_domain
 
@@ -599,7 +600,7 @@ class Record:
         assert isinstance(seq_record, SeqRecord)
         if seq_record.seq and isinstance(seq_record.seq, Seq):
             if isinstance(seq_record.seq.alphabet, Alphabet.ProteinAlphabet):
-                raise ValueError("protein records are not supported")
+                raise SecmetInvalidInputError("protein records are not supported")
         transl_table = 1  # standard
         if str(taxon) == "bacteria":
             transl_table = 11  # bacterial, archea, plant plastid code
@@ -609,7 +610,7 @@ class Record:
             if feature.ref or feature.ref_db:
                 for ref in [feature.ref, feature.ref_db]:
                     if ref and ref != seq_record.id:
-                        raise ValueError("Feature references another sequence: (%s)" % feature.ref)
+                        raise SecmetInvalidInputError("feature references another sequence: (%s)" % feature.ref)
                 # to handle a biopython issue, set the references to None
                 feature.ref = None
                 feature.ref_db = None

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -17,7 +17,7 @@ import logging
 from typing import Any, Dict, List, Tuple, Union, cast
 from typing import Optional, Sequence, Set  # comment hints # pylint: disable=unused-import
 
-from Bio import SeqIO
+from Bio import Alphabet, SeqIO
 import Bio.Alphabet
 from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, FeatureLocation, CompoundLocation
@@ -597,6 +597,9 @@ class Record:
         }  # type: Dict[str, SeqFeature]
 
         assert isinstance(seq_record, SeqRecord)
+        if seq_record.seq and isinstance(seq_record.seq, Seq):
+            if isinstance(seq_record.seq.alphabet, Alphabet.ProteinAlphabet):
+                raise ValueError("protein records are not supported")
         transl_table = 1  # standard
         if str(taxon) == "bacteria":
             transl_table = 11  # bacterial, archea, plant plastid code

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 import unittest
 
 import Bio.SeqIO
+from Bio.Alphabet.IUPAC import IUPACProtein
 from Bio.Seq import Seq
 from Bio.SeqFeature import FeatureLocation
 
@@ -56,6 +57,17 @@ class TestConversion(unittest.TestCase):
         assert type_counts["PFAM_domain"] == len(record.get_pfam_domains())
         assert type_counts["cluster"] == len(record.get_clusters())
         assert type_counts["aSDomain"] == len(record.get_antismash_domains())
+
+    def test_protein_sequences_caught(self):
+        before = list(Bio.SeqIO.parse(helpers.get_path_to_nisin_genbank(), "genbank"))[0]
+
+        # as a sanity check, make sure it's a seq and it functions as expected
+        assert isinstance(before.seq, Seq)
+        after = Record.from_biopython(before, taxon="bacteria")
+
+        before.seq = Seq("AAAA", IUPACProtein())
+        with self.assertRaisesRegex(ValueError, "protein records are not supported"):
+            Record.from_biopython(before, taxon="bacteria")
 
 
 class TestRecordFeatureNumbering(unittest.TestCase):

--- a/antismash/outputs/html/js.py
+++ b/antismash/outputs/html/js.py
@@ -204,7 +204,7 @@ def get_description(record: Record, feature: CDSFeature, type_: str,
     template += 'Locus-tag: %s; Protein-ID: %s<br>\n' % (feature.locus_tag, feature.protein_id)
 
     ec_number = feature.get_qualifier('EC_number')
-    if ec_number is not None:
+    if isinstance(ec_number, tuple):
         template += "EC-number(s): %s<br>\n" % ",".join(ec_number)
 
     for gene_function in feature.gene_functions:


### PR DESCRIPTION
Fixes some minor issues in secmet:
- protein inputs caused failures when processing CDS features, now caught at the beginning of record conversion
- qualifier dictionaries from BioPython could contain None as a valid value, so handling of that was corrected
- `Gene` and specifically `Gene.is_pseudo()` could be simplified since the qualifier was more easily detectable
- two format strings were incorrectly tuples
- made pylint a little happier with the `CDSFeature` init

This PR also changes some errors raised by secmet to more accurately indicate that the problem is with the input records, such as the protein input case mentioned earlier.