### PR TITLE
Compound inheritance correction

### DIFF
--- a/antismash/common/secmet/features/__init__.py
+++ b/antismash/common/secmet/features/__init__.py
@@ -10,7 +10,7 @@ from .cds_feature import CDSFeature
 from .cds_motif import CDSMotif
 from .cluster import Cluster
 from .domain import Domain
-from .feature import Feature, FeatureLocation, SeqFeature
+from .feature import Feature, FeatureLocation, Location, SeqFeature
 from .gene import Gene
 from .pfam_domain import PFAMDomain
 from .prepeptide import Prepeptide

--- a/antismash/common/secmet/features/antismash_domain.py
+++ b/antismash/common/secmet/features/antismash_domain.py
@@ -10,14 +10,14 @@ from typing import Optional  # comment hints, pylint: disable=unused-import
 from Bio.SeqFeature import SeqFeature
 
 from .domain import Domain
-from .feature import Feature, FeatureLocation
+from .feature import Feature, Location
 
 
 class AntismashDomain(Domain):
     """ A class to represent a Domain with extra specificities and type information """
     __slots__ = ["domain_subtype", "specificity"]
 
-    def __init__(self, location: FeatureLocation, tool: str) -> None:
+    def __init__(self, location: Location, tool: str) -> None:
         super().__init__(location, feature_type="aSDomain", tool=tool, created_by_antismash=True)
         self.domain_subtype = None  # type: Optional[str]
         self.specificity = []  # type: List[str]

--- a/antismash/common/secmet/features/antismash_feature.py
+++ b/antismash/common/secmet/features/antismash_feature.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional
 from Bio.SeqFeature import SeqFeature
 
 from ..errors import SecmetInvalidInputError
-from .feature import Feature, FeatureLocation
+from .feature import Feature, Location
 
 
 class AntismashFeature(Feature):
@@ -17,7 +17,7 @@ class AntismashFeature(Feature):
     __slots__ = ["domain_id", "database", "detection", "_evalue", "label",
                  "locus_tag", "_score", "_translation", "tool"]
 
-    def __init__(self, location: FeatureLocation, feature_type: str, tool: Optional[str] = None,
+    def __init__(self, location: Location, feature_type: str, tool: Optional[str] = None,
                  created_by_antismash: bool = True) -> None:
         if created_by_antismash and not tool:
             raise ValueError("an AntismashFeature created by antiSMASH must have a tool supplied")

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -19,7 +19,8 @@ from antismash.common.secmet.qualifiers import (
 )
 
 from ..errors import SecmetInvalidInputError
-from .feature import Feature, FeatureLocation
+from ..locations import Location
+from .feature import Feature
 
 
 def _sanitise_id_value(name: Optional[str]) -> Optional[str]:
@@ -39,7 +40,7 @@ class CDSFeature(Feature):
                  "transl_table", "_sec_met", "_gene_functions",
                  "unique_id", "_nrps_pks", "motifs", "region"]
 
-    def __init__(self, location: FeatureLocation, translation: str, locus_tag: str = None,
+    def __init__(self, location: Location, translation: str, locus_tag: str = None,
                  protein_id: str = None, product: str = "", gene: str = None,
                  translation_table: int = 1) -> None:
         super().__init__(location, feature_type="CDS")

--- a/antismash/common/secmet/features/cds_motif.py
+++ b/antismash/common/secmet/features/cds_motif.py
@@ -9,14 +9,14 @@ from typing import Dict, List, Optional
 from Bio.SeqFeature import SeqFeature
 
 from .domain import Domain
-from .feature import Feature, FeatureLocation
+from .feature import Feature, Location
 
 
 class CDSMotif(Domain):
     """ A base class for features that represent a motif within a CDSFeature """
     __slots__ = ["motif"]
 
-    def __init__(self, location: FeatureLocation, tool: Optional[str] = None) -> None:
+    def __init__(self, location: Location, tool: Optional[str] = None) -> None:
         # if there's a tool, it was created by antismash
         created = tool is not None
         super().__init__(location, feature_type="CDS_motif", tool=tool, created_by_antismash=created)

--- a/antismash/common/secmet/features/domain.py
+++ b/antismash/common/secmet/features/domain.py
@@ -10,7 +10,7 @@ from Bio.SeqFeature import SeqFeature
 
 from antismash.common.secmet.qualifiers import ActiveSiteFinderQualifier
 
-from .feature import Feature, FeatureLocation
+from .feature import Feature, Location
 from .antismash_feature import AntismashFeature
 
 
@@ -18,7 +18,7 @@ class Domain(AntismashFeature):
     """ A base class for features which represent a domain type """
     __slots__ = ["domain", "_asf"]
 
-    def __init__(self, location: FeatureLocation, feature_type: str,
+    def __init__(self, location: Location, feature_type: str,
                  domain: Optional[str] = None, tool: str = None,
                  created_by_antismash: bool = True) -> None:
         super().__init__(location, feature_type, tool=tool, created_by_antismash=created_by_antismash)

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -180,16 +180,15 @@ class Feature:
             raise TypeError("Container must be a Feature, CompoundLocation, or FeatureLocation, not %s" % type(other))
         return locations_overlap(self.location, location)
 
-    def is_contained_by(self, other: Union["Feature", FeatureLocation]) -> bool:
+    def is_contained_by(self, other: Union["Feature", Location]) -> bool:
         """ Returns True if the given feature is wholly contained by this
             feature.
         """
-        end = self.location.end - 1  # to account for the non-inclusive end
         if isinstance(other, Feature):
-            return self.location.start in other.location and end in other.location
-        if isinstance(other, FeatureLocation):
-            return self.location.start in other and end in other
-        raise TypeError("Container must be a Feature or a FeatureLocation, not %s" % type(other))
+            return location_contains_other(other.location, self.location)
+        if isinstance(other, (CompoundLocation, FeatureLocation)):
+            return location_contains_other(other, self.location)
+        raise TypeError("Container must be a Feature, CompoundLocation or FeatureLocation, not %s" % type(other))
 
     def to_biopython(self, qualifiers: Dict[str, Any] = None) -> List[SeqFeature]:
         """ Converts this feature into one or more SeqFeature instances.

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -13,10 +13,12 @@ from Bio.Seq import Seq
 from antismash.common.secmet.locations import (
     convert_protein_position_to_dna,
     location_bridges_origin,
+    location_contains_other,
     locations_overlap,
 )
 
 from ..errors import SecmetInvalidInputError
+from ..locations import Location
 
 
 def _adjust_location_by_offset(location: FeatureLocation, offset: int) -> FeatureLocation:
@@ -165,17 +167,17 @@ class Feature:
         assert qualifier is None
         return True
 
-    def overlaps_with(self, other: Union["Feature", FeatureLocation]) -> bool:
+    def overlaps_with(self, other: Union["Feature", Location]) -> bool:
         """ Returns True if the given feature overlaps with this feature.
             This operation is commutative, a.overlaps_with(b) is equivalent to
             b.overlaps_with(a).
         """
         if isinstance(other, Feature):
             location = other.location
-        elif isinstance(other, FeatureLocation):
+        elif isinstance(other, (CompoundLocation, FeatureLocation)):
             location = other
         else:
-            raise TypeError("Container must be a Feature or a FeatureLocation, not %s" % type(other))
+            raise TypeError("Container must be a Feature, CompoundLocation, or FeatureLocation, not %s" % type(other))
         return locations_overlap(self.location, location)
 
     def is_contained_by(self, other: Union["Feature", FeatureLocation]) -> bool:

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -21,7 +21,7 @@ from ..errors import SecmetInvalidInputError
 from ..locations import Location
 
 
-def _adjust_location_by_offset(location: FeatureLocation, offset: int) -> FeatureLocation:
+def _adjust_location_by_offset(location: Location, offset: int) -> Location:
     """ Adjusts the given location to account for an offset (e.g. start_codon)
     """
     assert -2 <= offset <= 2, "invalid offset %d" % offset
@@ -58,7 +58,7 @@ class Feature:
     __slots__ = ["location", "notes", "type", "_qualifiers", "created_by_antismash",
                  "_original_codon_start"]
 
-    def __init__(self, location: FeatureLocation, feature_type: str,
+    def __init__(self, location: Location, feature_type: str,
                  created_by_antismash: bool = False) -> None:
         assert isinstance(location, (FeatureLocation, CompoundLocation)), type(location)
         if location_bridges_origin(location):
@@ -86,7 +86,7 @@ class Feature:
         assert isinstance(sequence, Seq)
         return self.location.extract(sequence)
 
-    def get_sub_location_from_protein_coordinates(self, start: int, end: int) -> FeatureLocation:
+    def get_sub_location_from_protein_coordinates(self, start: int, end: int) -> Location:
         """ Generates a FeatureLocation for a protein sequence based on the start
             and end positions within the features protein sequence.
 

--- a/antismash/common/secmet/features/gene.py
+++ b/antismash/common/secmet/features/gene.py
@@ -7,14 +7,14 @@ from typing import Any, Dict, List, Optional
 
 from Bio.SeqFeature import SeqFeature
 
-from .feature import Feature, FeatureLocation
+from .feature import Feature, Location
 
 
 class Gene(Feature):
     """ A feature representing a Gene (more general than a CDS) """
     __slots__ = ["locus_tag", "gene_name"]
 
-    def __init__(self, location: FeatureLocation, locus_tag: Optional[str] = None,
+    def __init__(self, location: Location, locus_tag: Optional[str] = None,
                  gene_name: Optional[str] = None, created_by_antismash: bool = False,
                  qualifiers: Optional[Dict[str, List[str]]] = None) -> None:
         super().__init__(location, feature_type="gene",

--- a/antismash/common/secmet/features/pfam_domain.py
+++ b/antismash/common/secmet/features/pfam_domain.py
@@ -11,7 +11,7 @@ from Bio.SeqFeature import SeqFeature
 from antismash.common.secmet.qualifiers import GOQualifier
 
 from ..errors import SecmetInvalidInputError
-from .feature import Feature, FeatureLocation
+from .feature import Feature, Location
 from .domain import Domain
 
 
@@ -21,7 +21,7 @@ class PFAMDomain(Domain):
     __slots__ = ["description", "probability", "protein_start", "protein_end",
                  "gene_ontologies", "identifier", "version"]
 
-    def __init__(self, location: FeatureLocation, description: str, protein_start: int,
+    def __init__(self, location: Location, description: str, protein_start: int,
                  protein_end: int, identifier: str, tool: str, domain: Optional[str] = None,
                  ) -> None:
         """ Arguments:

--- a/antismash/common/secmet/features/prepeptide.py
+++ b/antismash/common/secmet/features/prepeptide.py
@@ -10,8 +10,8 @@ from Bio.SeqFeature import SeqFeature
 
 from ..errors import SecmetInvalidInputError
 from .cds_motif import CDSMotif
-from .feature import Feature
-from ..locations import FeatureLocation, build_location_from_others, location_from_string
+from .feature import Feature, Location
+from ..locations import build_location_from_others, location_from_string
 from ..qualifiers.prepeptide_qualifiers import RiPPQualifier  # comment hints, pylint: disable=unused-import
 from ..qualifiers.prepeptide_qualifiers import rebuild_qualifier
 
@@ -21,7 +21,7 @@ class Prepeptide(CDSMotif):  # pylint: disable=too-many-instance-attributes
         construction with a leader, core and tail. To allow for multiple types
         of prepeptide (e.g. lanthi- or sacti-peptides), only the core must exist.
     """
-    def __init__(self, location: FeatureLocation, peptide_class: str, core: str, locus_tag: str,
+    def __init__(self, location: Location, peptide_class: str, core: str, locus_tag: str,
                  tool: str, peptide_subclass: str = None, score: float = 0., monoisotopic_mass: float = 0.,
                  molecular_weight: float = 0., alternative_weights: List[float] = None,
                  leader: str = "", tail: str = "") -> None:

--- a/antismash/common/secmet/features/test/test_domain.py
+++ b/antismash/common/secmet/features/test/test_domain.py
@@ -6,7 +6,8 @@
 
 import unittest
 
-from antismash.common.secmet.features.domain import Domain, FeatureLocation
+from antismash.common.secmet import FeatureLocation
+from antismash.common.secmet.features.domain import Domain
 
 
 class TestDomain(unittest.TestCase):

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -19,7 +19,7 @@ from Bio.SeqFeature import (
 Location = Union[CompoundLocation, FeatureLocation]  # pylint: disable=invalid-name
 
 
-def convert_protein_position_to_dna(start: int, end: int, location: FeatureLocation) -> Tuple[int, int]:
+def convert_protein_position_to_dna(start: int, end: int, location: Location) -> Tuple[int, int]:
     """ Convert a protein position to a nucleotide sequence position for use in generating
         new FeatureLocations from existing FeatureLocations and/or CompoundLocations.
 
@@ -73,7 +73,7 @@ def convert_protein_position_to_dna(start: int, end: int, location: FeatureLocat
     return dna_start, dna_end
 
 
-def build_location_from_others(locations: Sequence[FeatureLocation]) -> FeatureLocation:
+def build_location_from_others(locations: Sequence[Location]) -> FeatureLocation:
     """ Builds a new location from non-overlapping others.
         If location boundaries are equal, they will be merged.
         If at least one provided location is a CompoundLocation or the locations
@@ -100,7 +100,7 @@ def build_location_from_others(locations: Sequence[FeatureLocation]) -> FeatureL
     return location
 
 
-def location_bridges_origin(location: CompoundLocation) -> bool:
+def location_bridges_origin(location: Location) -> bool:
     """ Determines if a CompoundLocation would cross the origin of a record.
 
         Arguments:
@@ -203,7 +203,7 @@ def location_contains_other(outer: Location, inner: Location) -> bool:
     return inner.start in outer and inner.end - 1 in outer
 
 
-def location_from_string(data: str) -> FeatureLocation:
+def location_from_string(data: str) -> Location:
     """ Converts a string, e.g. [<1:6](-), to a FeatureLocation or CompoundLocation
     """
     def parse_position(string: str) -> AbstractPosition:
@@ -248,7 +248,7 @@ def location_from_string(data: str) -> FeatureLocation:
     return CompoundLocation(locations, operator=operator)
 
 
-def combine_locations(*locations: Iterable[FeatureLocation]) -> FeatureLocation:
+def combine_locations(*locations: Iterable[Location]) -> Location:
     """ Combines multiple FeatureLocations into a single location using the
         minimum start and maximum end. Will not create a CompoundLocation if any
         of the inputs are CompoundLocations.

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -185,17 +185,21 @@ def locations_overlap(first: Location, second: Location) -> bool:
             or second.start in first or second.end - 1 in first)
 
 
-def location_contains_other(outer: FeatureLocation, inner: FeatureLocation) -> bool:
+def location_contains_other(outer: Location, inner: Location) -> bool:
     """ Returns True if the first of two provided FeatureLocations contains the
         second
 
         Arguments:
-            outer: a FeatureLocation that should contain the other
-            inner: a FeatureLocation to test
+            outer: a FeatureLocation or CompoundLocation that should contain the other
+            inner: a FeatureLocation or CompoundLocation to test
 
         Returns:
             True if outer contains inner, otherwise False
     """
+    if isinstance(inner, CompoundLocation):
+        return all(location_contains_other(outer, part) for part in inner.parts)
+    if isinstance(outer, CompoundLocation):
+        return any(location_contains_other(part, inner) for part in outer.parts)
     return inner.start in outer and inner.end - 1 in outer
 
 


### PR DESCRIPTION
There was an assumption throughout the code that `CompoundLocation` was a subclass of `FeatureLocation`. This was a faulty assumption.

The main issue was some type checking inside `common.secmet`, but those remaining location functions that didn't explicitly handle `CompoundLocation` have also been altered.