### PR TITLE
NRPS/PKS classification and annotation fixes

### DIFF
--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -272,6 +272,7 @@ class CDSFeature(Feature):
         gene_functions = leftovers.pop("gene_functions", [])
         if gene_functions:
             feature.gene_functions.add_from_qualifier(gene_functions)
+        feature.nrps_pks.add_from_qualifier(leftovers.pop("NRPS_PKS", []))
 
         # grab parent optional qualifiers
         super(CDSFeature, feature).from_biopython(bio_feature, feature=feature, leftovers=leftovers)
@@ -293,6 +294,8 @@ class CDSFeature(Feature):
             mine["gene_kind"] = [str(self.gene_function)]
         if self.sec_met:
             mine["sec_met_domain"] = list(map(str, self.sec_met))
+        if self.nrps_pks:
+            mine["NRPS_PKS"] = list(map(str, self.nrps_pks))
         # respect qualifiers given to us
         if qualifiers:
             mine.update(qualifiers)

--- a/antismash/common/secmet/qualifiers/test/test_nrpspks.py
+++ b/antismash/common/secmet/qualifiers/test/test_nrpspks.py
@@ -43,3 +43,22 @@ class TestNRPSPKS(unittest.TestCase):
         assert len(qualifier) == 4
         for i in qualifier:
             assert isinstance(i, str)
+
+    def test_biopython_conversion(self):
+        qualifier = NRPSPKSQualifier(strand=1)
+        for pks in ["PKS_AT", "AMP-binding"]:
+            qualifier.add_domain(HMMResult(pks, 1, 1, 1, 1), "missing")
+            qualifier.add_subtype(pks + "dummy")
+        qualifier.type = "some type"
+
+        bio = list(qualifier)
+        for val in bio:
+            assert isinstance(val, str)
+
+        new = NRPSPKSQualifier(strand=1)
+        new.add_from_qualifier(bio)
+        assert list(qualifier) == list(new)
+
+        for bad in [["mismatching info"], ["Domain: missing info"]]:
+            with self.assertRaisesRegex(ValueError, "unknown NRPS/PKS qualifier|could not match"):
+                new.add_from_qualifier(bad)

--- a/antismash/detection/nrps_pks_domains/domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/domain_identification.py
@@ -270,7 +270,7 @@ def classify_cds(domain_names: List[str], ks_domain_subtypes: List[str]) -> str:
                                          "Condensation_Dual", "AMP-binding"})
     if not pks_domains and not nrps_domains:
         classification = "other"
-    elif {"Cglyc", "Epimerization", "AMP-binding"} in domains and not pks_domains:
+    elif {"Cglyc", "Epimerization", "AMP-binding"}.issubset(domains) and not pks_domains:
         classification = "Glycopeptide NRPS"
     elif len(nrps_domains) >= 2 and "AMP-binding" in domains:
         if pks_domains:

--- a/antismash/detection/nrps_pks_domains/test/integration_domains.py
+++ b/antismash/detection/nrps_pks_domains/test/integration_domains.py
@@ -27,7 +27,7 @@ class TestAnalyses(unittest.TestCase):
 
         expected_types = {'bpsC': 'NRPS', 'pks': 'other', 'bpsD': 'NRPS-like protein',
                           'dpgD': 'other', 'pgat': 'other', 'dpgB': 'other',
-                          'bpsA': 'NRPS', 'bpsB': 'NRPS', 'dpgC': 'other'}
+                          'bpsA': 'Glycopeptide NRPS', 'bpsB': 'Glycopeptide NRPS', 'dpgC': 'other'}
 
         for cds, cds_result in results.cds_results.items():
             assert isinstance(cds_result, nrps_pks_domains.domain_identification.CDSResult)

--- a/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
@@ -114,6 +114,18 @@ class TestCDSClassification(unittest.TestCase):
         # three KS, but mod is most
         assert self.func(["PKS_AT"] + ["PKS_KS"]*3, ["Modular-KS"]*3) == mod
 
+    def test_glycopeptide(self):
+        glyc = "Glycopeptide NRPS"
+        base = ["Cglyc", "Epimerization", "AMP-binding"]
+        assert self.func(base) == glyc
+        assert self.func(base + ["PKS_KS"]) != glyc
+        assert self.func(base + ["PKS_AT"]) != glyc
+
+        # all three domains have to be present
+        assert self.func(base[1:]) != glyc
+        assert self.func(base[::2]) != glyc
+        assert self.func(base[:-1]) != glyc
+
 
 class TestKSCounter(unittest.TestCase):
     def setUp(self):

--- a/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
@@ -55,6 +55,66 @@ class TestTerminalRemoval(unittest.TestCase):
             print(results)
             assert results[self.cds.locus_tag] == hits
 
+
+class TestCDSClassification(unittest.TestCase):
+    def func(self, domains, ks_subtypes=None):
+        return domain_identification.classify_cds(domains, ks_subtypes or [])
+
+    def test_other(self):
+        assert self.func(["notPKS", "notNRPS"]) == "other"
+
+    def test_nrps_like(self):
+        assert self.func(["AMP-binding", "PKS_KS"]) == "PKS/NRPS-like protein"
+        assert self.func(["Condensation_Starter", "PKS_KS"]) == "PKS/NRPS-like protein"
+
+    def test_hybrid(self):
+        assert self.func(["AMP-binding", "Condensation_LCL", "PKS_KS"]) == "Hybrid PKS-NRPS"
+
+    def test_nrps(self):
+        assert self.func(["AMP-binding", "Condensation_LCL"]) == "NRPS"
+
+    def test_trans_at(self):
+        trans = "Type I Trans-AT PKS"
+        base = ["PKS_KS", "Trans-AT_docking"]
+        assert self.func(base) != trans
+        assert self.func(base + ["PKS_KS"], ["Trans-AT-KS", "Modular-KS"]) != trans
+        assert self.func(base, ["Trans-AT-KS"]) == trans
+        assert self.func(base + ["PKS_AT"], ["Trans-AT-KS"]) != trans
+
+    def test_iterative(self):
+        iterative = "Type I Iterative PKS"
+        # missing AT
+        assert self.func(["PKS_KS"], ["Iterative-KS"]) != iterative
+        # too many KS domains
+        assert self.func(["PKS_KS"]*3, ["Iterative-KS"]*3) != iterative
+        # iterative isn't most common
+        assert self.func(["PKS_AT"] + ["PKS_KS"]*2, ["Iterative-KS", "Modular-KS"]) != iterative
+
+        assert self.func(["PKS_KS", "PKS_AT"], ["Iterative-KS"]) == iterative
+        assert self.func(["PKS_AT"] + ["PKS_KS"]*2, ["Iterative-KS"]*2) == iterative
+
+    def test_enediyne(self):
+        ene = "Type I Enediyne PKS"
+        # missing AT
+        assert self.func(["PKS_KS"], ["Enediyne-KS"]) != ene
+        # too many KS domains
+        assert self.func(["PKS_AT"] + ["PKS_KS"]*3, ["Enediyne-KS"]*3) != ene
+        # ene isn't most common
+        assert self.func(["PKS_AT"] + ["PKS_KS"]*2, ["Enediyne-KS", "Modular-KS"]) != ene
+
+        assert self.func(["PKS_KS", "PKS_AT"], ["Enediyne-KS"]) == ene
+        assert self.func(["PKS_AT"] + ["PKS_KS"]*2, ["Enediyne-KS"]*2) == ene
+
+    def test_modular(self):
+        mod = "Type I Modular PKS"
+        # missing AT
+        assert self.func(["PKS_KS"], ["Enediyne-KS"]) != mod
+        # more than three KS, regardless of type
+        assert self.func(["PKS_AT"] + ["PKS_KS"]*4, ["Enediyne-KS"]*4) == mod
+        # three KS, but mod is most
+        assert self.func(["PKS_AT"] + ["PKS_KS"]*3, ["Modular-KS"]*3) == mod
+
+
 class TestKSCounter(unittest.TestCase):
     def setUp(self):
         self.counter = domain_identification.KetosynthaseCounter

--- a/antismash/modules/nrps_pks/test/test_orderfinder.py
+++ b/antismash/modules/nrps_pks/test/test_orderfinder.py
@@ -213,7 +213,7 @@ class TestEnzymeCounter(unittest.TestCase):
             gene.nrps_pks = DummyNRPSQualfier()
             gene.nrps_pks.domain_names = all_domains[gene.get_name()]
             if not types:
-                gene.nrps_pks.type = domain_identification.classify_cds(all_domains[gene.get_name()])
+                gene.nrps_pks.type = domain_identification.classify_cds(all_domains[gene.get_name()], [])
             else:
                 gene.nrps_pks.type = types[gene.get_name()]
         results = orderfinder.find_candidate_cluster_modular_enzymes(genes)


### PR DESCRIPTION
The NRPS/PKS secmet qualifier was never being annotated into genbank outputs, this fixes that.

Along the way, other issues were found that were also fixed:
- the glycopeptide NRPS classification would never be made due to a bad comparison for a subset
- specific kinds of KS domains were never detected because the function was never called
- the `run_and_regenerate` helper for integration tests wasn't using the `Record.strip_antismash_annotations` method, which skipped clearing of NRPS/PKS qualifiers and other some other annotations

An example of the newly annotated NRPS/PKS qualifiers in genbank format ():
```
     CDS             ...
                     /NRPS_PKS="Domain: PKS_KS (36-412). E-value: 1.8e-135.
                     Score: 443.8. Matches aSDomain:
                     nrpspksdomains_AFUA_1G17740_PKS_KS.1"
                     /NRPS_PKS="Domain: PKS_AT (552-809). E-value: 5.2e-73.
                     Score: 237.7. Matches aSDomain:
                     nrpspksdomains_AFUA_1G17740_PKS_AT.1"
                     /NRPS_PKS="Domain: cMT (1241-1448). E-value: 1.2e-70.
                     Score: 229.4. Matches aSDomain:
                     nrpspksdomains_AFUA_1G17740_cMT.1"
                     /NRPS_PKS="Domain: PKS_KR (1927-2102). E-value: 1.4e-39.
                     Score: 127.6. Matches aSDomain:
                     nrpspksdomains_AFUA_1G17740_PKS_KR.1"
                     /NRPS_PKS="type: Type I Iterative PKS" 
```