### PR TITLE
Convert more biopython warnings to exceptions

### DIFF
--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -48,6 +48,7 @@ def _strict_parse(filename: str) -> List[SeqRecord]:
     filter_messages = [
         r".*invalid location.*",
         r".*Expected sequence length.*",
+        r".*Couldn't parse feature location.*",
     ]
     try:
         # prepend warning filters to raise exceptions on certain messages


### PR DESCRIPTION
- refactors the new strict parsing into a separate function
- adds the biopython warning `Couldn't parse feature location: 'omplement(23931..28567)'` to the list of warnings raised as exceptions