### PR TITLE
Revert "html: handle ipads and phones better"

### DIFF
--- a/antismash/outputs/html/templates/overview.html
+++ b/antismash/outputs/html/templates/overview.html
@@ -14,7 +14,6 @@
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@antismash_dev" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 {% set multi_record = records | length + records_without_regions | length > 1 %}
 <body>


### PR DESCRIPTION
Turns out this only improves things if the rest of your layout is fully
responsive, which the antiSMASH results page isn't.

This reverts commit 941d19e8588b91509ac0f7b476ef47502df4c275.