### PR TITLE
Handle errors in clusterblast database

### DIFF
--- a/antismash/modules/clusterblast/test/test_clusterblast.py
+++ b/antismash/modules/clusterblast/test/test_clusterblast.py
@@ -7,6 +7,7 @@
 from collections import OrderedDict
 import os
 import unittest
+from unittest import mock as unittest_mock
 
 from minimock import mock, restore
 from helperlibs.wrappers.io import TemporaryDirectory
@@ -556,8 +557,8 @@ class TestOrthologousGroups(unittest.TestCase):
 
 class TestReferenceProteinLoading(unittest.TestCase):
     def mock_with(self, content):
-        # unittest.mock.mock_open doesn't handle the __iter__ case, so work around it
-        mocked_open = unittest.mock.mock_open(read_data=content)
+        # unittest_mock.mock_open doesn't handle the __iter__ case, so work around it
+        mocked_open = unittest_mock.mock_open(read_data=content)
         mocked_open.return_value.__iter__ = lambda self: iter(self.readline, '')
         return mocked_open
 
@@ -569,7 +570,7 @@ class TestReferenceProteinLoading(unittest.TestCase):
 
     def test_standard(self):
         hit = ">CVNH01000008|c1|65549-69166|-|BN1184_AH_00620|Urea_carboxylase_{ECO:0000313}|CRH36422"
-        with unittest.mock.patch("builtins.open", self.mock_with(hit)):
+        with unittest_mock.patch("builtins.open", self.mock_with(hit)):
             proteins = core.load_reference_proteins(set(), "clusterblast")
         assert len(proteins) == 1
         protein = proteins["CRH36422"]
@@ -578,7 +579,7 @@ class TestReferenceProteinLoading(unittest.TestCase):
 
     def test_non_standard(self):
         hit = ">CVNH01000008|c1|65549-69166|-|BN1184_AH_00620|Urea_carboxylase_{ECO:0000313|EMBL:CCF11062.1}|CRH36422"
-        with unittest.mock.patch("builtins.open", self.mock_with(hit)):
+        with unittest_mock.patch("builtins.open", self.mock_with(hit)):
             proteins = core.load_reference_proteins(set(), "clusterblast")
         assert len(proteins) == 1
         protein = proteins["CRH36422"]

--- a/antismash/modules/clusterblast/test/test_clusterblast.py
+++ b/antismash/modules/clusterblast/test/test_clusterblast.py
@@ -584,3 +584,19 @@ class TestReferenceProteinLoading(unittest.TestCase):
         protein = proteins["CRH36422"]
         assert protein.name == "CRH36422"
         assert protein.annotations == "Urea_carboxylase_{ECO:0000313|EMBL:CCF11062.1}"
+
+
+class TestMissingProteinCleanup(unittest.TestCase):
+    def test_missing_removed(self):
+        proteins = {}
+        for name in "ABDEFH":
+            proteins[name] = core.Protein(name, "dummylocus", "1-5", "+", "annotation")
+        clusters = {
+            "1": core.ReferenceCluster("1", "c1", ["A", "B", "C"], "desc", "type", ["tag1"]),
+            "2": core.ReferenceCluster("2", "c1", ["D", "E"], "desc", "type", ["tag3"]),
+            "3": core.ReferenceCluster("3", "c1", ["F", "G"], "desc", "type", ["tag2"]),
+            "4": core.ReferenceCluster("4", "c2", ["H"], "desc", "type", ["tag4"])
+        }
+        core.strip_clusters_missing_proteins(clusters, proteins)
+        assert sorted(clusters) == ["2", "4"]
+        assert sorted(proteins) == ["D", "E", "H"]


### PR DESCRIPTION
Reference clusters in the clusterblast database (from `clusterblast_20170105_v8_31.tar.xz`) have a listing of locus tags and protein ids. For 28 of those clusters (of ~220,000), the database is missing details of one or more proteins (e.g. `DF820425` and protein `GAJ32366`, presumably due to sharing a locus tag with `GAJ32367`). This caused crashes when those particular clusters had hits *and* were in the top scores.

Until such point as the clusterblast database is regenerated and these issues are removed, this PR fixes the problem by removing the offending clusters, along with any proteins they contained. Any hits against those removed proteins will be ignored.

The runtime cost is around 2 seconds on my machine per load of the database. Running diamond on the database will take a few minutes, so this is manageable for the moment.

Also included is a workaround for a bad interaction between `minimock` and `unittest.mock`, which only appeared when running the test file directly (e.g. `pytest antismash/modules/clusterblast/test/test_clusterblast.py`).