### PR TITLE
Style pass

### DIFF
--- a/antismash/common/secmet/features/subregion.py
+++ b/antismash/common/secmet/features/subregion.py
@@ -15,11 +15,11 @@ class SubRegion(CDSCollection):
     """ A feature which marks a specific region of a record as interesting,
         without being considered a cluster.
     """
-    def __init__(self, location: FeatureLocation, tool: str, probability: float = None, anchor: str = "") -> None:
+    def __init__(self, location: FeatureLocation, tool: str, probability: float = None, label: str = "") -> None:
         super().__init__(location, feature_type="subregion")
         self.tool = tool
         self.probability = probability
-        self.anchor = anchor  # if anchored to a gene/CDS, this is the name
+        self.label = label  # if anchored to a gene/CDS, this is the name
 
     def get_subregion_number(self) -> int:
         """ Returns the subregion's numeric ID, only guaranteed to be consistent
@@ -37,8 +37,8 @@ class SubRegion(CDSCollection):
         qualifiers["aStool"] = [self.tool]
         if self.probability is not None:
             qualifiers["probability"] = [str(self.probability)]
-        if self.anchor:
-            qualifiers["anchor"] = [self.anchor]
+        if self.label:
+            qualifiers["label"] = [self.label]
         return super().to_biopython(qualifiers)
 
     @staticmethod
@@ -51,9 +51,11 @@ class SubRegion(CDSCollection):
         probability = None
         if "probability" in leftovers:
             probability = float(leftovers.pop("probability")[0])
-        anchor = leftovers.pop("anchor", [""])[0]
+        label = leftovers.pop("label", [""])[0]
+        if not label:
+            label = leftovers.pop("anchor", [""])[0]  # backwards compatibility
         if not feature:
-            feature = SubRegion(bio_feature.location, tool, probability, anchor)
+            feature = SubRegion(bio_feature.location, tool, probability, label)
 
         # remove the subregion_number, as it's not relevant
         leftovers.pop("subregion_number", "")

--- a/antismash/common/secmet/features/test/test_subregion.py
+++ b/antismash/common/secmet/features/test/test_subregion.py
@@ -19,8 +19,8 @@ class TestSubRegion(unittest.TestCase):
 
     def test_anchor(self):
         loc = FeatureLocation(0, 10)
-        assert SubRegion(loc, tool="test").anchor == ""
-        assert SubRegion(loc, tool="test", anchor="anch").anchor == "anch"
+        assert SubRegion(loc, tool="test").label == ""
+        assert SubRegion(loc, tool="test", label="anch").label == "anch"
 
     def test_orphaned(self):
         sub = SubRegion(FeatureLocation(0, 10), tool="test")

--- a/antismash/common/secmet/test/helpers.py
+++ b/antismash/common/secmet/test/helpers.py
@@ -114,10 +114,10 @@ class DummyRegion(Region):
 
 class DummySubRegion(SubRegion):
     def __init__(self, start=0, end=10, location=None, tool="test",
-                 anchor="test_anchor", probability=0.):
+                 label="test_label", probability=0.):
         if location is None:
             location = FeatureLocation(start, end)
-        super().__init__(location, anchor=anchor, tool=tool, probability=probability)
+        super().__init__(location, label=label, tool=tool, probability=probability)
 
 
 class DummyCandidateCluster(CandidateCluster):

--- a/antismash/detection/cassis/__init__.py
+++ b/antismash/detection/cassis/__init__.py
@@ -86,8 +86,6 @@ class CassisResults(module_results.DetectionResults):
     def get_predicted_subregions(self) -> List[SubRegion]:
         # for the purposes of the record, don't return all possible matches,
         # only return non-contained ones
-        for sub in self.subregions:
-            print(sub.location, sub.anchor)
         return filter_subregions(self.subregions)
 
 
@@ -348,14 +346,10 @@ def filter_subregions(subregions: List[SubRegion]) -> List[SubRegion]:
     # any sharing an anchor will overlap on that gene anyway
     for sub in sorted(subregions, key=lambda x: x.location.end - x.location.start, reverse=True):
         contained = False
-        print(sub, sub.anchor)
         for other in by_anchor[sub.anchor]:
             if sub.is_contained_by(other):
-                print(sub, sub.anchor, "contained by", other, other.anchor)
                 contained = True
                 break
-            else:
-                print(sub, sub.anchor, "not contained by", other, other.anchor)
         if not contained:
             by_anchor[sub.anchor].append(sub)
     # flatten the lists and sort back into location order, then anchor

--- a/antismash/detection/cassis/__init__.py
+++ b/antismash/detection/cassis/__init__.py
@@ -346,16 +346,16 @@ def filter_subregions(subregions: List[SubRegion]) -> List[SubRegion]:
     # any sharing an anchor will overlap on that gene anyway
     for sub in sorted(subregions, key=lambda x: x.location.end - x.location.start, reverse=True):
         contained = False
-        for other in by_anchor[sub.anchor]:
+        for other in by_anchor[sub.label]:
             if sub.is_contained_by(other):
                 contained = True
                 break
         if not contained:
-            by_anchor[sub.anchor].append(sub)
+            by_anchor[sub.label].append(sub)
     # flatten the lists and sort back into location order, then anchor
     # mypy doesn't handle this reduce well
     flattened = reduce(operator.concat, by_anchor.values())  # type: ignore
-    return sorted(flattened, key=lambda x: (x.location.start, x.location.end, x.anchor))
+    return sorted(flattened, key=lambda x: (x.location.start, x.location.end, x.label))
 
 
 def create_subregions(anchor: str, cluster_preds: List[ClusterPrediction],
@@ -385,7 +385,7 @@ def create_subregions(anchor: str, cluster_preds: List[ClusterPrediction],
             FeatureLocation(left.location.start, right.location.end), type="subregion")
         new_feature.qualifiers = {
             "aStool": ["cassis"],
-            "anchor": [anchor],
+            "label": [anchor],
             "abundance": [cluster.start.abundance + cluster.end.abundance],
             "motif_score": ["{:.1e}".format(cluster.start.score + cluster.end.score)],
             "gene_left": [cluster.start.gene],

--- a/antismash/detection/cassis/test/test_cassis.py
+++ b/antismash/detection/cassis/test/test_cassis.py
@@ -252,7 +252,7 @@ class TestCassisStorageMethods(unittest.TestCase):
             subregion = record_with_subregions.get_subregions()[i]
             self.assertEqual(subregion.type, "subregion")
             self.assertEqual(subregion.tool, "cassis")
-            self.assertEqual(subregion.anchor, anchor)
+            self.assertEqual(subregion.label, anchor)
             self.assertEqual(subregion.get_qualifier("genes"), (region.genes,))
             self.assertEqual(subregion.get_qualifier("promoters"), (region.promoters,))
             self.assertEqual(subregion.get_qualifier("gene_left"), (region.start.gene,))
@@ -262,7 +262,7 @@ class TestCassisStorageMethods(unittest.TestCase):
 
 class TestSubRegionFiltering(unittest.TestCase):
     def create_sub(self, start, end, anchor):
-        return secmet.SubRegion(FeatureLocation(start, end), anchor=anchor, tool="cassis")
+        return secmet.SubRegion(FeatureLocation(start, end), label=anchor, tool="cassis")
 
     def test_empty(self):
         assert cassis.filter_subregions([]) == []

--- a/antismash/outputs/html/js.py
+++ b/antismash/outputs/html/js.py
@@ -183,7 +183,7 @@ def get_clusters_from_region_parts(candidate_clusters: Iterable[CandidateCluster
                       "tool": subregion.tool,
                       "neighbouring_start": subregion.location.start,
                       "neighbouring_end": subregion.location.end,
-                      "product": subregion.anchor,
+                      "product": subregion.label,
                       "height": start_index}
         js_clusters.append(js_cluster)
 


### PR DESCRIPTION
- removes a bunch of print statements that were left behind in CASSIS at some point
- changes `SubRegion`'s  `anchor` attribute/parameter to `label` to be more generic, since incoming sideloaded annotations and `anchor` don't really make sense