### PR TITLE
Misc fixes

### DIFF
--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -66,6 +66,9 @@ def _strict_parse(filename: str) -> List[SeqRecord]:
         # remove the new warning filters (functions in at least 3.5 and 3.6)
         # since mypy doesn't recognise this attribute, ignore the type
         warnings.filters = warnings.filters[len(filter_messages):]   # type: ignore
+
+    if not records:
+        raise AntismashInputError("no valid records found in file %s" % filename)
     return records
 
 
@@ -101,7 +104,7 @@ def parse_input_sequence(filename: str, taxon: str = "bacteria", minimum_length:
 
     # if no records are left, that's a problem
     if not records:
-        raise AntismashInputError("no valid records found in file %r" % filename)
+        raise AntismashInputError("all input records smaller than minimum length (%d)" % minimum_length)
 
     for record in records:
         if isinstance(record.seq.alphabet, Bio.Alphabet.ProteinAlphabet) or not is_nucl_seq(record.seq):

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -452,7 +452,9 @@ def trim_sequence(record: SeqRecord, start: int, end: int) -> SeqRecord:
         start = 0
     if end < 0:
         end = len(record)
-    return record[start:end]
+    new = record[start:end]
+    new.annotations = record.annotations  # preserve old annotations that biopython ignores
+    return new
 
 
 def is_nucl_seq(sequence: Union[Seq, str]) -> bool:

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -115,6 +115,9 @@ def parse_input_sequence(filename: str, taxon: str = "bacteria", minimum_length:
         except AntismashInputError:
             raise
         except Exception as err:
+            # avoid swallowing details if possible
+            if str(err):
+                logging.error(err)
             raise AntismashInputError("could not parse records from GFF3 file") from err
         gff_features = gff_parser.run(gff_file)
         for record in records:

--- a/antismash/common/secmet/features/protocluster.py
+++ b/antismash/common/secmet/features/protocluster.py
@@ -33,6 +33,8 @@ class Protocluster(CDSCollection):
         super().__init__(surrounding_location, feature_type="protocluster")
         # cluster-wide
         self.detection_rule = detection_rule
+        if not product.replace("-", "").replace("_", "").isalnum() or product[0] in "-_" or product[-1] in "-_":
+            raise ValueError("invalid protocluster product: %s" % product)
         self.product = product
         self.tool = tool
 

--- a/antismash/common/secmet/features/test/test_protocluster.py
+++ b/antismash/common/secmet/features/test/test_protocluster.py
@@ -99,3 +99,12 @@ class TestDefinitionCDS(unittest.TestCase):
         self.add_core_function(self.outside_cds, cluster_product=False)
         with self.assertRaisesRegex(ValueError, "not contained by"):
             self.cluster.add_cds(self.outside_cds)
+
+
+class TestConstruction(unittest.TestCase):
+    def test_product(self):
+        loc = FeatureLocation(1, 6, strand=1)
+        for bad in ["-", "-like", "NRPS-", "NRPS PKS", "NRPS/PKS", "NRPS,PKS", "NRPS.PKS"]:
+            with self.assertRaisesRegex(ValueError, "invalid protocluster product"):
+                Protocluster(loc, loc, tool="test", cutoff=17, neighbourhood_range=5,
+                             product=bad, detection_rule="some rule text")

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -60,9 +60,11 @@ class Record:
                  "_subregions", "_subregion_numbering",
                  "_regions", "_region_numbering"]
 
-    def __init__(self, seq: str = "", transl_table: int = 1, **kwargs: Any) -> None:
+    def __init__(self, seq: Union[Seq, str] = "", transl_table: int = 1, **kwargs: Any) -> None:
         # prevent paths from being used as a sequence
         assert not set("./\\").issubset(set(seq)), "Invalid sequence provided"
+        if isinstance(seq, str):
+            seq = Seq(seq)
         self._record = SeqRecord(seq, **kwargs)
         self.record_index = None  # type: Optional[int]
         self.original_id = None

--- a/antismash/common/secmet/test/helpers.py
+++ b/antismash/common/secmet/test/helpers.py
@@ -75,7 +75,7 @@ class DummyFeature(Feature):
 
 class DummyProtocluster(Protocluster):
     def __init__(self, start=None, end=None, core_start=0, core_end=1,  # pylint: disable=too-many-arguments
-                 core_location=None, tool="test", product="test product",
+                 core_location=None, tool="test", product="test-product",
                  cutoff=10, neighbourhood_range=10, high_priority_product=True):
         if core_location is None:
             core_location = FeatureLocation(core_start, core_end)

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -335,6 +335,13 @@ class TestRecord(unittest.TestCase):
         for i, motif in enumerate(motifs):
             assert motif.domain_id == "non_aS_motif_0_6_%s" % (i + 1)
 
+    def test_seq_types(self):
+        first = Record("A" * 20)
+        assert isinstance(first.seq, Seq)
+        second = Record(Seq("A" * 20))
+        assert isinstance(second.seq, Seq)
+        assert first.seq == second.seq
+
 
 class TestCDSFetchByLocation(unittest.TestCase):
     def setUp(self):

--- a/antismash/common/test/helpers.py
+++ b/antismash/common/test/helpers.py
@@ -41,8 +41,6 @@ def get_simple_options(module, args):
 class DummyRecord(Record):
     "class for generating a Record like data structure"
     def __init__(self, features=None, seq='FAKESEQ', taxon='bacteria'):
-        if isinstance(seq, str):
-            seq = Seq(seq)
         super().__init__(seq, transl_table=11 if taxon == 'bacteria' else 1)
         if features:
             for feature in features:

--- a/antismash/common/test/test_gff_parser.py
+++ b/antismash/common/test/test_gff_parser.py
@@ -22,20 +22,21 @@ class GffParserTest(TestCase):
         self.sequences = [contig1, contig2]
 
     def test_run(self):
-        first = gff_parser.run("CONTIG_1", self.single_entry, self.gff_file)
+        results = gff_parser.run(self.gff_file)
+        first = results["CONTIG_1"]
         assert len(first) == 1
         assert isinstance(first[0], SeqFeature)
 
-        assert not gff_parser.run("CONTIG_2", self.single_entry, self.gff_file)
+        assert "CONTIG_2" not in results
 
     def test_top_level_cds(self):
         self.gff_file = path.get_full_path(__file__, "data", "single_cds.gff")
-        cds_features = gff_parser.run("CONTIG_1", self.single_entry, self.gff_file)
+        cds_features = gff_parser.run(self.gff_file)["CONTIG_1"]
         assert len(cds_features) == 1
 
     def test_features_from_file(self):
         filename = path.get_full_path(__file__, 'data', 'fumigatus.cluster1.gff')
-        features = gff_parser.get_features_from_file(open(filename))
+        features = gff_parser.get_features_from_file(open(filename))["cluster0"]
         assert len(features) == 11
         for feature in features:
             assert feature.type == 'CDS'
@@ -48,10 +49,8 @@ class GffParserTest(TestCase):
             gff_parser.check_gff_suitability(self.gff_file, self.sequences)
 
         self.sequences[0].id = "CONTIG_1"
-        cdses = gff_parser.run("CONTIG_1", self.single_entry, self.gff_file)
-        self.sequences[0].features.extend(cdses)
-        assert not gff_parser.check_gff_suitability(self.gff_file, self.sequences)
+        gff_parser.check_gff_suitability(self.gff_file, self.sequences)
 
         # test force correlation
         self.sequences = self.sequences[1:]  # CONTIG_2
-        assert gff_parser.check_gff_suitability(self.gff_file, self.sequences)
+        gff_parser.check_gff_suitability(self.gff_file, self.sequences)

--- a/antismash/common/test/test_record_processing.py
+++ b/antismash/common/test/test_record_processing.py
@@ -46,7 +46,7 @@ class TestParseRecords(unittest.TestCase):
                                                          minimum_length=15016)
         assert len(records) == 1
 
-        with self.assertRaisesRegex(AntismashInputError, "no valid records found"):
+        with self.assertRaisesRegex(AntismashInputError, "smaller than minimum length"):
             record_processing.parse_input_sequence(nisin_path, minimum_length=15017)
 
         for bad_len in [5.6, None, "5"]:

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -505,7 +505,7 @@ def advanced_options() -> ModuleArgs:
     group.add_option('--reuse-results',
                      dest='reuse_results',
                      type=str,
-                     action=FullPathAction,
+                     action=ReadableFullPathAction,
                      default="",
                      metavar="PATH",
                      help="Use the previous results from the specified json datafile")
@@ -533,6 +533,7 @@ def advanced_options() -> ModuleArgs:
                      dest='database_dir',
                      default=os.path.join(os.path.dirname(os.path.dirname(__file__)), 'databases'),
                      metavar="PATH",
+                     action=FullPathAction,
                      type=str,
                      help="Root directory of the databases (default: %(default)s).")
     group.add_option('--write-config-file',
@@ -575,6 +576,7 @@ def debug_options() -> ModuleArgs:
                      dest='logfile',
                      default="",
                      metavar="PATH",
+                     action=FullPathAction,
                      type=str,
                      help="Also write logging output to a file.")
     group.add_option('--list-plugins',

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -253,6 +253,18 @@ class FullPathAction(argparse.Action):  # pylint: disable=too-few-public-methods
         setattr(namespace, self.dest, os.path.abspath(values))
 
 
+class ReadableFullPathAction(FullPathAction):
+    """ An argparse.Action to ensure provided paths are absolute. """
+    def __call__(self, parser: argparse.ArgumentParser, namespace: argparse.Namespace,  # type: ignore
+                 values: AnyStr, option_string: str = None) -> None:
+        path = os.path.abspath(values)
+        if not os.path.isfile(path):
+            raise argparse.ArgumentError(self, "%s does not exist" % values)
+        if not os.access(path, os.R_OK):
+            raise argparse.ArgumentError(self, "%s: permission denied" % values)
+        super().__call__(parser, namespace, values, option_string)
+
+
 class ModuleArgs:
     """ The vehicle for adding module specific arguments in sane groupings.
         Each module should have a unique prefix for their arguments, for clarity

--- a/antismash/config/test/test_args.py
+++ b/antismash/config/test/test_args.py
@@ -16,9 +16,14 @@ from antismash.config import get_config, update_config, destroy_config, executab
 from antismash.config import args
 
 
+def raise_not_exit(message):
+    raise ValueError(message)
+
+
 class TestConfig(unittest.TestCase):
     def setUp(self):
         self.core_parser = args.build_parser()
+        self.core_parser.error = raise_not_exit
         modules = get_all_modules()
         self.default_parser = args.build_parser(modules=modules)
 
@@ -26,7 +31,7 @@ class TestConfig(unittest.TestCase):
         destroy_config()
 
     def test_invalid_args(self):
-        with self.assertRaises(SystemExit):
+        with self.assertRaisesRegex(ValueError, "unrecognized arguments"):
             self.core_parser.parse_args(["--an-invalid-switch"])
 
     def test_valid_args(self):

--- a/antismash/config/test/test_args.py
+++ b/antismash/config/test/test_args.py
@@ -88,8 +88,16 @@ class TestConfig(unittest.TestCase):
             assert vars(default_options) == vars(from_file)
 
     def test_paths(self):
-        options = self.core_parser.parse_args(["--reuse-results", "local"])
-        assert os.sep in options.reuse_results
+        with TemporaryDirectory(change=True) as temp_dir:
+            open("local", "w")
+            options = self.core_parser.parse_args(["--reuse-results", "local"])
+            assert options.reuse_results == os.path.join(temp_dir, "local")
+            os.chmod("local", 0)
+            with self.assertRaisesRegex(ValueError, "permission denied"):
+                self.core_parser.parse_args(["--reuse-results", "local"])
+
+        with self.assertRaisesRegex(ValueError, "does not exist"):
+            self.core_parser.parse_args(["--reuse-results", "non-existant"])
 
 
 class TestExecutableArg(unittest.TestCase):

--- a/antismash/detection/genefinding/__init__.py
+++ b/antismash/detection/genefinding/__init__.py
@@ -4,12 +4,11 @@
 """ A module to find genes in a record using external tools """
 
 import logging
-import os
 from typing import List
 
 from antismash.common.secmet import Record
 from antismash.config import ConfigType
-from antismash.config.args import ModuleArgs
+from antismash.config.args import ModuleArgs, ReadableFullPathAction
 
 from .run_prodigal import run_prodigal
 from .run_glimmerhmm import run_glimmerhmm
@@ -37,6 +36,7 @@ def get_arguments() -> ModuleArgs:
     args.add_option('gff3',
                     dest='gff3',
                     default="",
+                    action=ReadableFullPathAction,
                     type=str,
                     metavar="GFF3_FILE",
                     help="Specify GFF3 file to extract features from.")
@@ -67,10 +67,6 @@ def check_options(options: ConfigType) -> List[str]:
         and vice versa.
     """
     errors = []
-    if options.genefinding_gff3:
-        if not os.path.exists(options.genefinding_gff3):
-            errors.append("Specified gff file does not exist: %s" % (
-                    options.genefinding_gff3))
     if options.taxon == "fungi" and options.genefinding_tool not in ["glimmerhmm", "none", "error"]:
         errors.append("Fungi taxon must use glimmerhmm for genefinding if using genefinding")
     if options.taxon == "bacteria" and options.genefinding_tool == "glimmerhmm":

--- a/antismash/detection/genefinding/run_glimmerhmm.py
+++ b/antismash/detection/genefinding/run_glimmerhmm.py
@@ -60,6 +60,6 @@ def run_glimmerhmm(record: Record) -> None:
         return
 
     handle = StringIO(results_text)
-    features = get_features_from_file(handle)
+    features = get_features_from_file(handle)[record.id]
     for feature in features:
         record.add_biopython_feature(feature)

--- a/antismash/detection/genefinding/test/test_genefinding.py
+++ b/antismash/detection/genefinding/test/test_genefinding.py
@@ -15,12 +15,6 @@ class TestCore(unittest.TestCase):
         options = Namespace()
         options.taxon = 'bacteria'
         options.genefinding_tool = "none"
-        with self.assertRaises(AttributeError):
-            check_options(options)
-        options.genefinding_gff3 = '/nonexistant/path/to.gff'
-        assert len(check_options(options)) == 1
-        options.genefinding_gff3 = '/dev/null'
-        assert not check_options(options)
 
     def test_is_enabled(self):
         options = Namespace()

--- a/antismash/detection/hmm_detection/__init__.py
+++ b/antismash/detection/hmm_detection/__init__.py
@@ -122,7 +122,10 @@ def regenerate_previous_results(results: Dict[str, Any], record: Record,
     if not results:
         return None
     regenerated = HMMDetectionResults.from_json(results, record)
-    if set(regenerated.enabled_types) != set(get_supported_cluster_types(options.hmmdetection_strictness)):
+    if regenerated.strictness != options.hmmdetection_strictness:
+        logging.warning("Ignoring hmmdetection strictness option %r, reusing %r from results",
+                        options.hmmdetection_strictness, regenerated.strictness)
+    if set(regenerated.enabled_types) != set(get_supported_cluster_types(regenerated.strictness)):
         raise RuntimeError("Protocluster types supported by HMM detection have changed, all results invalid")
     regenerated.rule_results.annotate_cds_features()
     return regenerated

--- a/antismash/modules/nrps_pks/test/test_parsers.py
+++ b/antismash/modules/nrps_pks/test/test_parsers.py
@@ -19,7 +19,7 @@ class TestNRPSParserMonomerModification(unittest.TestCase):
         self.genes = []
         self.regions = []
         domain_names = self.gen_domain_names()
-        for product in ['not_atpks', 'transatpks']:
+        for product in ['not-atpks', 'transatpks']:
             cluster = helpers.DummyProtocluster(1, 2, product=product)
             candidate_cluster = helpers.DummyCandidateCluster([cluster])
             self.regions.append(Region(candidate_clusters=[candidate_cluster]))

--- a/antismash/outputs/html/css/style.scss
+++ b/antismash/outputs/html/css/style.scss
@@ -103,7 +103,7 @@ nav {
     background-repeat: repeat-x;
     color: #e1e1e1;
     font-size: 14px;
-    border-bottom: 4px solid #810e15;
+    border-bottom: 4px solid $antismash-main;
     height: 50px;
     & a {
         background: none;

--- a/antismash/outputs/html/templates/overview.html
+++ b/antismash/outputs/html/templates/overview.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <title>{{page_title}} - {{regions_written}} region(s) - antiSMASH results</title>
+  <style>img {width: 20px; height: 20px;}</style>
   <link rel="stylesheet" type="text/css" href="css/{{options.taxon}}.css">
   <meta property="og:title" content="{{page_title}} - {{records | length}} record(s) - {{regions_written}} region(s)" />
   <meta property="og:description" content="{{options.html_description}}">

--- a/antismash/outputs/html/templates/regions.html
+++ b/antismash/outputs/html/templates/regions.html
@@ -13,14 +13,18 @@
       </div>
       <div class = 'description-text'>
         {{region.description_text()}}
+        {% if region.detection_rules %}
         <a class="cluster-rules-header" id="{{region.anchor_id}}-rules-header" href="#{{region.anchor_id}}">Show pHMM detection rules used</a>
+        {% endif %}
         {% if region.contig_edge %}
           <div class="contig-edge-warning">Region on contig edge.</div>
         {% endif %}
       </div>
+      {% if region.detection_rules %}
       <div class="cluster-rules" id="{{region.anchor_id}}-rules">
         {{- region.detection_rules|join('<br>'|safe) -}}
       </div>
+      {% endif %}
       <div class="region-svg-container">
        <div id='{{region.anchor_id}}-svg'>
        </div>

--- a/antismash/outputs/html/templates/regions.html
+++ b/antismash/outputs/html/templates/regions.html
@@ -3,7 +3,7 @@
 {% for record in records %}
 {% set results = results_by_record_id[record.id] %}
 {% for region in record.regions %}
-<div class="page" id='{{region.anchor_id}}'>
+<div class="page" id='{{region.anchor_id}}' style="display: none;">
  <div class="region-grid">
   <div class = "content">
     <div class ="description-container">


### PR DESCRIPTION
Fixes a number of small performance and value issues, with the interesting ones being:
- GFF parsing occurred twice per record, with some 1000+ record inputs taking 20 minutes, that same input now takes 20 seconds
- error details for GFF files are no longer swallowed up by a monolithic `could not parse records` error, messages are logged first
- commandline arguments that are paths can now be checked at parse time for existence and read permissions
- Genbank annotations improved when using `--start` and/or `--end`
- HTML output will look less terrible while CSS is loading on slow connections (or doesn't load, as when opened directly from a zipfile)
- `--hmmdetection-strictness` option now persists through reuse