### PR TITLE
Help tooltips

### DIFF
--- a/antismash/config/default.cfg
+++ b/antismash/config/default.cfg
@@ -5,3 +5,4 @@ score = 0
 [urls]
 bacteria_baseurl = https://antismash.secondarymetabolites.org/
 fungi_baseurl = https://fungismash.secondarymetabolites.org/
+docs_baseurl = https://docs.antismash.secondarymetabolites.org/

--- a/antismash/detection/nrps_pks_domains/domain_drawing.py
+++ b/antismash/detection/nrps_pks_domains/domain_drawing.py
@@ -84,11 +84,12 @@ def has_domain_details(region: Region) -> bool:
 
 
 def generate_html(region_layer: RegionLayer, _results: ModuleResults,
-                  _record_layer: RecordLayer, _options_layer: OptionsLayer
+                  _record_layer: RecordLayer, options_layer: OptionsLayer
                   ) -> HTMLSections:
     """ Generate the details section of NRPS/PKS domains in the main HTML output """
     template = FileTemplate(path.get_full_path(__file__, 'templates', 'details.html'))
-    section = template.render(has_domain_details=has_domain_details, region=region_layer)
+    section = template.render(has_domain_details=has_domain_details, region=region_layer,
+                              docs_url=options_layer.urls.docs_baseurl)
     html = HTMLSections("nrps_pks")
     html.add_detail_section("NRPS/PKS domains", section)
     return html

--- a/antismash/detection/nrps_pks_domains/templates/details.html
+++ b/antismash/detection/nrps_pks_domains/templates/details.html
@@ -2,7 +2,7 @@
   {% if has_domain_details %}
     <div class="heading">
       <span>Detailed domain annotation</span>
-      {{help_tooltip("Shows <a href='https://docs.antismash.secondarymetabolites.org/glossary/#nrps' target='_blank'>NRPS</a>- and <a href='https://docs.antismash.secondarymetabolites.org/glossary/#pks' target='_blank'>PKS</a>-related domains for each feature that contains them. Click on each domain for more information about the domain's location, consensus monomer prediction, and other details.", "nrps-domain")}}
+      {{help_tooltip("Shows <a href='{0}glossary/#nrps' target='_blank'>NRPS</a>- and <a href='{0}glossary/#pks' target='_blank'>PKS</a>-related domains for each feature that contains them. Click on each domain for more information about the domain's location, consensus monomer prediction, and other details.".format(docs_url), "nrps-domain")}}
     </div>
     <div class="nrps-pks-domain-buttons">
       {{switch("Selected features only", "domains-selected-only")}}

--- a/antismash/detection/nrps_pks_domains/templates/details.html
+++ b/antismash/detection/nrps_pks_domains/templates/details.html
@@ -2,7 +2,7 @@
   {% if has_domain_details %}
     <div class="heading">
       <span>Detailed domain annotation</span>
-      {{help_tooltip("Shows <a href='{0}glossary/#nrps' target='_blank'>NRPS</a>- and <a href='{0}glossary/#pks' target='_blank'>PKS</a>-related domains for each feature that contains them. Click on each domain for more information about the domain's location, consensus monomer prediction, and other details.".format(docs_url), "nrps-domain")}}
+      {{help_tooltip("Shows <a href='{0}glossary/#nrps' target='_blank'>NRPS</a>- and <a href='{0}glossary/#pks' target='_blank'>PKS</a>-related domains for each feature that contains them. Click on each domain for more information about the domain's location, consensus monomer prediction, and other details.<br>A glossary is available <a href='{0}modules/nrps_pks_domains/' target='_blank'>here</a>.".format(docs_url), "nrps-domain")}}
     </div>
     <div class="nrps-pks-domain-buttons">
       {{switch("Selected features only", "domains-selected-only")}}

--- a/antismash/modules/clusterblast/html_output.py
+++ b/antismash/modules/clusterblast/html_output.py
@@ -27,23 +27,34 @@ def generate_html(region_layer: RegionLayer, _results: ClusterBlastResults,
     html = HTMLSections("clusterblast")
     region = region_layer.region_feature
 
+    base_tooltip = ("Shows %s that are similar to the current region. Genes marked with the "
+                    "same colour are interrelated. White genes have no relationship.<br>"
+                    "Click on reference genes to show details of similarities to "
+                    "genes within the current region.")
+
     if options_layer.cb_general or region.clusterblast is not None:
-        div = generate_div(region_layer, record_layer, options_layer, "clusterblast")
+        tooltip = base_tooltip % "clusters from the antiSMASH database and other clusters of interest"
+        tooltip += "<br>Click on an accession to open that entry in the antiSMASH database (if applicable)."
+        div = generate_div(region_layer, record_layer, options_layer, "clusterblast", tooltip)
         html.add_detail_section("ClusterBlast", div, "clusterblast")
     if options_layer.cb_knownclusters or region.knownclusterblast is not None:
-        div = generate_div(region_layer, record_layer, options_layer, "knownclusterblast")
+        tooltip = base_tooltip % "clusters from the MiBIG database"
+        tooltip += "<br>Click on an accession to open that entry in the MiBIG database."
+        div = generate_div(region_layer, record_layer, options_layer, "knownclusterblast", tooltip)
         html.add_detail_section("KnownClusterBlast", div, "knownclusterblast")
     if options_layer.cb_subclusters or region.subclusterblast is not None:
-        div = generate_div(region_layer, record_layer, options_layer, "subclusterblast")
+        tooltip = base_tooltip % "sub-cluster units"
+        div = generate_div(region_layer, record_layer, options_layer, "subclusterblast", tooltip)
         html.add_detail_section("SubClusterBlast", div, "subclusterblast")
 
     return html
 
 
 def generate_div(region_layer: RegionLayer, record_layer: RecordLayer,
-                 options_layer: OptionsLayer, search_type: str) -> Markup:
+                 options_layer: OptionsLayer, search_type: str,
+                 tooltip: str) -> Markup:
     """ Generates the specific HTML section of the body for a given variant of
         clusterblast
     """
     template = FileTemplate(path.get_full_path(__file__, "templates", "%s.html" % search_type))
-    return template.render(record=record_layer, region=region_layer, options=options_layer)
+    return template.render(record=record_layer, region=region_layer, options=options_layer, tooltip=tooltip)

--- a/antismash/modules/clusterblast/templates/clusterblast.html
+++ b/antismash/modules/clusterblast/templates/clusterblast.html
@@ -1,5 +1,8 @@
 <div class = "clusterblast">
-  <h3>Similar gene clusters</h3>
+    <div class="heading">
+      <span>Similar gene clusters</span>
+      {{help_tooltip(tooltip, "cb-general")}}
+    </div>
   {% if region.cluster_blast %}
   <div>
     <select id= "clusterblast-{{region.anchor_id}}-select" class= "clusterblast-selector">

--- a/antismash/modules/clusterblast/templates/knownclusterblast.html
+++ b/antismash/modules/clusterblast/templates/knownclusterblast.html
@@ -1,5 +1,8 @@
 <div class = "knownclusterblast">
-  <h3>Similar known gene clusters</h3>
+    <div class="heading">
+      <span>Similar known gene clusters</span>
+      {{help_tooltip(tooltip, "cb-known")}}
+    </div>
   {% if region.knowncluster_blast %}
   <div>
     <select id="knownclusterblast-{{region.anchor_id}}-select" class="clusterblast-selector">

--- a/antismash/modules/clusterblast/templates/subclusterblast.html
+++ b/antismash/modules/clusterblast/templates/subclusterblast.html
@@ -1,5 +1,8 @@
 <div class = "subclusterblast">
-  <h3>Similar subclusters</h3>
+    <div class="heading">
+      <span>Similar subclusters</span>
+      {{help_tooltip(tooltip, "cb-sub")}}
+    </div>
   {% if region.subcluster_blast %}
   <div>
     <select id= "subclusterblast-{{region.anchor_id}}-select" class= "clusterblast-selector">

--- a/antismash/modules/lanthipeptides/html_output.py
+++ b/antismash/modules/lanthipeptides/html_output.py
@@ -24,12 +24,17 @@ def generate_html(region_layer: RegionLayer, results: LanthiResults,
     """ Generates HTML output for the module """
     html = HTMLSections("lanthipeptides")
 
+    detail_tooltip = ("Lists the possible core peptides for each biosynthetic enzyme, including the predicted class. "
+                      "Each core peptide shows the leader and core peptide sequences, separated by a dash.")
     template = FileTemplate(path.get_full_path(__file__, "templates", "details.html"))
     motifs = results.get_motifs_for_region(region_layer.region_feature)
-    html.add_detail_section("Lanthipeptides", template.render(results=motifs))
+    html.add_detail_section("Lanthipeptides", template.render(results=motifs, tooltip=detail_tooltip))
 
+    side_tooltip = ("Lists the possible core peptides in the region. "
+                    "Each core peptide lists the number of lanthionine bridges, possible molecular weights, "
+                    "and the scores for cleavage site prediction and RODEO.")
     template = FileTemplate(path.get_full_path(__file__, "templates", "sidepanel.html"))
     motifs = results.get_motifs_for_region(region_layer.region_feature)
-    html.add_sidepanel_section("Lanthipeptides", template.render(results=motifs))
+    html.add_sidepanel_section("Lanthipeptides", template.render(results=motifs, tooltip=side_tooltip))
 
     return html

--- a/antismash/modules/lanthipeptides/templates/details.html
+++ b/antismash/modules/lanthipeptides/templates/details.html
@@ -1,5 +1,8 @@
 <div class="details">
-  <h3>Detailed annotation</h3>
+    <div class="heading">
+      <span>Lanthipeptide predictions</span>
+      {{help_tooltip(tooltip, "lanthi-body")}}
+    </div>
   {% if not results %}
     <div class="details-text">
       Lanthipeptides - No core peptides found.

--- a/antismash/modules/lanthipeptides/templates/sidepanel.html
+++ b/antismash/modules/lanthipeptides/templates/sidepanel.html
@@ -1,5 +1,8 @@
 <div class="more-details">
-<h3> Prediction details </h3>
+  <div class="heading">
+    <span>Core peptide predictions</span>
+    {{help_tooltip(tooltip, "lanthi-side")}}
+  </div>
 {% if results | length != 0 %}
     <dl class ="prediction-text">
     {% for motifs in results.values() %}

--- a/antismash/modules/lassopeptides/html_output.py
+++ b/antismash/modules/lassopeptides/html_output.py
@@ -28,10 +28,16 @@ def generate_html(region_layer: RegionLayer, results: LassoResults,
         if record_layer.get_cds_by_name(locus).is_contained_by(region_layer.region_feature):
             motifs_in_region[locus] = results.motifs_by_locus[locus]
 
-    template = FileTemplate(path.get_full_path(__file__, "templates", "details.html"))
-    html.add_detail_section("Lasso peptides", template.render(results=motifs_in_region))
+    detail_tooltip = ("Lists the possible core peptides for each biosynthetic enzyme, including the predicted class. "
+                      "Each core peptide shows the leader and core peptide sequences, separated by a dash.")
 
+    template = FileTemplate(path.get_full_path(__file__, "templates", "details.html"))
+    html.add_detail_section("Lasso peptides", template.render(results=motifs_in_region, tooltip=detail_tooltip))
+
+    side_tooltip = ("Lists the possible core peptides in the region. "
+                    "Each core peptide lists the number of disulfide bridges, possible molecular weights, "
+                    "and the scores for cleavage site prediction and RODEO.")
     template = FileTemplate(path.get_full_path(__file__, "templates", "sidepanel.html"))
-    html.add_sidepanel_section("Lasso peptides", template.render(results=motifs_in_region))
+    html.add_sidepanel_section("Lasso peptides", template.render(results=motifs_in_region, tooltip=side_tooltip))
 
     return html

--- a/antismash/modules/lassopeptides/templates/details.html
+++ b/antismash/modules/lassopeptides/templates/details.html
@@ -1,5 +1,8 @@
 <div class="details">
-  <h3>Detailed annotation</h3>
+    <div class="heading">
+      <span>Lasso peptide predictions</span>
+      {{help_tooltip(tooltip, "lasso-body")}}
+    </div>
   {% if not results %}
     <div class="details-text">
       Lassopeptides - No core peptides found.

--- a/antismash/modules/lassopeptides/templates/sidepanel.html
+++ b/antismash/modules/lassopeptides/templates/sidepanel.html
@@ -1,5 +1,8 @@
 <div class="more-details">
-  <h3> Prediction details </h3>
+    <div class="heading">
+      <span>Core peptide predictions</span>
+      {{help_tooltip(tooltip, "lasso-side")}}
+    </div>
 {% if results | length != 0 %}
   <dl class ="prediction-text">
     {% for motifs in results.values() %}

--- a/antismash/modules/nrps_pks/html_output.py
+++ b/antismash/modules/nrps_pks/html_output.py
@@ -42,14 +42,24 @@ def generate_html(region_layer: RegionLayer, results: NRPS_PKS_Results,
             if monomer:
                 monomers.append(monomer)
 
-    for filename, name, class_name in [("products.html", "NRPS/PKS products", "nrps_pks_products"),
-                                       ("monomers.html", "NRPS/PKS monomers", "")]:
+    prod_tt = ("Shows estimated product structure and polymer for each supercluster in the region. "
+               "To show the product, click on the expander or the supercluster feature drawn in the overview. "
+               )
+    mon_tt = ("Shows the predicted monomers for each adynelation domain and acyltransferase within genes. "
+              "Each gene prediction can be expanded to view detailed predictions of each domain. "
+              "Each prediction can be expanded to view the predictions by tool "
+              " (and, for some tools, further expanded for extra details). "
+              )
+
+    for filename, name, class_name, tooltip in [("products.html", "NRPS/PKS products", "nrps_pks_products", prod_tt),
+                                                ("monomers.html", "NRPS/PKS monomers", "", mon_tt)]:
         template = FileTemplate(path.get_full_path(__file__, "templates", filename))
         section = template.render(record=record_layer,
                                   region=nrps_layer,
                                   results=results,
                                   relevant_features=features_with_domain_predictions,
-                                  options=options_layer)
+                                  options=options_layer,
+                                  tooltip=tooltip)
         html.add_sidepanel_section(name, section, class_name)
 
     return html

--- a/antismash/modules/nrps_pks/templates/monomers.html
+++ b/antismash/modules/nrps_pks/templates/monomers.html
@@ -1,5 +1,8 @@
 <div class="more-details">
-  <div class="heading">NRPS/PKS domain predictions</div>
+    <div class="heading">
+      <span>NRPS/PKS monomer predictions</span>
+      {{help_tooltip(tooltip, "nrps-monomers")}}
+    </div>
   <dl class="prediction-text">
     {% for gene_id in region.sidepanel_features if gene_id in relevant_features %}
       <strong>{{gene_id}}</strong>: {{relevant_features[gene_id] | join(" - ")}}

--- a/antismash/modules/nrps_pks/templates/products.html
+++ b/antismash/modules/nrps_pks/templates/products.html
@@ -1,6 +1,9 @@
 <div class="structure">
   {% if region.has_any_polymer() %}
-    <div class="heading">Predicted core structure(s)</div>
+    <div class="heading">
+      <span>Predicted core structure(s)</span>
+      {{help_tooltip(tooltip, "nrps-structures")}}
+    </div>
     {% for supercluster in region.superclusters %}
       {% if supercluster.smiles or supercluster.polymer %}
         <div>

--- a/antismash/modules/sactipeptides/html_output.py
+++ b/antismash/modules/sactipeptides/html_output.py
@@ -34,18 +34,24 @@ def generate_html(region_layer: RegionLayer, results: SactiResults,
 
     sacti_layer = SactipeptideLayer(record_layer, region_layer.region_feature)
 
+    detail_tooltip = ("Lists the possible core peptides for each biosynthetic enzyme, including the predicted class. "
+                      "Each core peptide shows the leader and core peptide sequences, separated by a dash.")
     template = FileTemplate(path.get_full_path(__file__, "templates", "details.html"))
     details = template.render(record=record_layer,
                               region=sacti_layer,
                               options=options_layer,
-                              results=motifs_in_region)
+                              results=motifs_in_region,
+                              tooltip=detail_tooltip)
     html.add_detail_section("Sactipeptides", details)
 
+    side_tooltip = ("Lists the possible core peptides in the region. "
+                    "Each core peptide lists its RODEO score and predicted core sequence.")
     template = FileTemplate(path.get_full_path(__file__, "templates", "sidepanel.html"))
     sidepanel = template.render(record=record_layer,
                                 region=sacti_layer,
                                 options=options_layer,
-                                results=motifs_in_region)
+                                results=motifs_in_region,
+                                tooltip=side_tooltip)
     html.add_sidepanel_section("Sactipeptides", sidepanel)
 
     return html

--- a/antismash/modules/sactipeptides/templates/details.html
+++ b/antismash/modules/sactipeptides/templates/details.html
@@ -1,5 +1,8 @@
 <div class="details">
-  <h3>Detailed annotation</h3>
+    <div class="heading">
+      <span>Sactipeptide predictions</span>
+      {{help_tooltip(tooltip, "sacti-body")}}
+    </div>
   {% if not results %}
     <div class="details-text">
       Sactipeptides - No core peptides found.

--- a/antismash/modules/sactipeptides/templates/sidepanel.html
+++ b/antismash/modules/sactipeptides/templates/sidepanel.html
@@ -1,5 +1,8 @@
 <div class="more-details">
-  <h3> Prediction details </h3>
+    <div class="heading">
+      <span>Core peptide predictions</span>
+      {{help_tooltip(tooltip, "sacti-side")}}
+    </div>
 {% if results | length != 0 %}
   <dl class ="prediction-text">
   {% for motifs in results.values() %}

--- a/antismash/modules/t2pks/html_output.py
+++ b/antismash/modules/t2pks/html_output.py
@@ -18,7 +18,7 @@ def will_handle(products: List[str]) -> bool:
 
 
 def generate_html(region_layer: RegionLayer, results: T2PKSResults,
-                  _record_layer: RecordLayer, _options_layer: OptionsLayer) -> HTMLSections:
+                  _record_layer: RecordLayer, options_layer: OptionsLayer) -> HTMLSections:
     """ Generate the sidepanel HTML with results from the type II PKS module """
     html = HTMLSections("t2pks")
 
@@ -28,6 +28,15 @@ def generate_html(region_layer: RegionLayer, results: T2PKSResults,
             predictions.append(results.cluster_predictions[cluster.get_cluster_number()])
 
     template = FileTemplate(path.get_full_path(__file__, "templates", "sidepanel.html"))
-    html.add_sidepanel_section("Type II PKS", template.render(predictions=predictions))
+
+    docs_url = options_layer.urls.docs_baseurl + "modules/t2pks"
+    tooltip_content = ("Predictions of starter units, elongations, product classes, "
+                       "and potential molecular weights for type II PKS clusters."
+                      )
+
+    tooltip_content += "<br>More detailed information is available <a href='%s' target='_blank'>here</a>." % docs_url
+
+    html.add_sidepanel_section("Type II PKS", template.render(predictions=predictions,
+                                                              tooltip_content=tooltip_content))
 
     return html

--- a/antismash/modules/t2pks/templates/sidepanel.html
+++ b/antismash/modules/t2pks/templates/sidepanel.html
@@ -1,5 +1,8 @@
 <div class="more-details">
-	<h3>Type II PKS gene cluster prediction details</h3>
+    <div class="heading">
+      <span>Type II PKS gene cluster prediction details</span>
+      {{help_tooltip(tooltip_content, "t2pks")}}
+    </div>
 	{% for prediction in predictions %}
 	{% if loop.index > 1 %}
 	<hr>

--- a/antismash/modules/thiopeptides/html_output.py
+++ b/antismash/modules/thiopeptides/html_output.py
@@ -39,15 +39,24 @@ def generate_html(region_layer: RegionLayer, results: ThioResults,
 
     thio_layer = ThiopeptideLayer(record_layer, results, region_layer.region_feature)
 
+    detail_tooltip = ("Lists the possible core peptides for each biosynthetic enzyme, including the predicted class. "
+                      "Each core peptide shows the leader and core peptide sequences, separated by a dash. "
+                      "Predicted tail sequences are also shown.")
     template = FileTemplate(path.get_full_path(__file__, "templates", "details.html"))
     details = template.render(record=record_layer,
                               cluster=thio_layer,
-                              options=options_layer)
+                              options=options_layer,
+                              tooltip=detail_tooltip)
     html.add_detail_section("Thiopeptides", details)
 
+    side_tooltip = ("Lists the possible core peptides in the region. "
+                    "Each core peptide lists its possible molecular weights "
+                    "and the scores for cleavage site prediction and RODEO. "
+                    "If relevant, other features, such as macrocycle and amidation, will also be listed.")
     template = FileTemplate(path.get_full_path(__file__, "templates", "sidepanel.html"))
     sidepanel = template.render(record=record_layer,
                                 cluster=thio_layer,
-                                options=options_layer)
+                                options=options_layer,
+                                tooltip=side_tooltip)
     html.add_sidepanel_section("Thiopeptides", sidepanel)
     return html

--- a/antismash/modules/thiopeptides/templates/details.html
+++ b/antismash/modules/thiopeptides/templates/details.html
@@ -1,5 +1,8 @@
 <div class="details">
-  <h3>Detailed annotation</h3>
+    <div class="heading">
+      <span>Thiopeptide predictions</span>
+      {{help_tooltip(tooltip, "thio-body")}}
+    </div>
   {% if not cluster.motifs %}
     <div class="details-text">
       No core peptides found.

--- a/antismash/modules/thiopeptides/templates/sidepanel.html
+++ b/antismash/modules/thiopeptides/templates/sidepanel.html
@@ -1,5 +1,8 @@
 <div class="more-details">
-  <h3> Prediction details </h3>
+    <div class="heading">
+      <span>Core peptide predictions</span>
+      {{help_tooltip(tooltip, "thio-side")}}
+    </div>
   {% if cluster.motifs %}
   <dl class ="prediction-text">
   {% for motif in cluster.motifs %}

--- a/antismash/outputs/html/generator.py
+++ b/antismash/outputs/html/generator.py
@@ -140,12 +140,22 @@ def generate_webpage(records: List[Record], results: List[Dict[str, module_resul
 
         html_sections = generate_html_sections(record_layers_with_regions, results_by_record_id, options)
 
+        doc_url = options.urls.docs_baseurl + "understanding_output/#the-antismash-5-region-concept"
+        svg_tooltip = ("Shows the layout of the region, marking coding sequences and areas of interest. "
+                       "Clicking a gene will select it and show any relevant details. "
+                       "Clicking an area feature (e.g. a candidate cluster) will select all coding "
+                       "sequences within that area. Double clicking an area feature will zoom to that area. "
+                       "Multiple genes and area features can be selected by clicking them while holding the Ctrl key."
+                       )
+        svg_tooltip += "<br>More detailed help is available <a href='%s' target='_blank'>here</a>." % doc_url
+
         aux = template.render(records=record_layers_with_regions, options=options_layer,
                               version=options.version, extra_data=js_domains,
                               regions_written=regions_written, sections=html_sections,
                               results_by_record_id=results_by_record_id,
                               config=options, job_id=job_id, page_title=page_title,
-                              records_without_regions=record_layers_without_regions)
+                              records_without_regions=record_layers_without_regions,
+                              svg_tooltip=svg_tooltip)
         result_file.write(aux)
 
 

--- a/antismash/outputs/html/templates/header.html
+++ b/antismash/outputs/html/templates/header.html
@@ -25,7 +25,7 @@
         </ul>
       </div>
       <div class="ancillary-link"><a href="{{options.base_url}}#!/about"><img src="images/about.svg" alt="about"> &nbsp; About</a></div>
-      <div class="ancillary-link"><a href="https://docs.antismash.secondarymetabolites.org"><img src="images/help.svg" alt="help"> &nbsp; Help</a></div>
+      <div class="ancillary-link"><a href="{{options.urls.docs_baseurl}}"><img src="images/help.svg" alt="help"> &nbsp; Help</a></div>
       <div class="ancillary-link"><a href="{{options.base_url}}#!/contact"><img src="images/contact.svg" alt="contact"> &nbsp; Contact</a></div>
     </div>
   </nav>

--- a/antismash/outputs/html/templates/overview.html
+++ b/antismash/outputs/html/templates/overview.html
@@ -81,7 +81,7 @@
               <td>
                 {% set dash = joiner("-") %}
                 {% for subtype in region.products -%}
-                  {{dash()}}<a href="https://docs.antismash.secondarymetabolites.org/glossary/#{{subtype}}" target="_blank">{{subtype | title}}</a>
+                  {{dash()}}<a href="{{options.urls.docs_baseurl}}glossary/#{{subtype}}" target="_blank">{{subtype | title}}</a>
                 {%- endfor %}
               </td>
               <td class="digits">{{region.location.start + 1}}</td>

--- a/antismash/outputs/html/templates/regions.html
+++ b/antismash/outputs/html/templates/regions.html
@@ -53,7 +53,10 @@
   </div>
 
   <div class="focus-panel">
-    <h3>Gene details</h3>
+    <div class="heading">
+      <span>Gene details</span>
+      {{help_tooltip("Shows details of the most recently selected gene, including names, products, location, and other annotations.", "focus-panel")}}
+    </div>
     <div class="focus-panel-content focus-panel-content-{{region.anchor_id}}">
         <div style="text-align: center; margin-top: 30%;">
             Select a gene to view the details available for it

--- a/antismash/outputs/html/templates/regions.html
+++ b/antismash/outputs/html/templates/regions.html
@@ -4,10 +4,10 @@
 {% set results = results_by_record_id[record.id] %}
 {% for region in record.regions %}
 <div class="page" id='{{region.anchor_id}}'>
-  <h3> {{record.seq_record.name}} - Region {{region.get_region_number()}} - {{region.get_product_string() | capitalize }}</h3>
  <div class="region-grid">
   <div class = "content">
     <div class ="description-container">
+      <div class="heading"> {{record.seq_record.name}} - Region {{region.get_region_number()}} - {{region.get_product_string() | capitalize }} {{help_tooltip(svg_tooltip, "region_svg")}}</div>
       <div class="region-download">
         <a href = {{ '%s.region%03d.gbk' % (record.id, region.get_region_number()) }}>Download region GenBank file</a>
       </div>


### PR DESCRIPTION
Adds a help tooltip to every panel of the output HTML, including one for each module tab. Where possible, the tooltips also link to the docs website for further details.