### PR TITLE
More fixes

### DIFF
--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -74,6 +74,7 @@ The grammar itself:
     GROUP_CLOSE = ')'
     INT = [-]{[1-9]}*[0-9]
     ID = [a-zA-Z]{[a-zA-Z0-9_-]}*
+    TEXT = {[a-zA-Z0-9_-.]}*
     MINIMUM_LABEL = 'minimum'
     CDS_LABEL = 'cds'
     SCORE_LABEL = 'minscore'
@@ -191,6 +192,7 @@ class TokenTypes(IntEnum):
     CONDITIONS = 20
     SUPERIORS = 21
     RELATED = 22
+    TEXT = 23  # covers words that aren't valid identifiers for use in rule COMMENT fields
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -214,7 +216,7 @@ class TokenTypes(IntEnum):
             elif is_legal_identifier(text):
                 classification = cls.IDENTIFIER
             else:
-                raise RuleSyntaxError("Unclassifiable token: %s" % text)
+                classification = cls.TEXT
         return classification
 
     def is_a_rule_keyword(self) -> bool:
@@ -267,7 +269,7 @@ class Tokeniser:  # pylint: disable=too-few-public-methods
                 self._finalise(line, position)
                 self.tokens.append(Token(char, line, position))
             # part of a multi-char symbol
-            elif char.isalnum() or char in ['-', '_']:
+            elif char.isalnum() or char in ['-', '_', '.']:
                 self.current_symbol.append(char)
             # a comment, don't parse anything in the line
             elif char == "#":

--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -281,8 +281,9 @@ class Tokeniser:  # pylint: disable=too-few-public-methods
                     # no newline after #, so we're finished
                     return
             else:
+                line_text = self.text.splitlines()[line - 1]
                 raise RuleSyntaxError("Unexpected character in rule: %s\n%s\n%s^"
-                                      % (char, self.text, " "*position))
+                                      % (char, line_text, " "*position))
             position += 1
             global_position += 1
         self._finalise(line, len(self.text))

--- a/antismash/common/hmmer.py
+++ b/antismash/common/hmmer.py
@@ -121,7 +121,7 @@ def build_hits(record: Record, hmmscan_results: List, min_score: float,
             hit = {"location": str(location),
                    "label": result.id, "locus_tag": feature.locus_tag,
                    "domain": hsp.hit_id, "evalue": hsp.evalue, "score": hsp.bitscore,
-                   "translation": str(location.extract(record.seq).translate(table=feature.transl_table)),
+                   "translation": feature.translation[hsp.query_start:hsp.query_end + 1],
                    "identifier": pfamdb.get_pfam_id_from_name(hsp.hit_id, database),
                    "description": hsp.hit_description, "protein_start": hsp.query_start, "protein_end": hsp.query_end}
             hits.append(hit)

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -248,7 +248,7 @@ def pre_process_sequences(sequences: List[Record], options: ConfigType, genefind
 
     # catch WGS master or supercontig entries
     if records_contain_shotgun_scaffolds(sequences):
-        raise RuntimeError("Incomplete whole genome shotgun records are not supported")
+        raise AntismashInputError("incomplete whole genome shotgun records are not supported")
 
     for i, seq in enumerate(sequences):
         seq.record_index = i + 1  # 1-indexed
@@ -289,7 +289,12 @@ def pre_process_sequences(sequences: List[Record], options: ConfigType, genefind
     # Check GFF suitability
     single_entry = False
     if options.genefinding_gff3:
-        single_entry = gff_parser.check_gff_suitability(options, sequences)
+        try:
+            single_entry = gff_parser.check_gff_suitability(options, sequences)
+        except AntismashInputError:
+            raise
+        except Exception as err:
+            raise AntismashInputError("could not parse records from GFF3 file") from err
 
     if checking_required:
         # ensure CDS features have all relevant information

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -64,6 +64,8 @@ class CDSFeature(Feature):
         # mandatory
         self._gene_functions = GeneFunctionAnnotations()
 
+        if not (protein_id or locus_tag or gene):
+            raise ValueError("CDSFeature requires at least one of: gene, protein_id, locus_tag")
         # semi-optional
         self.protein_id = _sanitise_id_value(protein_id)
         self.locus_tag = _sanitise_id_value(locus_tag)
@@ -79,9 +81,6 @@ class CDSFeature(Feature):
         self._nrps_pks = NRPSPKSQualifier(self.location.strand)
 
         self.motifs = []  # type: List[features.CDSMotif]
-
-        if not (protein_id or locus_tag or gene):
-            raise ValueError("CDSFeature requires at least one of: gene, protein_id, locus_tag")
 
         # runtime-only data
         self.region = None  # type: Optional[features.Region]

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -193,6 +193,9 @@ class CDSFeature(Feature):
         if not translation:
             if not record:
                 raise SecmetInvalidInputError("no translation in CDS and no record to generate it with")
+            if bio_feature.location.end > len(record.seq):
+                raise SecmetInvalidInputError("feature missing translation and sequence too short: %s" % (
+                                              (gene or protein_id or locus_tag)))
             translation = record.get_aa_translation_from_location(bio_feature.location, transl_table)
 
         assert _is_valid_translation_length(translation, bio_feature.location)

--- a/antismash/common/secmet/features/cluster.py
+++ b/antismash/common/secmet/features/cluster.py
@@ -80,7 +80,6 @@ class Cluster(CDSCollection):
             "detection_rule": [self.detection_rule]
         }
         if self._parent_record:
-            common["parent_cluster_number"] = [str(self.get_cluster_number())]
             common["cluster_number"] = [str(self.get_cluster_number())]
 
         shared_qualifiers = dict(qualifiers) if qualifiers else {}
@@ -116,7 +115,6 @@ class Cluster(CDSCollection):
                               tool, product, cutoff, neighbourhood_range, rule)
 
         # remove run-specific info
-        leftovers.pop("parent_cluster_number", "")
         leftovers.pop("cluster_number", "")
 
         # rebuild analysis annotations

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -219,10 +219,10 @@ class Feature:
             quals["tool"] = ["antismash"]
         if self._original_codon_start is not None:
             start = int(self._original_codon_start)
-            if self.location.strand == -1:
-                start *= -1
             quals["codon_start"] = [str(start + 1)]
             # adjust location back if neccessary
+            if self.location.strand == -1:
+                start *= -1
             if self._original_codon_start != 0:
                 feature.location = _adjust_location_by_offset(feature.location, -start)
         # sorted here to match the behaviour of biopython
@@ -275,9 +275,9 @@ class Feature:
                 codon_start = int(leftovers.pop("codon_start")[0]) - 1
                 if not 0 <= codon_start <= 2:
                     raise SecmetInvalidInputError("invalid codon_start qualifier: %d" % (codon_start + 1))
+                feature._original_codon_start = codon_start  # very much private, so pylint: disable=protected-access
                 if feature.location.strand == -1:
                     codon_start *= -1
-                feature._original_codon_start = codon_start  # very much private, so pylint: disable=protected-access
                 if codon_start != 0:
                     # adjust the location for now until converting back to biopython if required
                     feature.location = _adjust_location_by_offset(feature.location, codon_start)

--- a/antismash/common/secmet/features/supercluster.py
+++ b/antismash/common/secmet/features/supercluster.py
@@ -124,7 +124,7 @@ class TemporarySuperCluster:  # pylint: disable=too-many-instance-attributes
         """
         if len(record.get_clusters()) < max(self.clusters):
             raise ValueError("Not all referenced clusters are present in the record")
-        relevant_clusters = [record.get_cluster(num) for num in self.clusters]
+        relevant_clusters = sorted([record.get_cluster(num) for num in self.clusters])
         new = SuperCluster(self.kind, relevant_clusters,
                            smiles=self.smiles_structure, polymer=self.polymer)
         return new

--- a/antismash/common/secmet/features/test/test_cds_feature.py
+++ b/antismash/common/secmet/features/test/test_cds_feature.py
@@ -18,7 +18,7 @@ from antismash.common.secmet.qualifiers.gene_functions import GeneFunction
 
 class TestCDSFeature(unittest.TestCase):
     def test_required_identifiers(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "requires at least one of: gene, protein_id, locus_tag"):
             CDSFeature(FeatureLocation(1, 5, 1), translation="A")
         assert CDSFeature(FeatureLocation(1, 5, 1), locus_tag="foo", translation="A")
         assert CDSFeature(FeatureLocation(1, 5, 1), protein_id="foo", translation="A")

--- a/antismash/common/secmet/features/test/test_feature.py
+++ b/antismash/common/secmet/features/test/test_feature.py
@@ -119,6 +119,8 @@ class TestFeature(unittest.TestCase):
             assert feature.location.start == BeforePosition(5 + feature._original_codon_start)
             new = feature.to_biopython()[0]
             assert new.qualifiers["codon_start"] == [codon_start]
+            assert new.location.start == seqf.location.start
+            assert new.location.end == seqf.location.end
 
     def test_conversion_with_codon_start_reverse(self):
         seqf = SeqFeature(FeatureLocation(5, AfterPosition(12), -1))
@@ -126,10 +128,12 @@ class TestFeature(unittest.TestCase):
         for codon_start in "123":
             seqf.qualifiers["codon_start"] = [codon_start]
             feature = Feature.from_biopython(seqf)
-            assert feature._original_codon_start == -(int(codon_start) - 1)
-            assert feature.location.end == AfterPosition(12 + feature._original_codon_start)
+            assert feature._original_codon_start == int(codon_start) - 1
+            assert feature.location.end == AfterPosition(12 - feature._original_codon_start)
             new = feature.to_biopython()[0]
             assert new.qualifiers["codon_start"] == [codon_start]
+            assert new.location.start == seqf.location.start
+            assert new.location.end == seqf.location.end
 
     def test_invalid_codon_start(self):
         seqf = SeqFeature(FeatureLocation(5, AfterPosition(12), -1))

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -742,6 +742,8 @@ class Record:
     def get_aa_translation_from_location(self, location: FeatureLocation,
                                          transl_table: Union[str, int] = None) -> Seq:
         """ Obtain the translation for a feature based on its location """
+        if location.end > len(self.seq):
+            raise ValueError("location outside available sequence")
         if transl_table is None:
             transl_table = self._transl_table
         extracted = location.extract(self.seq).ungap('-')

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -331,7 +331,10 @@ class Record:
 
     def get_domain_by_name(self, name: str) -> Domain:
         """ Return the Domain with the given name """
-        return self._domains_by_name[name]
+        try:
+            return self._domains_by_name[name]
+        except KeyError:
+            raise KeyError("record %s contains no domain named %s" % (self.id, name))
 
     def get_cds_motifs(self) -> Tuple[CDSMotif, ...]:
         """A list of secondary metabolite CDS_motifs present in the record"""

--- a/antismash/common/test/test_record_processing.py
+++ b/antismash/common/test/test_record_processing.py
@@ -241,7 +241,7 @@ class TestPreprocessRecords(unittest.TestCase):
     def test_shotgun(self):
         filepath = path.get_full_path(__file__, "data", "wgs.gbk")
         records = record_processing.parse_input_sequence(filepath)
-        with self.assertRaisesRegex(RuntimeError, "Incomplete whole genome shotgun records are not supported"):
+        with self.assertRaisesRegex(AntismashInputError, "incomplete whole genome shotgun records are not supported"):
             record_processing.pre_process_sequences(records, self.options, self.genefinding)
 
     def test_duplicate_record_ids(self):

--- a/antismash/detection/hmm_detection/cluster_rules.txt
+++ b/antismash/detection/hmm_detection/cluster_rules.txt
@@ -19,7 +19,7 @@ RULE t3pks
     CONDITIONS Chal_sti_synt_C or Chal_sti_synt_N
 
 RULE transatpks
-    CUTOFF 20
+    CUTOFF 45  # kirromycin (CP006259) has a range of ~42kb
     EXTENT 20
     CONDITIONS cds(ATd and (PKS_KS or ene_KS or mod_KS or hyb_KS or itr_KS or tra_KS))
                and cds(PKS_AT and not (PKS_KS or ene_KS or mod_KS or hyb_KS or itr_KS or tra_KS))

--- a/antismash/detection/hmm_detection/cluster_rules.txt
+++ b/antismash/detection/hmm_detection/cluster_rules.txt
@@ -1,7 +1,7 @@
 # Cutoffs and extents are given in kilobases
 RULE t1pks
     COMMENT Type-I PKS
-            Comments can cover multiple lines
+            Comments can cover multiple lines.
     CUTOFF 20
     EXTENT 20
     CONDITIONS cds(PKS_AT and (PKS_KS or ene_KS or mod_KS or hyb_KS or itr_KS or tra_KS))

--- a/antismash/detection/nrps_pks_domains/domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/domain_identification.py
@@ -324,7 +324,7 @@ def generate_domain_features(record: Record, gene: CDSFeature,
         new_feature.score = domain.bitscore
 
         transl_table = gene.transl_table or 1
-        new_feature.translation = str(new_feature.extract(record.seq).translate(table=transl_table))
+        new_feature.translation = gene.translation[domain.query_start:domain.query_end + 1]
 
         domain_counts[domain.hit_id] += 1  # 1-indexed, so increment before use
         domain_name = "{}_{}.{}".format(gene.get_name(), domain.hit_id, domain_counts[domain.hit_id])
@@ -361,7 +361,7 @@ def generate_motif_features(record: Record, feature: CDSFeature, motifs: List[HM
         new_motif.database = "abmotifs"
         new_motif.locus_tag = locus_tag
 
-        new_motif.translation = str(new_motif.extract(record.seq).translate(table=transl_table))
+        new_motif.translation = feature.translation[motif.query_start:motif.query_end + 1]
         new_motif.notes.append("NRPS/PKS Motif: %s (e-value: %s, bit-score: %s)" % (
                                motif.hit_id, motif.evalue, motif.bitscore))  # TODO move to CDSMotif
 

--- a/antismash/modules/lanthipeptides/specific_analysis.py
+++ b/antismash/modules/lanthipeptides/specific_analysis.py
@@ -18,6 +18,7 @@ from antismash.common import all_orfs, path, subprocessing, module_results, util
 from antismash.common.fasta import get_fasta_from_features
 from antismash.common.secmet import CDSFeature, Cluster, GeneFunction, Prepeptide, Record, Region
 from antismash.common.secmet.features import CDSCollection
+from antismash.common.secmet.locations import location_from_string
 from antismash.common.secmet.qualifiers.prepeptide_qualifiers import LanthiQualifier
 
 from .rodeo import run_rodeo
@@ -89,7 +90,7 @@ class LanthiResults(module_results.ModuleResults):
                 results.motifs_by_locus[locus].append(Prepeptide.from_json(motif))
         results.clusters = {int(key): set(val) for key, val in json["clusters"].items()}
         for location, name in json["new_cds_features"]:
-            cds = all_orfs.create_feature_from_location(record, location, label=name)
+            cds = all_orfs.create_feature_from_location(record, location_from_string(location), label=name)
             results.new_cds_features.add(cds)
         return results
 

--- a/antismash/outputs/html/generator.py
+++ b/antismash/outputs/html/generator.py
@@ -74,15 +74,14 @@ def write_regions_js(records: List[Dict[str, Any]], output_dir: str,
         handle.write('var details_data = %s;\n' % json.dumps(clustered_domains, indent=4))
 
 
-def generate_html_sections(records: List[RecordLayer], results: List[Dict[str, module_results.ModuleResults]],
+def generate_html_sections(records: List[RecordLayer], results: Dict[str, Dict[str, module_results.ModuleResults]],
                            options: ConfigType) -> Dict[str, Dict[int, List[HTMLSections]]]:
     """ Generates a mapping of record->region->HTMLSections for each record, region and module
 
         Arguments:
             records: a list of RecordLayers to pass through to the modules
-            results: a list of
+            results: a dictionary mapping record name to
                         a dictionary mapping each module name to its results object
-                     one for each record
             options: the current antiSMASH config
 
         Returns:
@@ -91,8 +90,9 @@ def generate_html_sections(records: List[RecordLayer], results: List[Dict[str, m
                     a list of HTMLSections, one for each module
     """
     details = {}
-    for record, record_result in zip(records, results):
+    for record in records:
         record_details = {}
+        record_result = results[record.id]
         for region in record.regions:
             sections = []
             for handler in region.handlers:
@@ -138,7 +138,7 @@ def generate_webpage(records: List[Record], results: List[Dict[str, module_resul
         elif options.reuse_results:
             page_title, _ = os.path.splitext(os.path.basename(options.reuse_results))
 
-        html_sections = generate_html_sections(record_layers_with_regions, results, options)
+        html_sections = generate_html_sections(record_layers_with_regions, results_by_record_id, options)
 
         aux = template.render(records=record_layers_with_regions, options=options_layer,
                               version=options.version, extra_data=js_domains,

--- a/antismash/test/integration/data/nisin_postdetection.gbk
+++ b/antismash/test/integration/data/nisin_postdetection.gbk
@@ -55,7 +55,6 @@ FEATURES             Location/Qualifiers
                      lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
                      and not YcaO)"
                      /neighbourhood="10000"
-                     /parent_cluster_number="1"
                      /product="lanthipeptide"
                      /tool="antismash"
      cluster_core    828..7140
@@ -72,7 +71,6 @@ FEATURES             Location/Qualifiers
                      lacticin_l or lacticin_mat or LD_lanti_pre or strep_PEQAXS)
                      and not YcaO)"
                      /neighbourhood="10000"
-                     /parent_cluster_number="1"
                      /product="lanthipeptide"
      supercluster    1..15016
                      /child_cluster="1"


### PR DESCRIPTION
Another collection of small fixes:

- running on region genbank outputs no longer causes missing cluster issues
- more input exceptions are caught and reraised as `AntismashInputError`s
- improved CDS naming checks
- better error messages for missing CDSMotifs
- fixed result and record syncing with inputs containing empty records
- improve rule tokenisation error messages for cluster rules
- allow general text in COMMENT fields of rules
- fixes a case where lanthipeptides could have precursor details without a valid class

Edited to add:
- places where sub-CDS domain translations were created now slice the CDS translation instead of regenerating from the record sequence, important for when valid translations are initially provided