### PR TITLE
chore: Remove unused install dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,17 +15,12 @@ def read(fname):
 long_description = read('README.md')
 
 install_requires = [
-    'argparse',
-    'cssselect',
     'numpy',
     'biopython >= 1.71',
     'helperlibs',
     'jinja2',
     'pysvg-py3',
-    'pyExcelerator',
     'bcbio-gff',
-    'networkx',
-    'pandas',
     'matplotlib',
     'scipy',
     'scikit-learn == 0.19.0', # until pickles are rebuilt automatically


### PR DESCRIPTION
As far as I can tell, no piece of code imports these libraries.
None of our code imports 'scipy' either, but installing 'scikit-learn' fails if 'scipy' isn't there.

Signed-off-by: Kai Blin <kblin@biosustain.dtu.dk>