### PR TITLE
Genbank fixes

### DIFF
--- a/antismash/common/secmet/features/protocluster.py
+++ b/antismash/common/secmet/features/protocluster.py
@@ -92,6 +92,8 @@ class Protocluster(CDSCollection):
         core_feature = SeqFeature(self.core_location, type=self.core_seqfeature_type)
         for key, val in sorted(core_qualifiers.items()):
             core_feature.qualifiers[key] = val
+            # this doesn't go through to the Feature annotations, so add the tool explicitly
+            core_feature.qualifiers["tool"] = ["antismash"]
 
         shared_qualifiers["core_location"] = [str(self.core_location)]
         neighbourhood_feature = super().to_biopython(shared_qualifiers)[0]

--- a/antismash/common/secmet/features/region.py
+++ b/antismash/common/secmet/features/region.py
@@ -214,18 +214,18 @@ class Region(CDSCollection):
                 candidates = feature.qualifiers.get("candidate_cluster_numbers")
                 if not candidates:
                     continue
-                candidates = [str(int(num) - first_candidate_cluster) for num in candidates]
+                candidates = [str(int(num) - first_candidate_cluster + 1) for num in candidates]
                 feature.qualifiers["candidate_cluster_numbers"] = candidates
             elif feature.type == CandidateCluster.FEATURE_TYPE:
-                new = str(int(feature.qualifiers["candidate_cluster_number"][0]) - first_candidate_cluster)
+                new = str(int(feature.qualifiers["candidate_cluster_number"][0]) - first_candidate_cluster + 1)
                 feature.qualifiers["candidate_cluster_number"] = [new]
-                new_clusters = [str(int(num) - first_cluster) for num in feature.qualifiers["protoclusters"]]
+                new_clusters = [str(int(num) - first_cluster + 1) for num in feature.qualifiers["protoclusters"]]
                 feature.qualifiers["protoclusters"] = new_clusters
             elif feature.type in ["protocluster", "proto_core"]:
-                new = str(int(feature.qualifiers["protocluster_number"][0]) - first_cluster)
-                feature.qualifiers["cluster_number"] = [new]
+                new = str(int(feature.qualifiers["protocluster_number"][0]) - first_cluster + 1)
+                feature.qualifiers["protocluster_number"] = [new]
             elif feature.type == "subregion":
-                new = str(int(feature.qualifiers["subregion_number"][0]) - first_subregion)
+                new = str(int(feature.qualifiers["subregion_number"][0]) - first_subregion + 1)
                 feature.qualifiers["subregion_number"] = [new]
 
         seqio.write([cluster_record], filename, 'genbank')


### PR DESCRIPTION
- regions were changing from 1-index to 0-index feature numbering when adjusting for the region-specific details
- protocluster cores were missing the tool=antismash qualifier that meant they weren't properly being treated as a feature created by antismash on parsing