### PR TITLE
Ambiguous translations

### DIFF
--- a/antismash/common/gff_parser.py
+++ b/antismash/common/gff_parser.py
@@ -237,8 +237,6 @@ def check_sub(feature: SeqFeature, sequence: Record) -> List[SeqFeature]:
         new_feature = SeqFeature(new_loc)
         new_feature.qualifiers = qualifiers
         new_feature.type = 'CDS'
-        trans = ''.join([n.extract(sequence.seq).translate(stop_symbol='')._data for n in trans_locations])
-        new_feature.qualifiers['translation'] = [str(trans)]
         new_features.append(new_feature)
 
     return new_features

--- a/antismash/common/secmet/features/test/test_cds_feature.py
+++ b/antismash/common/secmet/features/test/test_cds_feature.py
@@ -10,6 +10,7 @@ from Bio.Seq import Seq
 
 from antismash.common.secmet.features import FeatureLocation, CDSFeature
 from antismash.common.secmet.features.feature import CompoundLocation
+from antismash.common.secmet.locations import AfterPosition, BeforePosition
 from antismash.common.secmet.qualifiers import SecMetQualifier
 from antismash.common.secmet.qualifiers.gene_functions import GeneFunction
 
@@ -320,3 +321,17 @@ class TestCDSProteinLocation(unittest.TestCase):
         new = cds.get_sub_location_from_protein_coordinates(353, 412)
         # pad the beginning to match the location
         assert new.extract(Seq("x" * location.start + seq)).translate() == translation[353:412]
+
+    def test_extends_past_after(self):
+        self.sub_locations[-1] = FeatureLocation(21, AfterPosition(29), strand=1)
+        self.cds.location = CompoundLocation(self.sub_locations)
+
+        new = self.cds.get_sub_location_from_protein_coordinates(0, 7)
+        assert new.end == 27
+
+    def test_extends_past_before(self):
+        self.reverse_strand()
+        self.sub_locations[0] = FeatureLocation(BeforePosition(2), self.sub_locations[0].end, strand=-1)
+        self.cds.location = CompoundLocation(self.sub_locations[::-1])
+        new = self.cds.get_sub_location_from_protein_coordinates(0, 7)
+        assert new.start == 3

--- a/antismash/common/secmet/test/helpers.py
+++ b/antismash/common/secmet/test/helpers.py
@@ -22,3 +22,12 @@ class DummyCDS(CDSFeature):
         super().__init__(FeatureLocation(start, end, strand), translation=translation,
                          locus_tag=locus_tag)
         assert self.get_accession() == locus_tag, self.get_accession()
+
+    # bypass translation checks for these artifical CDSs
+    @property
+    def translation(self):
+        return self._translation
+
+    @translation.setter
+    def translation(self, translation):
+        self._translation = translation

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -172,13 +172,13 @@ class TestRecord(unittest.TestCase):
 # since we're about to test assigning to non-slots, shut pylint up
 # pylint: disable=assigning-non-slot
     def test_membership(self):
-        location = FeatureLocation(0, 1, strand=1)
+        location = FeatureLocation(0, 3, strand=1)
         # Features don't have locus tags
         with self.assertRaises(AttributeError):
             Feature(location, feature_type="none").locus_tag = "something"
         # CDSFeatures don't have an 'other_value'
         with self.assertRaises(AttributeError):
-            CDSFeature(location, translation="none", gene="a").other_value = 1
+            CDSFeature(location, translation="A", gene="a").other_value = 1
 # pylint: enable=assigning-non-slot
 
     def test_gc_content(self):


### PR DESCRIPTION
Improves handling of awkward translations:
- catches more bad translation content (similar to #85, allows `X`)
- ensures translations aren't longer than the location can support (with exceptions for ambiguous positions)
- removes the gff_parser's translation generation in favour of the CDSFeature's
- protein position conversions of overly long translations with ambiguous positions no longer cause issues (e.g. MPTA5024_04555 from AWEV00000000.1)

Due to NCBI records inferring the amino from partial nucleotides, the length of a translation is allowed to extend beyond the location only when the end position (or start, for the reverse strand) is an extendable position (`AfterPosition` for forward strand, `BeforePosition` for reverse strand). In these cases, when a protein coordinate conversion is made, the protein end will be truncated to the last fully contained nucleotide triplet.

Due to the new restrictions on translation length, some unrelated tests had to be adjusted to continue functioning.