### PR TITLE
Fix executable missing paths being present in config object

### DIFF
--- a/antismash/config/executables.py
+++ b/antismash/config/executables.py
@@ -22,10 +22,14 @@ _ALTERNATE_EXECUTABLE_NAMES = {
         "hmm2pfam",  # debian/ubuntu default
         "hmmpfam2",  # general
     ],
+    "fasttree": [
+        "fasttree",  # general
+        "Fasttree",  # as per install from source instructions
+    ],
 }
 
 _NO_KNOWN_ALTS = ["hmmsearch", "hmmpress", "hmmscan", "meme", "fimo", "glimmerhmm",
-                  "prodigal", "muscle", "fasttree", "java", "blastp", "makeblastdb"]
+                  "prodigal", "muscle", "java", "blastp", "makeblastdb"]
 for _binary in _NO_KNOWN_ALTS:
     assert _binary not in _ALTERNATE_EXECUTABLE_NAMES, _binary
     _ALTERNATE_EXECUTABLE_NAMES[_binary] = [_binary]

--- a/antismash/config/executables.py
+++ b/antismash/config/executables.py
@@ -60,7 +60,8 @@ def get_default_paths() -> Dict[str, str]:
             path = find_executable_path(alternate)
             if path:
                 break
-        binaries[name] = path
+        if path:
+            binaries[name] = path
     return binaries
 
 

--- a/antismash/config/test/test_executables.py
+++ b/antismash/config/test/test_executables.py
@@ -4,6 +4,7 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=no-self-use,protected-access,missing-docstring
 
+from collections import OrderedDict
 import os
 import unittest
 from unittest.mock import patch
@@ -44,4 +45,10 @@ class TestGetPaths(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "cannot find"):
             executables.get_executable_paths("diamond=wrong_alias")
 
-    # test mulitple args don't override
+    @patch.object(executables, "_ALTERNATE_EXECUTABLE_NAMES",
+                  OrderedDict([("missing", ["missing"]), ("found", ["found"])]))
+    @patch.object(executables, "find_executable_path", side_effect=["", "/found"])
+    def test_missing_default_path(self, _mocked_find):
+        defaults = executables.get_default_paths()
+        assert "missing" not in defaults
+        assert defaults["found"] == "/found"


### PR DESCRIPTION
Also adds `Fasttree` as an alternative binary name, since that's what their own install/compile instructions use.

Fixes both the false positive prereq check and the binary naming from #157 