### PR TITLE
Improved input validation and error reporting

### DIFF
--- a/antismash/common/gff_parser.py
+++ b/antismash/common/gff_parser.py
@@ -85,8 +85,7 @@ def check_gff_suitability(options: ConfigType, sequences: List[Record]) -> bool:
     return single_entries
 
 
-def get_features_from_file(record: Record, handle: IO,
-                           limit_to_seq_id: Union[bool, Dict[str, List[str]]] = False
+def get_features_from_file(handle: IO, limit_to_seq_id: Union[bool, Dict[str, List[str]]] = False
                            ) -> List[SeqFeature]:
     """ Generates new SeqFeatures from a GFF file.
 
@@ -109,7 +108,7 @@ def get_features_from_file(record: Record, handle: IO,
             if feature.type == 'CDS':
                 new_features = [feature]
             else:
-                new_features = check_sub(feature, record)
+                new_features = check_sub(feature)
                 if not new_features:
                     continue
 
@@ -154,7 +153,7 @@ def run(record: Record, single_entry: bool, options: ConfigType) -> None:
         limit_info = {'gff_id': [record.id]}
 
     with open(options.genefinding_gff3) as handle:
-        features = get_features_from_file(record, handle, limit_info)
+        features = get_features_from_file(handle, limit_info)
         for feature in features:
             try:
                 record.add_biopython_feature(feature)
@@ -212,7 +211,7 @@ def generate_details_from_subfeature(sub_feature: SeqFeature,
     return mismatching_qualifiers
 
 
-def check_sub(feature: SeqFeature, sequence: Record) -> List[SeqFeature]:
+def check_sub(feature: SeqFeature) -> List[SeqFeature]:
     """ Recursively checks a GFF feature for any subfeatures and generates any
         appropriate SeqFeature instances from them.
     """
@@ -223,7 +222,7 @@ def check_sub(feature: SeqFeature, sequence: Record) -> List[SeqFeature]:
     mismatching_qualifiers = set()  # type: Set[str]
     for sub in feature.sub_features:
         if sub.sub_features:  # If there are sub_features, go deeper
-            new_features.extend(check_sub(sub, sequence))
+            new_features.extend(check_sub(sub))
         elif sub.type == 'CDS':
             sub_mismatch = generate_details_from_subfeature(sub, qualifiers,
                                                             locations, trans_locations)

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -346,10 +346,6 @@ def pre_process_sequences(sequences: List[Record], options: ConfigType, genefind
         partial = functools.partial(ensure_cds_info, single_entry, genefinding.run_on_record)
         sequences = parallel_function(partial, ([sequence] for sequence in sequences))
 
-        # Check if no duplicate locus tags / gene IDs are found
-        logging.debug("Ensuring CDS features do not have duplicate IDs")
-        ensure_no_duplicate_cds_gene_ids(sequences)
-
     if all(sequence.skip for sequence in sequences):
         raise AntismashInputError("all records skipped")
 
@@ -437,31 +433,6 @@ def records_contain_shotgun_scaffolds(records: List[Record]) -> bool:
                                                    or 'contig' in record.annotations):
             return True
     return False
-
-
-def ensure_no_duplicate_cds_gene_ids(sequences: List[Record]) -> None:
-    """ Ensures that every CDS has a unique id within it's Record
-
-        Arguments:
-            sequences: the secmet.Record instances to process
-
-        Returns:
-            None
-    """
-    for sequence in sequences:
-        all_ids = set()  # type: Set[str]
-        for cdsfeature in sequence.get_cds_features():
-            name = cdsfeature.get_name()
-            if name in all_ids:
-                name, _ = generate_unique_id(name[:8], all_ids, start=1)
-            if cdsfeature.product is None:
-                cdsfeature.product = name
-            # update only the name causing the conflict
-            if cdsfeature.locus_tag == cdsfeature.get_name():
-                cdsfeature.locus_tag = name
-            elif cdsfeature.gene == cdsfeature.get_name():
-                cdsfeature.gene = name
-            all_ids.add(name)
 
 
 def fix_record_name_id(record: Record, all_record_ids: Set[str]) -> None:

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -19,7 +19,12 @@ from antismash.common.secmet.locations import (
 )
 
 from ..errors import SecmetInvalidInputError
-from ..locations import AfterPosition, BeforePosition, Location
+from ..locations import (
+    AfterPosition,
+    BeforePosition,
+    Location,
+    location_contains_overlapping_exons,
+)
 
 
 def _adjust_location_by_offset(location: Location, offset: int) -> Location:
@@ -64,6 +69,8 @@ class Feature:
         assert isinstance(location, (FeatureLocation, CompoundLocation)), type(location)
         if location_bridges_origin(location):
             raise ValueError("Features that bridge the record origin cannot be directly created: %s" % location)
+        if location_contains_overlapping_exons(location):
+            raise ValueError("location contains overlapping exons: %s" % location)
         assert location.start <= location.end, "Feature location invalid: %s" % location
         self.location = location
         self.notes = []  # type: List[str]

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -628,6 +628,8 @@ class Record:
             # biopython drops invalid locations and might leave us with None, catch that first
             if feature.location is None:
                 raise SecmetInvalidInputError("feature is missing location: %s" % feature)
+            if feature.location.end > len(seq_record.seq):
+                raise SecmetInvalidInputError("feature outside record sequence: %s" % feature.location)
 
             if feature.ref or feature.ref_db:
                 for ref in [feature.ref, feature.ref_db]:

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -645,7 +645,10 @@ class Record:
             if record.is_circular() and location_bridges_origin(feature.location):
                 locations_adjusted = True
                 original_location = feature.location
-                lower, upper = split_origin_bridging_location(feature.location)
+                try:
+                    lower, upper = split_origin_bridging_location(feature.location)
+                except ValueError as err:
+                    raise SecmetInvalidInputError(str(err)) from err
 
                 if feature.type in ['CDS', 'gene']:
                     name_modified = True

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -627,7 +627,7 @@ class Record:
         for feature in seq_record.features:
             # biopython drops invalid locations and might leave us with None, catch that first
             if feature.location is None:
-                raise SecmetInvalidInputError("feature is missing location: %s" % feature)
+                raise SecmetInvalidInputError("one or more features with missing or invalid locations")
             if feature.location.end > len(seq_record.seq):
                 raise SecmetInvalidInputError("feature outside record sequence: %s" % feature.location)
 

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -42,6 +42,7 @@ from .features.candidate_cluster import create_candidates_from_protoclusters
 
 from .locations import (
     location_bridges_origin,
+    location_contains_overlapping_exons,
     split_origin_bridging_location,
     combine_locations,
 )
@@ -630,6 +631,8 @@ class Record:
                 raise SecmetInvalidInputError("one or more features with missing or invalid locations")
             if feature.location.end > len(seq_record.seq):
                 raise SecmetInvalidInputError("feature outside record sequence: %s" % feature.location)
+            if location_contains_overlapping_exons(feature.location):
+                raise SecmetInvalidInputError("location contains overlapping exons: %s" % feature.location)
 
             if feature.ref or feature.ref_db:
                 for ref in [feature.ref, feature.ref_db]:

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -678,7 +678,10 @@ class Record:
 
                 # since CDSs need translations, skip if too small or not a CDS
                 if feature.type != "CDS" or len(feature) >= 3:
-                    record.add_biopython_feature(feature)
+                    try:
+                        record.add_biopython_feature(feature)
+                    except ValueError as err:
+                        raise SecmetInvalidInputError(str(err)) from err
 
                 # adjust the current feature to only be the lower section
                 if len(lower) > 1:
@@ -698,7 +701,10 @@ class Record:
                 continue
             # again, since CDSs need translations, skip if too small or not a CDS
             if feature.type != "CDS" or len(feature) >= 3:
-                record.add_biopython_feature(feature)
+                try:
+                    record.add_biopython_feature(feature)
+                except ValueError as err:
+                    raise SecmetInvalidInputError(str(err)) from err
 
             # reset back to how the feature looked originally
             if locations_adjusted:
@@ -712,10 +718,13 @@ class Record:
                         feature.qualifiers.pop("gene", "")
                     else:
                         feature.qualifiers["gene"][0] = original_gene_name
-        for feature in postponed_features[CandidateCluster.FEATURE_TYPE]:
-            record.add_feature(CandidateCluster.from_biopython(feature).convert_to_real_feature(record))
-        for feature in postponed_features["region"]:
-            record.add_feature(Region.from_biopython(feature).convert_to_real_feature(record))
+        try:
+            for feature in postponed_features[CandidateCluster.FEATURE_TYPE]:
+                record.add_feature(CandidateCluster.from_biopython(feature).convert_to_real_feature(record))
+            for feature in postponed_features["region"]:
+                record.add_feature(Region.from_biopython(feature).convert_to_real_feature(record))
+        except ValueError as err:
+            raise SecmetInvalidInputError(str(err)) from err
         return record
 
     @staticmethod

--- a/antismash/common/secmet/test/test_circular_conversion.py
+++ b/antismash/common/secmet/test/test_circular_conversion.py
@@ -11,7 +11,7 @@ from Bio.SeqFeature import SeqFeature
 from Bio.SeqRecord import SeqRecord
 
 from antismash.common.secmet.locations import FeatureLocation, CompoundLocation
-from antismash.common.secmet.record import Record
+from antismash.common.secmet.record import Record, SecmetInvalidInputError
 
 
 class TestBridgeConversion(unittest.TestCase):
@@ -29,11 +29,11 @@ class TestBridgeConversion(unittest.TestCase):
     def test_bridge_in_linear_record(self):
         self.seqrec.annotations["topology"] = "linear"
         self.seqrec.features.append(self.seqcds)
-        with self.assertRaisesRegex(ValueError, "Features that bridge"):
-            Record.from_biopython(self.seqrec, taxon='bacteria')
+        with self.assertRaisesRegex(SecmetInvalidInputError, "cannot determine correct exon ordering"):
+            Record.from_biopython(self.seqrec, taxon='fungi')
         self.seqrec.features[0] = self.seqgene
-        with self.assertRaisesRegex(ValueError, "Features that bridge"):
-            Record.from_biopython(self.seqrec, taxon='bacteria')
+        with self.assertRaisesRegex(SecmetInvalidInputError, "cannot determine correct exon ordering"):
+            Record.from_biopython(self.seqrec, taxon='fungi')
 
     def test_cds_split(self):
         self.seqrec.features.append(self.seqcds)

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -12,6 +12,7 @@ from antismash.common.secmet.locations import (
     location_bridges_origin as is_bridged,
     split_origin_bridging_location as splitter,
     location_contains_other,
+    location_contains_overlapping_exons as overlapping_exons,
     location_from_string,
     locations_overlap,
     combine_locations,
@@ -448,3 +449,24 @@ class TestContainsOther(unittest.TestCase):
 
         compound = build_compound([(10, 20), (20, 40), (50, 60)], strand=1)
         assert not location_contains_other(simple, compound)
+
+
+class TestOverlappingExons(unittest.TestCase):
+    def test_non_compound(self):
+        assert not overlapping_exons(FeatureLocation(10, 40))
+
+    def test_not_overlapping(self):
+        assert not overlapping_exons(build_compound([(10, 30), (40, 70)], strand=1))
+
+    def test_overlapping(self):
+        assert overlapping_exons(build_compound([(10, 30), (20, 30)], strand=1))
+        assert overlapping_exons(build_compound([(10, 30), (70, 100), (20, 30)], strand=1))
+        assert overlapping_exons(build_compound([(70, 100), (20, 30), (10, 30)], strand=1))
+
+    def test_frameshifted(self):
+        assert not overlapping_exons(build_compound([(10, 30), (29, 59)], strand=1))
+
+    def test_bad_types(self):
+        for bad in [None, "loc", [FeatureLocation(10, 40)], 5]:
+            with self.assertRaises(TypeError):
+                overlapping_exons(bad)

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -230,6 +230,10 @@ class TestBridgedSplit(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Location does not bridge origin"):
             print(splitter(loc))
 
+        loc = build_compound([(15, 18), (9, 12), (0, 3)], -1)
+        with self.assertRaisesRegex(ValueError, "Location does not bridge origin"):
+            print(splitter(loc))
+
     def test_bad_strand(self):
         loc = build_compound([(9, 12), (0, 3)], -1)
         loc.parts[0].strand = 1

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -173,6 +173,20 @@ class TestBridgeDetection(unittest.TestCase):
         assert is_bridged(build_compound([(0, 3), (15, 18), (6, 9)], -1))
         assert not is_bridged(build_compound([(9, 12), (0, 3)], -1))
 
+    def test_alternate_orderings(self):
+        loc = build_compound([(0, 3), (6, 9), (12, 15)], -1)
+        assert loc.parts[0].start == 0
+        assert is_bridged(loc)
+        assert loc.parts[0].start == 0
+
+        assert not is_bridged(loc, allow_reversing=True)
+        assert loc.parts[0].start == 12
+
+        loc = build_compound([(12, 15), (6, 9), (0, 3)], -1)
+        assert loc.parts[0].start == 12
+        assert not is_bridged(loc, allow_reversing=True)
+        assert loc.parts[0].start == 12
+
     def test_bad_strand(self):
         pairs = [(9, 12), (0, 3)]
         assert is_bridged(build_compound(pairs, 1))
@@ -181,6 +195,9 @@ class TestBridgeDetection(unittest.TestCase):
     def test_not_bridged(self):
         assert not is_bridged(build_compound([(1, 6), (5, 10)], 1))
         assert not is_bridged(build_compound([(5, 10), (1, 6)], -1))
+
+    def test_indeterminate(self):
+        assert is_bridged(build_compound([(0, 3), (12, 15), (6, 9)], -1), allow_reversing=True)
 
 
 class TestBridgedSplit(unittest.TestCase):

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -220,6 +220,27 @@ class TestBridgedSplit(unittest.TestCase):
         self.check_pairs(lower, [(0, 3)])
         self.check_pairs(upper, [(15, 18), (6, 9)])
 
+    def test_unusable(self):
+        # this format crosses the origin multiple times and can't be interpreted
+        raw_loc_parts = [(0, 3), (6, 9), (12, 15), (18, 21)]
+        # test a variety of badly ordered parts
+        for ordering in [[0, 2, 1, 3], [0, 1, 3, 2], [0, 3, 1, 2]]:
+            # cycle them around to test position independence
+            for i in range(len(ordering)):
+                loc_parts = [raw_loc_parts[i] for i in ordering[i:] + ordering[:i]]
+
+                # forward
+                loc = build_compound(loc_parts, 1)
+                assert is_bridged(loc)
+                with self.assertRaisesRegex(ValueError, "cannot determine correct ordering"):
+                    splitter(loc)
+
+                # reverse
+                loc = build_compound(loc_parts[::-1], -1)
+                assert is_bridged(loc)
+                with self.assertRaisesRegex(ValueError, "cannot determine correct ordering"):
+                    splitter(loc)
+
     def test_not_bridging_forward(self):
         loc = build_compound([(0, 3), (9, 12)], 1)
         with self.assertRaisesRegex(ValueError, "Location does not bridge origin"):

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -85,7 +85,7 @@ class TestConversion(unittest.TestCase):
         rec = list(Bio.SeqIO.parse(get_path_to_nisin_genbank(), "genbank"))[0]
         Record.from_biopython(rec, taxon="bacteria")
         rec.features.append(SeqFeature(None, type="broken"))
-        with self.assertRaisesRegex(SecmetInvalidInputError, "feature is missing location"):
+        with self.assertRaisesRegex(SecmetInvalidInputError, "missing or invalid location"):
             Record.from_biopython(rec, taxon="bacteria")
 
 

--- a/antismash/common/test/test_gff_parser.py
+++ b/antismash/common/test/test_gff_parser.py
@@ -39,8 +39,7 @@ class GffParserTest(TestCase):
 
     def test_features_from_file(self):
         filename = path.get_full_path(__file__, 'data', 'fumigatus.cluster1.gff')
-        record = DummyRecord()
-        features = gff_parser.get_features_from_file(record, open(filename))
+        features = gff_parser.get_features_from_file(open(filename))
         assert len(features) == 11
         for feature in features:
             assert feature.type == 'CDS'

--- a/antismash/common/test/test_record_processing.py
+++ b/antismash/common/test/test_record_processing.py
@@ -239,7 +239,7 @@ class TestPreprocessRecords(unittest.TestCase):
         fasta = path.get_full_path(__file__, "data", "nisin.fasta")
         gff = path.get_full_path(__file__, "data", "nisin.gff3")
         config.update_config({"genefinding_gff3": gff})
-        records = record_processing.parse_input_sequence(fasta)
+        records = record_processing.parse_input_sequence(fasta, gff_file=gff)
         record_processing.pre_process_sequences(records, self.options, self.genefinding)
         assert not self.genefinding.was_run
         assert len(records[0].get_cds_features()) == 11

--- a/antismash/detection/genefinding/run_glimmerhmm.py
+++ b/antismash/detection/genefinding/run_glimmerhmm.py
@@ -60,6 +60,6 @@ def run_glimmerhmm(record: Record) -> None:
         return
 
     handle = StringIO(results_text)
-    features = get_features_from_file(record, handle)
+    features = get_features_from_file(handle)
     for feature in features:
         record.add_biopython_feature(feature)

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -447,7 +447,8 @@ def read_data(sequence_file: Optional[str], options: ConfigType) -> serialiser.A
 
     if sequence_file:
         records = record_processing.parse_input_sequence(sequence_file, options.taxon,
-                                options.minlength, options.start, options.end)
+                                options.minlength, options.start, options.end,
+                                gff_file=options.genefinding_gff3)
         results = serialiser.AntismashResults(sequence_file.rsplit(os.sep, 1)[-1],
                                               records, [{} for i in records],
                                               __version__, taxon=options.taxon)


### PR DESCRIPTION
Some input errors weren't properly being wrapped as input errors for the purposes of logging. Some inputs were also not being caught as errors.

New constraints:
- exons can no longer overlap beyond a single amino frameshift
- only two (CDS and gene) features can cross the origin in a circular record
- no features can cross the origin in a linear record
- features must be fully contained by the provided sequence

Better reporting:
- completely unordered exons are caught instead of reporting a split location as crossing the origin after that stage of processing was complete
- all known input errors are now logged (I'm sure there'll be something, somewhere that still sneaks through)
- error messages for features missing locations now include "invalid" in the message, since Biopython likes to strip invalid locations without raising an error

Relaxed constraints:
- reverse strand exons could be in ascending order instead of descending for some annotation pipelines, this is now allowed if consistently used
- circular records provided as a FASTA + GFF combination can now have cross-origin features

GFF parsing was moved to pre-secmet conversion of records for simplified validation. Some other redundant checks were removed at the same time (e.g. CDS naming uniqueness checks after conversion to a secmet Record).