### PR TITLE
More small fixes

### DIFF
--- a/antismash/common/module_results.py
+++ b/antismash/common/module_results.py
@@ -71,3 +71,7 @@ class DetectionResults(ModuleResults):  # keeping abstract is deliberate, pylint
             Should be overridden by any subclass that makes region predictions.
         """
         return []
+
+    @staticmethod
+    def from_json(json: Dict[str, Any], record: Record) -> Optional["DetectionResults"]:
+        raise NotImplementedError()

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -434,7 +434,7 @@ def is_nucl_seq(sequence: Union[Seq, str]) -> bool:
             sequence: the sequence to check, either a string or Bio.Seq
 
         Returns:
-            True if less than 20% of bases are not a,c,g,t or n
+            True if more than 80% of characters are nucleotide bases
     """
     other = str(sequence).lower()
     for char in "acgtn":

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -372,6 +372,8 @@ def pre_process_sequences(sequences: List[Record], options: ConfigType, genefind
         logging.debug("Ensuring CDS features do not have duplicate IDs")
         ensure_no_duplicate_cds_gene_ids(sequences)
 
+    if all(sequence.skip for sequence in sequences):
+        raise AntismashInputError("all records skipped")
 
     return sequences
 

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -63,7 +63,7 @@ def parse_input_sequence(filename: str, taxon: str = "bacteria", minimum_length:
         raise AntismashInputError("no valid records found in file %r" % filename)
 
     for record in records:
-        if isinstance(record.seq.alphabet, Bio.Alphabet.ProteinAlphabet):
+        if isinstance(record.seq.alphabet, Bio.Alphabet.ProteinAlphabet) or not is_nucl_seq(record.seq):
             raise AntismashInputError("protein records are not supported")
 
     # before conversion to secmet records, trim if required

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -309,7 +309,20 @@ def pre_process_sequences(sequences: List[Record], options: ConfigType, genefind
 
     # keep sequences as clean as possible and make sure they're valid
     if checking_required:
-        logging.debug("Sanitising record sequences")
+        logging.debug("Sanitising record ids and sequences")
+        # Ensure all records have unique names
+        all_record_ids = {seq.id for seq in sequences}
+        if len(all_record_ids) < len(sequences):
+            all_record_ids = set()
+            for record in sequences:
+                if record.id in all_record_ids:
+                    record.original_id = record.id
+                    record.id = generate_unique_id(record.id, all_record_ids)[0]
+                all_record_ids.add(record.id)
+            assert len(all_record_ids) == len(sequences), "%d != %d" % (len(all_record_ids), len(sequences))
+        # Ensure all records have valid names
+        for record in sequences:
+            fix_record_name_id(record, all_record_ids)
         if len(sequences) == 1:
             sequences = [sanitise_sequence(sequences[0])]
             sequences = [check_content(sequences[0])]
@@ -359,19 +372,6 @@ def pre_process_sequences(sequences: List[Record], options: ConfigType, genefind
         logging.debug("Ensuring CDS features do not have duplicate IDs")
         ensure_no_duplicate_cds_gene_ids(sequences)
 
-        all_record_ids = {seq.id for seq in sequences}
-        # Ensure all records have unique names
-        if len(all_record_ids) < len(sequences):
-            all_record_ids = set()
-            for record in sequences:
-                if record.id in all_record_ids:
-                    record.original_id = record.id
-                    record.id = generate_unique_id(record.id, all_record_ids)[0]
-                all_record_ids.add(record.id)
-            assert len(all_record_ids) == len(sequences), "%d != %d" % (len(all_record_ids), len(sequences))
-        # Ensure all records have valid names
-        for record in sequences:
-            fix_record_name_id(record, all_record_ids)
 
     return sequences
 


### PR DESCRIPTION
- simplifies catching protein record inputs
- ensures record identifiers are sanitised before they are used in genefinding
- raise an error if all input records will be skipped
- minor improvement typing annotations for `DetectionResults`