### PR TITLE
Style and cleanup pass

### DIFF
--- a/antismash/__main__.py
+++ b/antismash/__main__.py
@@ -27,8 +27,7 @@ def get_git_version(fallback_filename: Optional[str] = GIT_VERSION_FALLBACK_FILE
         if version_cmd.successful() and status_cmd.successful():
             git_version = version_cmd.stdout.strip()
             changes = status_cmd.stdout.splitlines()
-            if len(changes) > 0:
-                print(changes)
+            if changes:
                 git_version += "(changed)"
     except OSError:
         pass

--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -36,7 +36,7 @@ class CDSResults:
         # empty definition domains is ok
         self.definition_domains = definition_domains
 
-    def annotate(self, product: str, tool: str) -> None:
+    def annotate(self, tool: str) -> None:
         """ Annotates a CDSFeature with the results gathered """
         all_matching = set()
         if not self.cds.sec_met:
@@ -91,9 +91,9 @@ class RuleDetectionResults:
 
     def annotate_cds_features(self) -> None:
         """ Annotate relevant CDS features with the HMM information detected """
-        for cluster, cds_results in self.cds_by_cluster.items():
+        for cds_results in self.cds_by_cluster.values():
             for cds_result in cds_results:
-                cds_result.annotate(cluster.product, self.tool)
+                cds_result.annotate(self.tool)
 
     def to_json(self) -> Dict[str, Any]:
         """ Constructs a JSON representation from the RuleDetectionResults instance """
@@ -339,7 +339,6 @@ def apply_cluster_rules(record: Record, results_by_id: Dict[str, List[HSP]],
         domains_by_cluster = {}  # type: Dict[str, Set[str]]
         for rule in rules:
             if rule.cutoff not in info_by_range:
-                # TODO: improve performance
                 location = FeatureLocation(feature_start - rule.cutoff, feature_end + rule.cutoff)
                 nearby = record.get_cds_features_within_location(location, with_overlapping=True)
                 nearby_features = {neighbour.get_name(): neighbour for neighbour in nearby}

--- a/antismash/common/hmm_rule_parser/test/test_rule_parser.py
+++ b/antismash/common/hmm_rule_parser/test/test_rule_parser.py
@@ -321,6 +321,17 @@ class RuleParserTest(unittest.TestCase):
                        "RULE second SUPERIORS first CUTOFF 20 EXTENT 20 CONDITIONS b "
                        "RULE sub SUPERIORS second CUTOFF 20 EXTENT 20 CONDITIONS c")
 
+    def test_related(self):
+        rules = self.parse("RULE name RELATED b, c CUTOFF 20 EXTENT 20 CONDITIONS a").rules
+        assert rules[0].related == ["b", "c"]
+
+    def test_empty_related(self):
+        with self.assertRaises(rule_parser.RuleSyntaxError):
+            self.parse("RULE name RELATED CUTOFF 20 EXTENT 20 CONDITIONS a")
+
+        with self.assertRaises(rule_parser.RuleSyntaxError):
+            self.parse("RULE name RELATED")
+
     def test_missing_group_close(self):
         with self.assertRaises(rule_parser.RuleSyntaxError):
             self.parse(format_as_rule("A", 10, 10, "(a or b"))

--- a/antismash/common/path.py
+++ b/antismash/common/path.py
@@ -5,9 +5,10 @@
     Common functions for path manipulation and use
 """
 
+import contextlib
 import logging
 import os
-from typing import List, Optional, Union
+from typing import Generator, List, Optional, Union
 
 
 def get_full_path(current_file: str, *args: Union[str, List[str]]) -> str:
@@ -76,3 +77,27 @@ def locate_file(path: str, silent: bool = False) -> Optional[str]:
                 logging.debug("Found file %r", path)
             return path
     return None
+
+
+@contextlib.contextmanager
+def changed_directory(path: str) -> Generator:
+    """ Changes working directory for the duration of the context
+        e.g.:
+
+        # in /foo/bar
+        with changed_directory("/foo/baz"):
+            # do some work in /foo/baz
+        # automatically back to /foo/bar
+
+        Arguments:
+            path: the path of the directory to change into
+
+        Returns:
+            None
+    """
+    current_path = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(current_path)

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -54,7 +54,7 @@ class CDSFeature(Feature):
         self.gene = _sanitise_id_value(gene)
         if not translation or "-" in translation:
             raise ValueError("CDSFeature requires a valid translation, not '%s'" % translation)
-        self._translation = translation
+        self._translation = str(translation)
 
         # optional
         if not isinstance(product, str):

--- a/antismash/common/secmet/features/test/test_domain.py
+++ b/antismash/common/secmet/features/test/test_domain.py
@@ -16,7 +16,7 @@ class TestDomain(unittest.TestCase):
         assert domain.type == "test_type"
         assert domain.location == loc
         assert domain.created_by_antismash
-        assert domain.tool is "test"
+        assert domain.tool == "test"
         assert domain.domain is None
 
     def test_translation(self):

--- a/antismash/common/secmet/features/test/test_feature.py
+++ b/antismash/common/secmet/features/test/test_feature.py
@@ -4,8 +4,9 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=no-self-use,protected-access,missing-docstring
 
-from minimock import mock, restore
 import unittest
+
+from minimock import mock, restore
 
 from antismash.common.test import helpers
 
@@ -16,7 +17,7 @@ from antismash.common.secmet.features.feature import (
     SeqFeature,
     _adjust_location_by_offset as adjust,
 )
-from antismash.common.secmet.features import feature  # mocked, pylint: disable=unused-import
+from antismash.common.secmet import features  # mocked, pylint: disable=unused-import
 from antismash.common.secmet.locations import (
     ExactPosition,
     BeforePosition,
@@ -186,6 +187,7 @@ class TestLocationAdjustment(unittest.TestCase):
                 for old_part, new_part in zip(old.parts[1:], new.parts[1:]):
                     assert old_part is new_part
 
+
 class TestSubLocation(unittest.TestCase):
     def setUp(self):
         self.feature = Feature(FeatureLocation(10, 40, 1), feature_type="test")
@@ -203,13 +205,13 @@ class TestSubLocation(unittest.TestCase):
                 self.get_sub(bad_start, bad_end)
         with self.assertRaisesRegex(ValueError, "must be less than the end"):
             self.get_sub(5, 1)
-        mock("feature.convert_protein_position_to_dna", returns=(9, 15))
+        mock("features.feature.convert_protein_position_to_dna", returns=(9, 15))
         with self.assertRaisesRegex(ValueError, "Protein coordinate start .* is outside feature"):
             self.get_sub(1, 5)
-        mock("feature.convert_protein_position_to_dna", returns=(15, 41))
+        mock("features.feature.convert_protein_position_to_dna", returns=(15, 41))
         with self.assertRaisesRegex(ValueError, "Protein coordinate end .* is outside feature"):
             self.get_sub(1, 5)
-        mock("feature.convert_protein_position_to_dna", returns=(10, 3))
+        mock("features.feature.convert_protein_position_to_dna", returns=(10, 3))
         with self.assertRaisesRegex(ValueError, "Invalid protein coordinate conversion"):
             self.get_sub(1, 5)
 

--- a/antismash/common/secmet/qualifiers/secmet.py
+++ b/antismash/common/secmet/qualifiers/secmet.py
@@ -4,7 +4,8 @@
 """ Annotations for secondary metabolites """
 
 import re
-from typing import Any, Iterable, Iterator, List, Sequence, Set, Union
+from typing import Any, Iterator, List, Sequence, Union
+from typing import Set  # comment hints  # pylint: disable=unused-import
 
 
 def _parse_format(fmt: str, data: str) -> Sequence[str]:

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -18,7 +18,6 @@ from typing import Any, Dict, List, Tuple, Union, cast
 from typing import Optional, Sequence, Set  # comment hints # pylint: disable=unused-import
 
 from Bio import Alphabet, SeqIO
-import Bio.Alphabet
 from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, FeatureLocation, CompoundLocation
 from Bio.SeqRecord import SeqRecord
@@ -753,10 +752,10 @@ class Record:
         string_version = str(seq)
         for invalid in "*BJOUZ":
             string_version = string_version.replace(invalid, "X")
-        seq = Seq(string_version, Bio.Alphabet.generic_protein)
+        seq = Seq(string_version, Alphabet.generic_protein)
 
         if "-" in str(seq):
-            seq = Seq(str(seq).replace("-", ""), Bio.Alphabet.generic_protein)
+            seq = Seq(str(seq).replace("-", ""), Alphabet.generic_protein)
         return seq
 
     def get_cds_features_within_regions(self) -> List[CDSFeature]:  # pylint: disable=invalid-name

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -63,7 +63,7 @@ class TestConversion(unittest.TestCase):
 
         # as a sanity check, make sure it's a seq and it functions as expected
         assert isinstance(before.seq, Seq)
-        after = Record.from_biopython(before, taxon="bacteria")
+        Record.from_biopython(before, taxon="bacteria")
 
         before.seq = Seq("AAAA", IUPACProtein())
         with self.assertRaisesRegex(ValueError, "protein records are not supported"):

--- a/antismash/common/test/test_path.py
+++ b/antismash/common/test/test_path.py
@@ -1,0 +1,36 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+# for test files, silence irrelevant and noisy pylint warnings
+# pylint: disable=no-self-use,protected-access,missing-docstring,too-many-public-methods
+
+import os
+from tempfile import TemporaryDirectory
+import unittest
+
+from antismash.common import path
+
+
+class TestChangedDir(unittest.TestCase):
+    def setUp(self):
+        self.original_dir = os.getcwd()
+
+    def tearDown(self):
+        os.chdir(self.original_dir)
+
+    def test_functions(self):
+        with TemporaryDirectory() as tmpdir:
+            assert os.getcwd() != tmpdir
+            with path.changed_directory(tmpdir):
+                assert os.getcwd() == tmpdir
+            assert os.getcwd() == self.original_dir
+
+    def test_with_errors(self):
+        try:
+            with TemporaryDirectory() as tmpdir:
+                with path.changed_directory(tmpdir):
+                    raise ValueError("die mid-context")
+        except ValueError as err:
+            assert "die mid-context" in str(err)
+        finally:
+            assert os.getcwd() == self.original_dir

--- a/antismash/detection/cassis/promoters.py
+++ b/antismash/detection/cassis/promoters.py
@@ -8,7 +8,6 @@ import os
 from typing import Any, Dict, List, Union, Set, Tuple  # pylint: disable=unused-import
 
 from Bio import SeqIO
-from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
 from antismash.common.secmet import Record, Gene

--- a/antismash/detection/genefunctions/test/integration_smcogs.py
+++ b/antismash/detection/genefunctions/test/integration_smcogs.py
@@ -13,7 +13,7 @@ from antismash.common import secmet
 from antismash.common.secmet.qualifiers import GeneFunction
 from antismash.common.test import helpers
 from antismash.config import build_config, destroy_config, get_config, update_config
-from antismash.detection.genefunctions import core, smcogs
+from antismash.detection.genefunctions import core, smcogs, prepare_data
 
 
 class TestSMCOGs(unittest.TestCase):
@@ -24,6 +24,8 @@ class TestSMCOGs(unittest.TestCase):
         self.options = update_config(options)
 
         self.record = self.build_record(helpers.get_path_to_nisin_with_detection())
+
+        prepare_data()
 
     def tearDown(self):
         destroy_config()

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -578,6 +578,8 @@ def run_antismash(sequence_file: Optional[str], options: ConfigType) -> int:
 
 def _run_antismash(sequence_file: Optional[str], options: ConfigType) -> int:
     """ The real run_antismash, assumes logging is set up around it """
+    logging.debug("antiSMASH version: %s", options.version)
+
     detection_modules = get_detection_modules()
     analysis_modules = get_analysis_modules()
     modules = detection_modules + analysis_modules

--- a/antismash/modules/nrps_pks/smiles_generator.py
+++ b/antismash/modules/nrps_pks/smiles_generator.py
@@ -14,6 +14,10 @@ import antismash.common.path as path
 def gen_smiles_from_pksnrps(compound_pred: str) -> str:
     """ Generates the SMILES string for a specific compound prediction """
     smiles = ""
+
+    if not compound_pred:
+        return smiles
+
     residues = compound_pred.replace("(", "").replace(")", "").replace(" + ", " ").replace(" - ", " ").split()
     # Counts the number of malonate and its derivatives in polyketides
     mal_count = 0

--- a/antismash/modules/nrps_pks/test/test_smiles_generator.py
+++ b/antismash/modules/nrps_pks/test/test_smiles_generator.py
@@ -1,0 +1,39 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+# for test files, silence irrelevant and noisy pylint warnings
+# pylint: disable=no-self-use,protected-access,missing-docstring
+
+import unittest
+from antismash.modules.nrps_pks.smiles_generator import gen_smiles_from_pksnrps as gen_smiles
+
+
+class TestGenerator(unittest.TestCase):
+    def test_empty(self):
+        assert gen_smiles("") == ""
+
+    def test_single_nrp(self):
+        assert gen_smiles("(nrp)") == ""
+
+    def test_single_ala(self):
+        assert gen_smiles("(ala)") == ""
+
+    def test_special_cases(self):
+        # all mal variants and and end is ccmal appends a pks-end2
+        polymer = "(ohmal - mal - ccmal)"
+        assert gen_smiles(polymer) == "CC(O)CC(=O)C=CC(=O)(O)"
+        assert gen_smiles("(ohmal - mal - ccmal - pks-end2)") == gen_smiles(polymer)
+
+        # all mal variants and start is mal converts the first to pks-start1
+        polymer = "(mal - ohmal - mal)"
+        assert gen_smiles(polymer) == "CCC(O)CC(=O)"
+        assert gen_smiles("(pks-start1 - ohmal - mal)") == gen_smiles(polymer)
+
+        # pk in polymer and last is a mal variant removes the monomer after
+        # the first pk and adds a pks-end1 at the end
+        polymer = "(pk - nrp - pk - nrp - mal)"
+        assert gen_smiles(polymer) == "C([*])C(-O)C([*])C(-O)NC([*])C(=O)CC(=O)C(C)C(=O)(O)"
+        assert gen_smiles("(pk - pk - nrp - mal - pks-end1)") == gen_smiles(polymer)
+
+    def test_mixed_mal(self):
+        assert gen_smiles("(mal - nrp - mal)") == "CC(=O)NC([*])C(=O)CC(=O)"

--- a/antismash/modules/smcog_trees/__init__.py
+++ b/antismash/modules/smcog_trees/__init__.py
@@ -124,9 +124,7 @@ def run_on_record(record: Record, results: Optional[SMCOGTreeResults],
         os.mkdir(smcogs_dir)
 
     nrpspks_genes = record.get_nrps_pks_cds_features()
-    original_dir = os.getcwd()
-    os.chdir(smcogs_dir)  # TODO make a context manager
-    trees = generate_trees(smcogs_dir, record.get_cds_features_within_regions(), nrpspks_genes)
-    os.chdir(original_dir)
+    with path.changed_directory(smcogs_dir):
+        trees = generate_trees(smcogs_dir, record.get_cds_features_within_regions(), nrpspks_genes)
 
     return SMCOGTreeResults(record.id, relative_output_dir, trees)

--- a/antismash/modules/smcog_trees/trees.py
+++ b/antismash/modules/smcog_trees/trees.py
@@ -21,6 +21,9 @@ import matplotlib
 from antismash.common import path, fasta, subprocessing
 from antismash.common.secmet import CDSFeature
 
+# silence the matplotlib noisy logging (relevant when options.debug is set)
+logging.getLogger('matplotlib').setLevel(logging.WARNING)
+
 
 def generate_trees(smcogs_dir: str, genes_within_clusters: List[CDSFeature],
                    nrpspks_genes: List[CDSFeature]) -> Dict[str, str]:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
 ]
 
 tests_require = [
-    'pytest',
+    'pytest >= 3.3.0',
     'minimock',
     'coverage',
     'pylint == 1.8.4', # until pylint handles ignore lines the same way


### PR DESCRIPTION
- fixes a number of small style and safety issues
- adds a context manager for changing directories `common.path.changed_dir()`
- adds a `RELATED` field to detection rules as a first step to indicating which profiles are of interest to a rule even when not required for cluster detection
- silences the matplotlib debug logging in `modules.smcog_trees` if running with debug on
- logs the current antiSMASH version to make logfiles a little more useful in finding which version they were created with when full output fails