### PR TITLE
Fix missing RiPP precursors

### DIFF
--- a/antismash/common/test/test_utils.py
+++ b/antismash/common/test/test_utils.py
@@ -7,6 +7,8 @@
 import unittest
 
 from antismash.common import utils
+from antismash.common.secmet import FeatureLocation
+from antismash.common.test.helpers import DummyCDS, DummyRecord
 
 
 class TestRobustProteinAnalysis(unittest.TestCase):
@@ -51,3 +53,73 @@ class TestSignatureBuilding(unittest.TestCase):
         assert sig == "ACE-"
         sig = utils.extract_by_reference_positions("ABCDF", "ABCDE", [0, 1, 3, 4])
         assert sig == "ABDF"
+
+
+class TestDistanceCalculations(unittest.TestCase):
+    def setUp(self):
+        self.record = DummyRecord(seq="A" * 100000)
+        self.query = self.create_cds(50000, 50000, ["query_gene_prof"])
+        self.record.add_cds_feature(self.query)
+
+    def create_cds(self, start, end, profiles, strand=1):
+        cds = DummyCDS(start, end, strand=strand, translation="A")
+        for profile in profiles:
+            cds.sec_met.add_domains([cds.sec_met.Domain(profile, 1e-5, 20.5, 2, "test")])
+        return cds
+
+    def test_empty_record(self):
+        self.record._cds_features.clear()
+        assert utils.distance_to_pfam(self.record, self.query, []) == -1
+
+    def test_self_hit(self):
+        assert utils.distance_to_pfam(self.record, self.query, ["query_gene_prof"]) == 0
+
+    def test_simple_before(self):
+        cds = self.create_cds(29000, 30000, profiles=["left20k"])
+        self.record.add_cds_feature(cds)
+        assert utils.distance_to_pfam(self.record, self.query, ["notleft20k"]) == -1
+        assert utils.distance_to_pfam(self.record, self.query, ["left20k"]) == 20000
+
+    def test_simple_after(self):
+        cds = self.create_cds(60000, 63000, profiles=["right10k"])
+        self.record.add_cds_feature(cds)
+        assert utils.distance_to_pfam(self.record, self.query, ["notright10k"]) == -1
+        assert utils.distance_to_pfam(self.record, self.query, ["right10k"]) == 10000
+
+    def test_outside_before(self):
+        cds = self.create_cds(5000, 9999, profiles=["outside"])
+        self.record.add_cds_feature(cds)
+        assert utils.distance_to_pfam(self.record, self.query, ["outside"]) == -1
+
+    def test_outside_after(self):
+        cds = self.create_cds(90001, 95000, profiles=["outside"])
+        self.record.add_cds_feature(cds)
+        assert utils.distance_to_pfam(self.record, self.query, ["outside"]) == -1
+
+    def test_edge_overlap_after(self):
+        cds = self.create_cds(90000, 91000, profiles=["r.edge"])
+        self.record.add_cds_feature(cds)
+        assert utils.distance_to_pfam(self.record, self.query, ["r.edge"]) == -1
+
+        cds.location = FeatureLocation(89999, 91000, strand=1)
+        assert utils.distance_to_pfam(self.record, self.query, ["r.edge"]) == 39999
+
+        cds.location = FeatureLocation(89999, 91000, strand=-1)
+        assert utils.distance_to_pfam(self.record, self.query, ["r.edge"]) == 39999
+
+    def test_edge_overlap_before(self):
+        cds = self.create_cds(9000, 10000, profiles=["l.edge"])
+        self.record.add_cds_feature(cds)
+        assert utils.distance_to_pfam(self.record, self.query, ["l.edge"]) == -1
+
+        cds.location = FeatureLocation(9000, 10001, strand=1)
+        assert utils.distance_to_pfam(self.record, self.query, ["l.edge"]) == 39999
+
+        cds.location = FeatureLocation(9000, 10001, strand=-1)
+        assert utils.distance_to_pfam(self.record, self.query, ["l.edge"]) == 39999
+
+    def test_with_no_secmet(self):
+        cds = self.create_cds(55000, 60000, profiles=[])
+        cds.sec_met = None
+        self.record.add_cds_feature(cds)
+        assert utils.distance_to_pfam(self.record, self.query, ["test"]) == -1

--- a/antismash/modules/lanthipeptides/specific_analysis.py
+++ b/antismash/modules/lanthipeptides/specific_analysis.py
@@ -481,7 +481,7 @@ def run_cleavage_site_regex(fasta: str) -> Optional[CleavageSiteHit]:
         end += 15
     else:
         return None
-    return CleavageSiteHit(end, 0, "lanthipeptide")
+    return CleavageSiteHit(end, -100., "lanthipeptide")
 
 
 def determine_precursor_peptide_candidate(record: Record, query: CDSFeature, domains: List[str],

--- a/antismash/modules/lanthipeptides/specific_analysis.py
+++ b/antismash/modules/lanthipeptides/specific_analysis.py
@@ -117,9 +117,9 @@ class LanthiResults(module_results.ModuleResults):
 
 class PrepeptideBase:
     """ A generic prepeptide class for tracking various typical components """
-    def __init__(self, end: int, score: int, rodeo_score: int = 0) -> None:
+    def __init__(self, end: int, score: float, rodeo_score: int = 0) -> None:
         self.end = int(end)  # cleavage site position
-        self.score = int(score)  # of cleavage site
+        self.score = float(score)  # of cleavage site
         self.rodeo_score = int(rodeo_score)
         self._leader = None  # type: Optional[str]
         self._core = ''
@@ -202,9 +202,9 @@ class PrepeptideBase:
 
 class CleavageSiteHit:  # pylint: disable=too-few-public-methods
     """ A simple container for storing cleavage site information """
-    def __init__(self, end: int, score: int, lantype: str) -> None:
+    def __init__(self, end: int, score: float, lantype: str) -> None:
         self.end = int(end)
-        self.score = int(score)
+        self.score = float(score)
         self.lantype = lantype
 
     def __repr__(self) -> str:

--- a/antismash/modules/lanthipeptides/test/integration_lanthipeptides.py
+++ b/antismash/modules/lanthipeptides/test/integration_lanthipeptides.py
@@ -147,7 +147,7 @@ class IntegrationLanthipeptides(unittest.TestCase):
         prepeptide = rec.get_cds_motifs()[0]
         assert prepeptide.peptide_subclass == 'Class I'
         assert prepeptide.detailed_information.lan_bridges == 3
-        assert prepeptide.detailed_information.rodeo_score == 14
+        assert prepeptide.detailed_information.rodeo_score == 18
 
     def test_lactocin_s(self):
         """Test lanthipeptide prediction for lactocin S"""
@@ -157,10 +157,11 @@ class IntegrationLanthipeptides(unittest.TestCase):
 
         assert len(result.clusters) == 1
         assert result.clusters[1] == set(["lasM"])
-        assert len(result.motifs_by_locus["lasM"]) == 1
         motifs = result.motifs_by_locus["lasM"]
+        assert len(motifs) == 1
 
         assert motifs[0].peptide_subclass == "Class II"
+        assert motifs[0].locus_tag == "lasA"
 
     def test_multiple_biosynthetic_enzymes(self):
         # TODO: find/create an input with both class II and class III lanthipeptides

--- a/antismash/modules/lanthipeptides/test/integration_lanthipeptides.py
+++ b/antismash/modules/lanthipeptides/test/integration_lanthipeptides.py
@@ -147,7 +147,7 @@ class IntegrationLanthipeptides(unittest.TestCase):
         prepeptide = rec.get_cds_motifs()[0]
         assert prepeptide.peptide_subclass == 'Class I'
         assert prepeptide.detailed_information.lan_bridges == 3
-        assert prepeptide.detailed_information.rodeo_score == 15
+        assert prepeptide.detailed_information.rodeo_score == 14
 
     def test_lactocin_s(self):
         """Test lanthipeptide prediction for lactocin S"""

--- a/antismash/modules/lanthipeptides/test/test_specific_analysis.py
+++ b/antismash/modules/lanthipeptides/test/test_specific_analysis.py
@@ -37,7 +37,7 @@ class TestLanthipeptide(unittest.TestCase):
 
     def test_repr(self):
         "Test Lanthipeptide representation"
-        expected = "Lanthipeptide(..42, 17, 'Class-I', 'MAGICHAT', -1, " #  skip weights
+        expected = "Lanthipeptide(..42, 17.0, 'Class-I', 'MAGICHAT', -1, " #  skip weights
         assert repr(self.lant).startswith(expected)
 
     def test_core_ignore_invalid(self):
@@ -176,7 +176,7 @@ class TestNoCores(unittest.TestCase):
         results = run_lanthipred(DummyRecord(features=[self.cds]),
                                  self.cds, "Class-I", self.domains)
         assert results
-        assert str(results).startswith("Lanthipeptide(..40, -6, 'Class-I', 'LSQGLGGC', 1, 715")
+        assert str(results).startswith("Lanthipeptide(..40, -6.8, 'Class-I', 'LSQGLGGC', 1, 715")
 
     def test_prediction_with_core_class2(self):
         # the cleavage result adjusted to leave at least one amino in core
@@ -185,4 +185,4 @@ class TestNoCores(unittest.TestCase):
         results = run_lanthipred(DummyRecord(features=[self.cds]),
                                  self.cds, "Class-II", self.domains)
         assert results is not None
-        assert str(results).startswith("Lanthipeptide(..40, -6, 'Class-II', 'LSQGLGGC', 1, 715")
+        assert str(results).startswith("Lanthipeptide(..40, -6.8, 'Class-II', 'LSQGLGGC', 1, 715")

--- a/antismash/modules/sactipeptides/test/integration_sactipeptides.py
+++ b/antismash/modules/sactipeptides/test/integration_sactipeptides.py
@@ -36,7 +36,7 @@ class IntegrationSactipeptides(unittest.TestCase):
         assert prepeptide.get_name() == "BEST7613_6887"
         assert prepeptide.leader == "MKKAVIVENK"
         assert prepeptide.core == "GCATCSIGAACLVDGPIPDFEIAGATGLFGLWG"
-        self.assertAlmostEqual(prepeptide.score, 31.)
+        self.assertAlmostEqual(prepeptide.score, 33.)
 
     def test_ap012495_end_to_end_all_orfs(self):
         # make sure that unannotated orfs are found if they are the precursor
@@ -49,4 +49,4 @@ class IntegrationSactipeptides(unittest.TestCase):
         assert prepeptide.get_name() == "allorf041"
         assert prepeptide.leader == "MKKAVIVENK"
         assert prepeptide.core == "GCATCSIGAACLVDGPIPDFEIAGATGLFGLWG"
-        self.assertAlmostEqual(prepeptide.score, 31.)
+        self.assertAlmostEqual(prepeptide.score, 33.)


### PR DESCRIPTION
There were two issues causing precursors to score below their expected values from antiSMASH 4:
- a distance calculation used `-` when it should have used `+`, this affected lanthi-, lasso- and sactipeptides
- lanthipeptide precursor scoring was being based on the domains found within all the precursor candidates instead of the cluster itself

There were also two other small issues found in the lanthipeptides module that were fixed at the same time:
- signature scores were being truncated to ints from floats
- if a signature match could not be found, the regex version reported a score of `0` instead of the minimum threshold for signature matches of `-100`