### PR TITLE
Secmet/input updates

### DIFF
--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -255,3 +255,9 @@ class CDSFeature(Feature):
 
     def __str__(self) -> str:
         return "CDS(%s, %s)" % (self.get_name(), self.location)
+
+    def strip_antismash_annotations(self) -> None:
+        """ Remove all antiSMASH-specific annotations from the feature """
+        self.sec_met = SecMetQualifier()
+        self.gene_functions.clear()
+        self.nrps_pks = NRPSPKSQualifier(self.location.strand)

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -446,6 +446,8 @@ class Record:
                 results.append(feature)
             elif with_overlapping and feature.overlaps_with(location):
                 results.append(feature)
+            elif index + 1 < len(self._cds_features) and self._cds_features[index + 1].is_contained_by(feature):
+                pass
             else:
                 break
             index += 1

--- a/antismash/common/secmet/test/helpers.py
+++ b/antismash/common/secmet/test/helpers.py
@@ -6,8 +6,32 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=no-self-use,protected-access,missing-docstring
 
-from ..features import CDSFeature, CDSMotif
+from ..features import (
+    AntismashDomain,
+    CDSFeature,
+    CDSMotif,
+    Cluster,
+    Feature,
+    PFAMDomain,
+    Region,
+    SubRegion,
+    SuperCluster,
+)
+from ..features.supercluster import SuperClusterKind
 from ..locations import FeatureLocation
+
+
+class DummyAntismashDomain(AntismashDomain):
+    counter = 0
+
+    def __init__(self, start=0, end=3, strand=1, location=None, domain_id=None, tool="test_tool"):
+        if location is None:
+            location = FeatureLocation(start, end, strand=strand)
+        if not domain_id:
+            domain_id = "test_asDom_%d" % DummyAntismashDomain.counter
+            DummyAntismashDomain.counter += 1
+        super().__init__(location, tool=tool)
+        self.domain_id = domain_id
 
 
 class DummyCDS(CDSFeature):
@@ -42,3 +66,67 @@ class DummyCDSMotif(CDSMotif):
             domain_id = "dummy_domain%d_%d_%d" % (DummyCDSMotif.counter, start, end)
             DummyCDSMotif.counter += 1
         self.domain_id = domain_id
+
+
+class DummyFeature(Feature):
+    def __init__(self, start, end, strand=1, feature_type="none"):
+        super().__init__(FeatureLocation(start, end, strand), feature_type=feature_type)
+
+
+class DummyCluster(Cluster):
+    def __init__(self, start=None, end=None, core_start=0, core_end=1,  # pylint: disable=too-many-arguments
+                 core_location=None, tool="test", product="test product",
+                 cutoff=10, neighbourhood_range=10, high_priority_product=True):
+        if core_location is None:
+            core_location = FeatureLocation(core_start, core_end)
+        if start is None:
+            start = max(0, core_location.start - neighbourhood_range)
+        if end is None:
+            end = core_location.end + neighbourhood_range
+        surrounds = FeatureLocation(start, end)
+        super().__init__(core_location, surrounds, tool, product, cutoff,
+                         neighbourhood_range, high_priority_product)
+
+
+class DummyPFAMDomain(PFAMDomain):
+    counter = 0
+
+    def __init__(self, start=0, end=3, location=None, description="desc",  # pylint: disable=too-many-arguments
+                 protein_start=0, protein_end=1, identifier=None, tool="test",
+                 domain_id=None):
+        if location is None:
+            location = FeatureLocation(start, end)
+        if identifier is None:
+            identifier = "PF00001"
+        super().__init__(location, description, protein_start, protein_end, identifier, tool)
+        self.domain_id = domain_id or "dummy_pfam_%d" % DummyPFAMDomain.counter
+        DummyPFAMDomain.counter += 1
+
+
+class DummyRegion(Region):
+    def __init__(self, superclusters=None, subregions=None):
+        if superclusters is None:
+            superclusters = [DummySuperCluster()]
+        if subregions is None:
+            subregions = [DummySubRegion()]
+        super().__init__(superclusters, subregions)
+
+
+class DummySubRegion(SubRegion):
+    def __init__(self, start=0, end=10, location=None, tool="test",
+                 anchor="test_anchor", probability=0.):
+        if location is None:
+            location = FeatureLocation(start, end)
+        super().__init__(location, anchor=anchor, tool=tool, probability=probability)
+
+
+class DummySuperCluster(SuperCluster):
+    def __init__(self, clusters=None, kind=None):
+        if clusters is None:
+            clusters = [DummyCluster()]
+        if not kind:
+            if len(clusters) == 1:
+                kind = SuperClusterKind.SINGLE
+            else:
+                kind = SuperClusterKind.INTERLEAVED
+        super().__init__(kind, clusters)

--- a/antismash/common/test/helpers.py
+++ b/antismash/common/test/helpers.py
@@ -14,48 +14,21 @@
 import os
 
 from Bio.Seq import Seq
-from Bio.SeqFeature import FeatureLocation
 from helperlibs.wrappers.io import TemporaryDirectory
 
 import antismash
 from antismash.common import serialiser, path
 from antismash.common.module_results import ModuleResults
-from antismash.common.secmet import Cluster, Feature, Record, SuperCluster
-from antismash.common.secmet.test.helpers import DummyCDS  # for import by others, pylint: disable=unused-import
-from antismash.common.secmet.features.supercluster import SuperClusterKind
+from antismash.common.secmet import Record
+from antismash.common.secmet.test.helpers import (  # for import by others, pylint: disable=unused-import
+    DummyCDS,
+    DummyCluster,
+    DummyFeature,
+    DummySuperCluster,
+)
 from antismash.config import update_config
 from antismash.config.args import build_parser
 from antismash.main import get_all_modules
-
-
-class DummyFeature(Feature):
-    def __init__(self, start, end, strand=1, feature_type="none"):
-        super().__init__(FeatureLocation(start, end, strand), feature_type=feature_type)
-
-
-class DummyCluster(Cluster):
-    def __init__(self, start=None, end=None, core_start=0, core_end=1,
-                 core_location=None, tool="test", product="test product",
-                 cutoff=10, neighbourhood_range=10, high_priority_product=True):
-        if core_location is None:
-            core_location = FeatureLocation(core_start, core_end)
-        if start is None:
-            start = max(0, core_location.start - neighbourhood_range)
-        if end is None:
-            end = core_location.end + neighbourhood_range
-        surrounds = FeatureLocation(start, end)
-        super().__init__(core_location, surrounds, tool, product, cutoff,
-                         neighbourhood_range, high_priority_product)
-
-
-class DummySuperCluster(SuperCluster):
-    def __init__(self, clusters, kind=None):
-        if not kind:
-            if len(clusters) == 1:
-                kind = SuperClusterKind.SINGLE
-            else:
-                kind = SuperClusterKind.INTERLEAVED
-        super().__init__(kind, clusters)
 
 
 def get_simple_options(module, args):

--- a/antismash/common/test/test_record_processing.py
+++ b/antismash/common/test/test_record_processing.py
@@ -328,13 +328,20 @@ class TestStripRecord(unittest.TestCase):
     def test_cds_motifs(self):
         record = helpers.DummyRecord()
 
-        non_as_motif = DummyCDSMotif()
+        non_as_motif = DummyCDSMotif(domain_id="non-as")
         non_as_motif.created_by_antismash = False
         record.add_cds_motif(non_as_motif)
 
-        as_motif = DummyCDSMotif()
+        as_motif = DummyCDSMotif(domain_id="as")
         as_motif.created_by_antismash = True
         record.add_cds_motif(as_motif)
 
-        record_processing.strip_record(record)
-        assert record.get_cds_motifs() == (non_as_motif,)
+        bio = record.to_biopython()
+        assert len(bio.features) == 2
+        assert record_processing.strip_record(bio) is bio  # strips and returns
+        assert len(bio.features) == 1
+        record = Record.from_biopython(bio, taxon="bacteria")
+
+        motifs = record.get_cds_motifs()
+        assert len(motifs) == 1
+        assert motifs[0].domain_id == "non-as"

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -149,9 +149,6 @@ def run_detection(record: Record, options: ConfigType,
         Returns:
             the time taken by each detection module as a dictionary
     """
-    # strip any existing antismash results first
-    record_processing.strip_record(record)
-
     timings = {}  # type: Dict[str, float]
 
     # run full genome detections
@@ -463,6 +460,8 @@ def read_data(sequence_file: Optional[str], options: ConfigType) -> serialiser.A
             if not contents:
                 raise ValueError("No results contained in file: %s" % options.reuse_results)
         results = serialiser.AntismashResults.from_file(options.reuse_results)
+        for record in results.records:
+            record.strip_antismash_annotations()
         if options.taxon != results.taxon:
             logging.info("Reusing taxon %s from prior results", results.taxon)
             update_config({"taxon": results.taxon})

--- a/antismash/modules/tta/test/integration_tta.py
+++ b/antismash/modules/tta/test/integration_tta.py
@@ -11,7 +11,7 @@ import unittest
 import antismash
 from antismash.main import read_data
 from antismash.common.module_results import ModuleResults
-from antismash.common.record_processing import parse_input_sequence
+from antismash.common.secmet import Record
 import antismash.common.test.helpers as helpers
 from antismash.config import get_config, update_config, destroy_config, build_config
 from antismash.modules import tta
@@ -29,7 +29,7 @@ class TtaIntegrationTest(unittest.TestCase):
         update_config(self.old_config)
 
     def test_nisin(self):
-        record = parse_input_sequence(helpers.get_path_to_nisin_with_detection())[0]
+        record = Record.from_genbank(helpers.get_path_to_nisin_with_detection(), taxon="bacteria")[0]
         regions = record.get_regions()
         assert regions
         for region in regions:


### PR DESCRIPTION
Fixes an issue where `Record.get_cds_features_within_location()` failed to fetch all possible CDS features within that location (due to a single large CDS containing multiple small ones, usually a bad annotation to begin with).

Changes how input stripping is handled, so that no errors occur when secmet tries to parse obsolete annotations. There's now a biopython stripping function and a secmet stripping function. These now happen at input time instead of a blend of input and detection.

To make life easier for testing the stripping, the `Dummy` style test helpers leftover in `common.test.helpers` have been shifted to secmet and some missing feature dummies added.