### PR TITLE
Pfam/pfam2go fixes

### DIFF
--- a/antismash/common/hmmer.py
+++ b/antismash/common/hmmer.py
@@ -119,7 +119,7 @@ def build_hits(record: Record, hmmscan_results: List, min_score: float,
             location = feature.get_sub_location_from_protein_coordinates(hsp.query_start, hsp.query_end)
 
             hit = {"location": str(location),
-                   "label": result.id, "locus_tag": feature.locus_tag,
+                   "label": result.id, "locus_tag": feature.get_name(),
                    "domain": hsp.hit_id, "evalue": hsp.evalue, "score": hsp.bitscore,
                    "translation": feature.translation[hsp.query_start:hsp.query_end + 1],
                    "identifier": pfamdb.get_pfam_id_from_name(hsp.hit_id, database),

--- a/antismash/outputs/html/js.py
+++ b/antismash/outputs/html/js.py
@@ -213,7 +213,7 @@ def convert_tta_codons(tta_codons: List[Feature], record: Record) -> List[Dict[s
     return js_codons
 
 
-def generate_pfam2go_tooltip(record: Record, feature: CDSFeature) -> List[str]:
+def generate_pfam2go_tooltip(record: Record, feature: CDSFeature) -> List[html_renderer.Markup]:
     """Create tooltip text for Pfam to Gene Ontologies results."""
     go_notes = []
     unique_pfams_with_gos = {}
@@ -226,7 +226,7 @@ def generate_pfam2go_tooltip(record: Record, feature: CDSFeature) -> List[str]:
     for unique_id, go_qualifier in sorted(unique_pfams_with_gos.items()):
         for go_id, go_description in sorted(go_qualifier.go_entries.items()):
             go_notes.append(go_info_line.format(pf_id=unique_id, url=go_url, go_id=go_id, go_desc=go_description))
-    return go_notes
+    return list(map(html_renderer.Markup, go_notes))
 
 
 def generate_asf_tooltip_section(record: Record, feature: CDSFeature) -> Dict[Tuple[str, int, int], List[str]]:

--- a/antismash/outputs/html/templates/cds_detail.html
+++ b/antismash/outputs/html/templates/cds_detail.html
@@ -36,8 +36,9 @@
   <br>
   <span class="bold"> Gene Ontology terms for PFAM domains:</span><br>
   {% for note in go_notes %}
-   {{note}}<br><br>
+   {{note}}<br>
   {% endfor %}
+  <br>
  {% endif %}
 </div>
 <div class="focus-urls">


### PR DESCRIPTION
Pfam domains were being recorded using the parent feature's locus tag, which often was `None`, breaking the linkage between CDS features and Pfam domains and preventing the HTML display of pfam2go annotations. This fixes that issue.

The pfam2go HTML was also being escaped by templating, so the types were changed to fix that at the same time as tiny adjustment to appearance of the info.