### PR TITLE
Rules fix for MinimumConditions in an AndCondition

### DIFF
--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -342,10 +342,8 @@ def apply_cluster_rules(record: Record, results_by_id: Dict[str, List[HSP]],
     for cds_name in cds_with_hits:
         feature = record.get_cds_by_name(cds_name)
         feature_start, feature_end = sorted([feature.location.start, feature.location.end])
-        results = []  # type: List[str]
         rule_texts = []
         info_by_range = {}  # type: Dict[int, Tuple[Dict[str, CDSFeature], Dict[str, List[HSP]]]]
-        domain_matches = set()  # type: Set[str]
         for rule in rules:
             if rule.cutoff not in info_by_range:
                 location = FeatureLocation(feature_start - rule.cutoff, feature_end + rule.cutoff)
@@ -358,9 +356,7 @@ def apply_cluster_rules(record: Record, results_by_id: Dict[str, List[HSP]],
             matching = rule.detect(cds_name, nearby_features, nearby_results)
             if matching.met and matching.matches:
                 cds_domains_by_cluster_type[cds_name][rule.name].update(matching.matches)
-                results.append(rule.name)
                 rule_texts.append(rule.reconstruct_rule_text())
-                domain_matches.update(matching.matches)
                 cluster_type_hits[rule.name].add(cds_name)
                 for other_cds, other_matches in matching.ancillary_hits.items():
                     cluster_type_hits[rule.name].add(other_cds)


### PR DESCRIPTION
In an `AndCondition`, if one part was satisfied by one CDS and other parts
were satisfied by other CDSs, information was lost when other parts
were only satisfied due to the presence of a separate successful part
e.g.
`A --8kb-- X --8kb-- B` with a rule like `X and minimum(2, [A, B])` with a cutoff of 10kb.
if the minimum condition alone would fail due to distance, but the X
condition succeeds, only the CDS for X would be marked as core, despite
the whole cluster still being created.

Since `A and X and B` would result in the same 16kb cluster, allowing the `MinimumCondition` to extend by the cutoff to each side of an anchor in the same way seems the best way to solve it.

The behavior of finding clusters is unchanged, this fix just ensures that all components responsible for finding the cluster are properly marked. It also removes two unused variables left over from some other prior change.