### PR TITLE
Use os.makedirs instead of os.mkdir

### DIFF
--- a/antismash/outputs/html/generate_html_table.py
+++ b/antismash/outputs/html/generate_html_table.py
@@ -23,8 +23,7 @@ def generate_html_table(outfile_name: str, mibig_entries: List[MibigEntry]) -> N
         Returns:
             None
     """
-    if not os.path.exists(os.path.dirname(outfile_name)):
-        os.mkdir(os.path.dirname(outfile_name))
+    os.makedirs(os.path.dirname(outfile_name), exist_ok=True)
 
     with open(outfile_name, 'w') as handle:
         env = Environment(autoescape=True, undefined=StrictUndefined,


### PR DESCRIPTION
While playing with #180 I triggered the error message below. This is due to trying to write to a directory that doesn't  exists. Simply creating the directory manually and re-running antismash worked like a charm.  So i have changed to code to `os.makedirs` which acts like `mkdir -p` and I've used the `exist_ok=True` flag to not cause an error if the directory exists.  Therefore this should not change any behavior except in the case of a missing recursive directory which will now be created instead of throwing an error. 

os.makedirs docs [for reference](https://docs.python.org/3/library/os.html?highlight=os%20makedirs#os.makedirs)


Note: this came up in the context of the `--reuse-results` CLI flag. In the normal case these directories would have been created by the modules.

```bash
  File "/mnt/DataDrive1/miniconda/bin/antismash", line 10, in <module>
    sys.exit(entrypoint())
  File "/mnt/DataDrive1/miniconda/lib/python3.6/site-packages/antismash/__main__.py", line 126, in entrypoint
    sys.exit(main(sys.argv[1:]))
  File "/mnt/DataDrive1/miniconda/lib/python3.6/site-packages/antismash/__main__.py", line 115, in main
    antismash.run_antismash(sequence, options)
  File "/mnt/DataDrive1/miniconda/lib/python3.6/site-packages/antismash/main.py", line 616, in run_antismash
    result = _run_antismash(sequence_file, options)
  File "/mnt/DataDrive1/miniconda/lib/python3.6/site-packages/antismash/main.py", line 695, in _run_antismash
    write_outputs(results, options)
  File "/mnt/DataDrive1/miniconda/lib/python3.6/site-packages/antismash/main.py", line 415, in write_outputs
    html.write(results.records, module_results_per_record, options)
  File "/mnt/DataDrive1/miniconda/lib/python3.6/site-packages/antismash/outputs/html/__init__.py", line 98, in write
    generate_webpage(records, results, options)
  File "/mnt/DataDrive1/miniconda/lib/python3.6/site-packages/antismash/outputs/html/generator.py", line 115, in generate_webpage
    json_records, js_domains = build_json_data(records, results, options)
  File "/mnt/DataDrive1/miniconda/lib/python3.6/site-packages/antismash/outputs/html/generator.py", line 38, in build_json_data
    js_records = js.convert_records(records, results, options)
  File "/mnt/DataDrive1/miniconda/lib/python3.6/site-packages/antismash/outputs/html/js.py", line 29, in convert_records
    json_records.append(convert_record(record, options, result))
  File "/mnt/DataDrive1/miniconda/lib/python3.6/site-packages/antismash/outputs/html/js.py", line 41, in convert_record
    'regions': convert_regions(record, options, result)
  File "/mnt/DataDrive1/miniconda/lib/python3.6/site-packages/antismash/outputs/html/js.py", line 80, in convert_regions
    js_region['orfs'] = convert_cds_features(record, region.cds_children, options, mibig_entries)
  File "/mnt/DataDrive1/miniconda/lib/python3.6/site-packages/antismash/outputs/html/js.py", line 101, in convert_cds_features
    description = get_description(record, feature, gene_function, options, mibig_hits)
  File "/mnt/DataDrive1/miniconda/lib/python3.6/site-packages/antismash/outputs/html/js.py", line 275, in get_description
    generate_html_table(mibig_homology_file, mibig_result)
  File "/mnt/DataDrive1/miniconda/lib/python3.6/site-packages/antismash/outputs/html/generate_html_table.py", line 27, in generate_html_table
    os.mkdir(os.path.dirname(outfile_name))
FileNotFoundError: [Errno 2] No such file or directory: '/home/zachcp/test/outputs/antismash/knownclusterblast/region1'
```