### PR TITLE
Fix issues with protoclusters fully contained by others

### DIFF
--- a/antismash/common/secmet/features/candidate_cluster.py
+++ b/antismash/common/secmet/features/candidate_cluster.py
@@ -137,7 +137,7 @@ class CandidateCluster(CDSCollection):
     """
     FEATURE_TYPE = "cand_cluster"
     kinds = CandidateClusterKind
-    __slots__ = ["_protoclusters", "_kind", "smiles_structure", "polymer"]
+    __slots__ = ["_protoclusters", "_kind", "_core_location", "smiles_structure", "polymer"]
 
     def __init__(self, kind: CandidateClusterKind, protoclusters: List[Protocluster],
                  smiles: str = None, polymer: str = None) -> None:
@@ -153,6 +153,7 @@ class CandidateCluster(CDSCollection):
         self._kind = kind
         self.smiles_structure = smiles
         self.polymer = polymer
+        self._core_location = None
 
     def __repr__(self) -> str:
         return "CandidateCluster(%s, %s)" % (self.location, self.kind)
@@ -189,6 +190,17 @@ class CandidateCluster(CDSCollection):
         for cluster in self._protoclusters:
             unique_products[cluster.product] = None
         return list(unique_products)
+
+    @property
+    def core_location(self) -> FeatureLocation:
+        """ Returns a FeatureLocation covering the range of child Protocluster
+            core locations
+        """
+        if not self._core_location:
+            first_core = min(proto.core_location.start for proto in self._protoclusters)
+            last_core = max(proto.core_location.end for proto in self._protoclusters)
+            self._core_location = FeatureLocation(first_core, last_core)
+        return self._core_location
 
     def get_product_string(self) -> str:
         """ Returns all unique products from contained clusters in the order

--- a/antismash/common/secmet/features/candidate_cluster/__init__.py
+++ b/antismash/common/secmet/features/candidate_cluster/__init__.py
@@ -1,0 +1,57 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+""" Classes and helpers for candidate cluster features
+
+CandidateClusters contain one or more Protocluster features.
+
+There are four kinds of candidate cluster:
+    - chemical hybrid:
+        contains clusters which share Cluster-defining CDSFeatures, will also
+        include clusters within that shared range that do not share a CDS provided
+        that they are completely contained within the candidate cluster border,
+        e.g.
+            ---##A###############C#---   <- Cluster 1 with definition CDSes A and C
+             --##A##--                   <- Cluster 2 with definition CDS A
+                      --#B#--            <- Cluster 3 with definition CDS B
+                              --#C#--    <- Cluster 4 with definition CDS C
+                                   -#D#- <- Cluster 5 with definition CDS D
+            Since clusters 1 and 2 share a CDS that defines those clusters, a
+            chemical hybrid candidate cluster exists. Clusters 1 and 4 also share a
+            defining CDS, so the hybrid candidate cluster now contains clusters 1, 2 and 4.
+
+            Cluster 3 does not share a defining CDS with either cluster 1, 2 or 4,
+            but because it is interleaved into a chemical hybrid it is included
+            under the assumption that it is relevant to the other clusters.
+      NOTE: This may change so that there is also an 'interleaved' candidate cluster,
+            where the only difference between the interleaved and the hybrid is
+            that Cluster 3 would contribute it's product to the interleaved and
+            not the hybrid.
+    - interleaved:
+        contains clusters which do not share Cluster-defining CDS features, but
+        their core locations overlap,
+        e.g.
+            ---#A###A###A---      <- Cluster 1 with defining CDSes marked A
+               ---B##B####B---    <- Cluster 2 with defining CDSes marked B
+                      ---C###C--- <- Cluster 3 with defining CDSes marked C
+            Since none of the clusters share any defining CDS with any other cluster,
+            it is not a chemical hybrid. All three clusters would be part of an
+            interleaved candidate cluster, since A overlaps with B and B overlaps with C.
+    - neighbouring:
+        contains clusters which transitively overlap in their neighbourhoods
+        (the '-' sections in the examples above). In the chemical hybrid example,
+        as all clusters overlap in some way, all 5 would be part of a neighbouring
+        candidate cluster (with clusters 1-4 also being part of a hybrid candidate cluster).
+        Every cluster in a 'neighbouring' cluster will also belong to one of the
+        other kinds of candidate cluster.
+    - single:
+        the kind for all candidate clusters where only one cluster is contained,
+        only exists for consistency of access. A 'single' candidate cluster will not
+        exist for a cluster which is contained in either a chemical hybrid or
+        an interleaved candidate cluster. In the chemical hybrid example, only cluster 5
+        would be in a 'single' candidate cluster as well as in the 'neighbouring' candidate cluster
+
+"""
+
+from .formation import create_candidates_from_protoclusters
+from .structures import CandidateCluster, CandidateClusterKind

--- a/antismash/common/secmet/features/candidate_cluster/formation.py
+++ b/antismash/common/secmet/features/candidate_cluster/formation.py
@@ -1,0 +1,190 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+""" Handles creation of candidate clusters from protoclusters
+"""
+
+import bisect
+from typing import Iterable, List, Set, Tuple
+
+from ...locations import FeatureLocation, location_contains_other, locations_overlap
+from ..protocluster import Protocluster
+from .structures import CandidateCluster, CandidateClusterKind
+
+
+def create_candidates_from_protoclusters(protoclusters: List[Protocluster]) -> List[CandidateCluster]:
+    """ Constructs CandidateCluster features from a collection of Protocluster features
+
+        CandidateClusters created may overlap if they are of different kinds.
+
+        Chemical hybrid CandidateClusters may also contain one or more Protoclusters that
+        do not share a Protocluster-defining CDS with the others, provided that the
+        Protocluster(s) are fully contained within the area covered by other Protoclusters
+        that do shared defining CDS features.
+
+        Arguments:
+            clusters: a list of Protoluster features
+
+        Returns:
+            a list of CandidateCluster features
+    """
+    if not protoclusters:
+        return []
+
+    # ensure that only one candidate cluster can be created for each specific start/end combination
+    existing = set()  # type: Set[Tuple[int, int]]
+
+    def build_candidates(groups: List[List[Protocluster]], kind: CandidateClusterKind) -> List[CandidateCluster]:
+        """ Creates candidates of the given kind, one for each group
+        """
+        candidates = []
+        for group in groups:
+            assert kind == CandidateClusterKind.SINGLE or len(group) > 1
+            candidate = CandidateCluster(kind, sorted(group))
+            if (candidate.location.start, candidate.location.end) not in existing:
+                candidates.append(candidate)
+                existing.add((candidate.location.start, candidate.location.end))
+        return candidates
+
+    unassigned = sorted(protoclusters)  # will contain any protocluster not yet in hybrid/interleaved
+
+    # first all the chemical hybrids
+    hybrid_groups, unassigned = _find_hybrids(unassigned)
+    candidates = build_candidates(hybrid_groups, CandidateClusterKind.CHEMICAL_HYBRID)
+
+    # then any interleaved
+    interleaved_groups, unassigned = _find_interleaved(unassigned, candidates)
+    # unassigned won't be updated further, as anything left needs a SINGLE created anyway
+    new = build_candidates(interleaved_groups, CandidateClusterKind.INTERLEAVED)
+    candidates = sorted(candidates + new)  # since find_neighbouring requires sorted by location
+
+    # then neighbouring
+    neighbouring_groups = _find_neighbouring(unassigned, candidates)
+    new = build_candidates(neighbouring_groups, CandidateClusterKind.NEIGHBOURING)
+    candidates.extend(new)  # sorting postponed, since it's not critical for next step
+
+    # finally, create singles for every protocluster not in interleaved or hybrid
+    for cluster in unassigned:
+        if (cluster.location.start, cluster.location.end) not in existing:
+            candidates.append(CandidateCluster(CandidateClusterKind.SINGLE, [cluster]))
+
+    return sorted(candidates)  # again, reorder by location
+
+
+def _merge_sets(groups: Iterable[Set[Protocluster]]) -> List[List[Protocluster]]:
+    """ Merges all overlapping sets into a larger set. All sets returned are disjoint. """
+    # once ordered by earliest start location, a single pass should be sufficient
+    ordered = sorted(groups, key=lambda group: min(cluster.location.start for cluster in group))
+    for i, first in enumerate(ordered[:-1]):
+        if not first:
+            continue
+        for second in ordered[i+1:]:
+            if first.isdisjoint(second):
+                continue
+            # merge into the earlier group and make the second unable to hit any other
+            first.update(second)
+            second.clear()
+    return [sorted(group) for group in ordered if group]
+
+
+def _find_hybrids(clusters: List[Protocluster]) -> Tuple[List[List[Protocluster]], List[Protocluster]]:
+    """ Finds all chemical hybrid groupings within a sorted list of protoclusters """
+    unassigned = set(clusters)
+    clusters = sorted(clusters, key=lambda x: (x.core_location.start, x.core_location.end))
+
+    # first find all hybrid pairs
+    groups = []
+    for i, first in enumerate(clusters[:-1]):
+        for second in clusters[i+1:]:
+            if not first.overlaps_with(second):
+                break
+            if first.definition_cdses.intersection(second.definition_cdses):
+                groups.append({first, second})
+                unassigned.discard(first)
+                unassigned.discard(second)
+
+    # merge the pairs into larger groups
+    merged_groups = _merge_sets(groups)
+    clusters = sorted(unassigned)
+
+    # then find any unassigned cluster that is fully contained by a hybrid group
+    for group in merged_groups:
+        core = FeatureLocation(min(proto.core_location.start for proto in group),
+                               max(proto.core_location.end for proto in group))
+        index = max(0, bisect.bisect_left(clusters, core) - 1)
+        for cluster in clusters[index:]:
+            if cluster.location.start > core.end:
+                break
+            if location_contains_other(core, cluster.core_location):
+                group.append(cluster)
+                unassigned.discard(cluster)
+
+    return [sorted(group) for group in merged_groups], sorted(unassigned)
+
+
+def _find_interleaved(clusters: List[Protocluster], candidates: List[CandidateCluster]
+                      ) -> Tuple[List[List[Protocluster]], List[Protocluster]]:
+    """ Finds all interleaved groups from combinations of existing candidates
+        and single protoclusters (both inputs must be sorted)
+    """
+    found = set()
+    groups = []
+
+    # start with any interleaved candidates
+    for i, candidate in enumerate(candidates[:-1]):
+        for other_candidate in candidates[i+1:]:
+            if locations_overlap(candidate.core_location, other_candidate.core_location):
+                groups.append(set(candidate.protoclusters + other_candidate.protoclusters))
+
+    # unassigned overlapping with unassigned
+    for i, cluster in enumerate(clusters[:-1]):
+        for other_cluster in clusters[i + 1:]:
+            if cluster.core_location.end <= other_cluster.core_location.start:
+                break
+            if locations_overlap(cluster.core_location, other_cluster.core_location):
+                groups.append({cluster, other_cluster})
+                found.add(cluster)
+                found.add(other_cluster)
+
+    # unassigned overlapping with candidates
+    for cluster in clusters:
+        index = max(0, bisect.bisect_left(candidates, cluster) - 1)
+        for candidate in candidates[index:]:
+            if candidate.location.start > cluster.location.end:
+                break
+            if locations_overlap(candidate.core_location, cluster.core_location):
+                groups.append(set(candidate.protoclusters + (cluster,)))
+                found.add(cluster)
+
+    return _merge_sets(groups), sorted(set(clusters).difference(found))
+
+
+def _find_neighbouring(singles: List[Protocluster], candidates: List[CandidateCluster]) -> List[List[Protocluster]]:
+    """ Finds all neighbouring groups from combinations of existing candidates
+        and single protoclusters (both inputs must be sorted)
+    """
+    groups = []
+    # candidates overlapping with candidates
+    for i, first_candidate in enumerate(candidates[:-1]):
+        for second_candidate in candidates[i+1:]:
+            if not first_candidate.overlaps_with(second_candidate):
+                break
+            groups.append(set(first_candidate.protoclusters).union(set(second_candidate.protoclusters)))
+
+    # singles overlapping with candidates
+    for single in singles:
+        index = max(0, bisect.bisect_left(candidates, single) - 1)
+        for candidate in candidates[index:]:
+            if candidate.location.start > single.location.end:
+                break
+            if single.overlaps_with(candidate):
+                groups.append(set(candidate.protoclusters).union({single}))
+
+    # singles overlapping with singles
+    for i, first_single in enumerate(singles[:-1]):
+        for second_single in singles[i+1:]:
+            if not first_single.overlaps_with(second_single):
+                break
+            groups.append({first_single, second_single})
+
+    return _merge_sets(groups)

--- a/antismash/common/secmet/features/candidate_cluster/test/test_candidate_cluster.py
+++ b/antismash/common/secmet/features/candidate_cluster/test/test_candidate_cluster.py
@@ -12,9 +12,8 @@ from antismash.common.secmet import FeatureLocation, Record
 from antismash.common.secmet.features import Protocluster, CandidateCluster
 from antismash.common.secmet.features.candidate_cluster import (
     CandidateClusterKind,
-    TemporaryCandidateCluster,
-    create_candidates_from_protoclusters as creator,
 )
+from antismash.common.secmet.features.candidate_cluster.structures import TemporaryCandidateCluster
 from antismash.common.secmet.qualifiers import GeneFunction
 from antismash.common.secmet.test.helpers import DummyCDS
 
@@ -31,8 +30,6 @@ def create_cluster(n_start, start, end, n_end, product='a'):
                            FeatureLocation(n_start, n_end),
                            tool="testing", product=product, cutoff=1,
                            neighbourhood_range=0, detection_rule="some rule text")
-    cds = create_cds(start, end, [product])
-    cluster.add_cds(cds)
     return cluster
 
 
@@ -136,94 +133,3 @@ class TestCandidateCluster(unittest.TestCase):
         check(longer, candidate)
         check(longer, after)
         assert sorted([after, candidate, longer]) == [longer, candidate, after]
-
-
-class TestCreation(unittest.TestCase):
-    def test_creation_empty(self):
-        assert creator([]) == []
-
-    def test_creation_single(self):
-        created = creator([create_cluster(3, 8, 71, 76, 'a')])
-        print(created)
-        assert len(created) == 1
-        assert created[0].location == FeatureLocation(3, 76)
-        assert created[0].kind == CandidateCluster.kinds.SINGLE
-
-    def test_creation_neighbours(self):
-        cluster = create_cluster(3, 8, 71, 76, 'a')
-        extra_cluster = create_cluster(50, 100, 120, 170, 'b')
-        created = creator([cluster, extra_cluster])
-        print(created)
-        assert len(created) == 3
-        expected_location = FeatureLocation(cluster.location.start,
-                                            extra_cluster.location.end)
-        assert created[0].kind == CandidateCluster.kinds.NEIGHBOURING and created[0].location == expected_location
-        assert created[1].kind == CandidateCluster.kinds.SINGLE and created[1].location == cluster.location
-        assert created[2].kind == CandidateCluster.kinds.SINGLE and created[2].location == extra_cluster.location
-
-    def test_creation_coreoverlap(self):
-        cluster = create_cluster(3, 8, 71, 76, 'a')
-        extra_cluster = create_cluster(50, 60, 120, 170, 'b')
-        # create a CDS within both clusters that has a product from only one cluster
-        cds = create_cds(60, 65, ["a"])
-        cluster.add_cds(cds)
-        extra_cluster.add_cds(cds)
-
-        created = creator([cluster, extra_cluster])
-        print(created)
-        assert len(created) == 1
-        candidate_cluster = created[0]
-        assert candidate_cluster.kind == CandidateCluster.kinds.INTERLEAVED
-        assert candidate_cluster.location == FeatureLocation(3, 170)
-
-    def test_creation_hybrid(self):
-        cluster = create_cluster(3, 8, 71, 76, 'a')
-        hybrid_cluster = create_cluster(50, 60, 120, 170, 'b')
-
-        # insert the cds that will cause the hybrid call
-        cds_ab = create_cds(60, 65, ["a", "b"])
-        cluster.add_cds(cds_ab)
-        hybrid_cluster.add_cds(cds_ab)
-
-        created = creator([cluster, hybrid_cluster])
-        print(created)
-        assert len(created) == 1
-        candidate_cluster = created[0]
-        assert candidate_cluster.kind == CandidateCluster.kinds.CHEMICAL_HYBRID
-        assert candidate_cluster.location == FeatureLocation(3, 170)
-
-    def test_creation_mixed(self):
-        cluster = create_cluster(3, 8, 71, 76, 'a')
-        hybrid_cluster = create_cluster(50, 60, 120, 170, 'b')
-        overlap_cluster = create_cluster(80, 90, 130, 180, 'o')
-        neighbour_cluster = create_cluster(50, 210, 260, 270, 'a')
-        isolated_cluster = create_cluster(450, 500, 550, 600, 'alone')
-
-        # insert the cds that will cause the hybrid call
-        cds_ab = create_cds(60, 65, ["a", "b"])
-        cluster.add_cds(cds_ab)
-        hybrid_cluster.add_cds(cds_ab)
-
-        created = creator([cluster, hybrid_cluster, overlap_cluster, neighbour_cluster, isolated_cluster])
-        print(created)
-
-        assert len(created) == 5
-        assert created[0].location == FeatureLocation(3, 270)
-        assert created[0].kind == CandidateCluster.kinds.NEIGHBOURING
-        assert created[0].protoclusters == (cluster, hybrid_cluster, overlap_cluster, neighbour_cluster)
-
-        assert created[1].location == FeatureLocation(3, 180)
-        assert created[1].kind == CandidateCluster.kinds.INTERLEAVED
-        assert created[1].protoclusters == (cluster, hybrid_cluster, overlap_cluster)
-
-        assert created[2].location == FeatureLocation(3, 170)
-        assert created[2].kind == CandidateCluster.kinds.CHEMICAL_HYBRID
-        assert created[2].protoclusters == (cluster, hybrid_cluster)
-
-        assert created[3].location == FeatureLocation(50, 270)
-        assert created[3].kind == CandidateCluster.kinds.SINGLE
-        assert created[3].protoclusters == (neighbour_cluster,)
-
-        assert created[4].location == FeatureLocation(450, 600)
-        assert created[4].kind == CandidateCluster.kinds.SINGLE
-        assert created[4].protoclusters == (isolated_cluster,)

--- a/antismash/common/secmet/features/candidate_cluster/test/test_formation.py
+++ b/antismash/common/secmet/features/candidate_cluster/test/test_formation.py
@@ -1,0 +1,183 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+# for test files, silence irrelevant and noisy pylint warnings
+# pylint: disable=no-self-use,protected-access,missing-docstring
+
+import unittest
+
+from antismash.common.secmet import FeatureLocation
+from antismash.common.secmet.features import CandidateCluster
+from antismash.common.secmet.features.candidate_cluster import (
+    create_candidates_from_protoclusters as creator,
+)
+
+from .test_candidate_cluster import create_cds, create_cluster
+
+
+class TestCreation(unittest.TestCase):
+    def test_creation_empty(self):
+        assert creator([]) == []
+
+    def test_creation_single(self):
+        created = creator([create_cluster(3, 8, 71, 76, 'a')])
+        print(created)
+        assert len(created) == 1
+        assert created[0].location == FeatureLocation(3, 76)
+        assert created[0].kind == CandidateCluster.kinds.SINGLE
+
+    def test_creation_neighbours(self):
+        cluster = create_cluster(3, 8, 71, 76, 'a')
+        extra_cluster = create_cluster(50, 100, 120, 170, 'b')
+        created = creator([cluster, extra_cluster])
+        print(created)
+        assert len(created) == 3
+        expected_location = FeatureLocation(cluster.location.start,
+                                            extra_cluster.location.end)
+        assert created[0].kind == CandidateCluster.kinds.NEIGHBOURING and created[0].location == expected_location
+        assert created[1].kind == CandidateCluster.kinds.SINGLE and created[1].location == cluster.location
+        assert created[2].kind == CandidateCluster.kinds.SINGLE and created[2].location == extra_cluster.location
+
+    def test_creation_coreoverlap(self):
+        cluster = create_cluster(3, 8, 71, 76, 'a')
+        extra_cluster = create_cluster(50, 60, 120, 170, 'b')
+        # create a CDS within both clusters that has a product from only one cluster
+        cds = create_cds(60, 65, ["a"])
+        cluster.add_cds(cds)
+        extra_cluster.add_cds(cds)
+
+        created = creator([cluster, extra_cluster])
+        print(created)
+        assert len(created) == 1
+        candidate_cluster = created[0]
+        assert candidate_cluster.kind == CandidateCluster.kinds.INTERLEAVED
+        assert candidate_cluster.location == FeatureLocation(3, 170)
+
+    def test_creation_hybrid(self):
+        cluster = create_cluster(3, 8, 71, 76, 'a')
+        hybrid_cluster = create_cluster(50, 60, 120, 170, 'b')
+
+        # insert the cds that will cause the hybrid call
+        cds_ab = create_cds(60, 65, ["a", "b"])
+        cluster.add_cds(cds_ab)
+        hybrid_cluster.add_cds(cds_ab)
+
+        created = creator([cluster, hybrid_cluster])
+        print(created)
+        assert len(created) == 1
+        candidate_cluster = created[0]
+        assert candidate_cluster.kind == CandidateCluster.kinds.CHEMICAL_HYBRID
+        assert candidate_cluster.location == FeatureLocation(3, 170)
+
+    def test_creation_mixed(self):
+        cluster = create_cluster(3, 8, 71, 76, 'a')
+        hybrid_cluster = create_cluster(50, 60, 120, 170, 'b')
+        overlap_cluster = create_cluster(80, 90, 130, 180, 'o')
+        neighbour_cluster = create_cluster(50, 210, 260, 270, 'a')
+        isolated_cluster = create_cluster(450, 500, 550, 600, 'alone')
+
+        # insert the cds that will cause the hybrid call
+        cds_ab = create_cds(60, 65, ["a", "b"])
+        cluster.add_cds(cds_ab)
+        hybrid_cluster.add_cds(cds_ab)
+
+        created = creator([cluster, hybrid_cluster, overlap_cluster, neighbour_cluster, isolated_cluster])
+        print(created)
+
+        assert len(created) == 5
+        assert created[0].location == FeatureLocation(3, 270)
+        assert created[0].kind == CandidateCluster.kinds.NEIGHBOURING
+        assert created[0].protoclusters == (cluster, neighbour_cluster, hybrid_cluster, overlap_cluster)
+
+        assert created[1].location == FeatureLocation(3, 180)
+        assert created[1].kind == CandidateCluster.kinds.INTERLEAVED
+        assert created[1].protoclusters == (cluster, hybrid_cluster, overlap_cluster)
+
+        assert created[2].location == FeatureLocation(3, 170)
+        assert created[2].kind == CandidateCluster.kinds.CHEMICAL_HYBRID
+        assert created[2].protoclusters == (cluster, hybrid_cluster)
+
+        assert created[3].location == FeatureLocation(50, 270)
+        assert created[3].kind == CandidateCluster.kinds.SINGLE
+        assert created[3].protoclusters == (neighbour_cluster,)
+
+        assert created[4].location == FeatureLocation(450, 600)
+        assert created[4].kind == CandidateCluster.kinds.SINGLE
+        assert created[4].protoclusters == (isolated_cluster,)
+
+    def test_hybrid_interactions(self):
+        cluster = create_cluster(3, 8, 171, 176, "a")
+        hybrid = create_cluster(3, 8, 50, 55, "b")
+        contained = create_cluster(80, 90, 100, 110, "c")  # will form part of hybrid
+
+        hybrid_cds = create_cds(8, 50, ["a", "b"])
+        cluster.add_cds(hybrid_cds)
+        hybrid.add_cds(hybrid_cds)
+
+        for overlapping in [create_cluster(120, 130, 200, 250, "d"),
+                            create_cluster(60, 70, 200, 250, "d")]:
+
+            created = creator([cluster, hybrid, contained, overlapping])
+
+            assert len(created) == 2
+            assert created[0].location == FeatureLocation(3, 250)
+            assert created[0].kind == CandidateCluster.kinds.INTERLEAVED
+            assert created[0].protoclusters == tuple(sorted([cluster, hybrid, contained, overlapping]))
+
+            assert created[1].location == FeatureLocation(3, 176)
+            assert created[1].kind == CandidateCluster.kinds.CHEMICAL_HYBRID
+            assert created[1].protoclusters == (cluster, hybrid, contained)
+
+    def test_interleaving(self):
+        # these first two hybrid clumps should be interleaved
+        first_hybrid_clusters = [create_cluster(30, 60, 120, 150, "a"),
+                                 create_cluster(60, 90, 150, 180, "b")]
+        cds = create_cds(90, 120, ["a", "b"])
+        for cluster in first_hybrid_clusters:
+            cluster.add_cds(cds)
+
+        second_hybrid_clusters = [create_cluster(90, 120, 250, 280, "c"),
+                                  create_cluster(190, 220, 280, 310, "d")]
+        cds = create_cds(220, 250, ["c", "d"])
+        for cluster in second_hybrid_clusters:
+            cluster.add_cds(cds)
+
+        # this non-hybrid should also be included in the interleaved
+        single = create_cluster(230, 250, 410, 430, "e")
+        # this hybrid should not
+        standalone = [create_cluster(1000, 1100, 1400, 1500, "f"),
+                      create_cluster(1100, 1200, 1500, 1600, "g")]
+        cds = create_cds(1300, 1400, ["f", "g"])
+        for cluster in standalone:
+            cluster.add_cds(cds)
+
+        created = creator(first_hybrid_clusters + second_hybrid_clusters + [single] + standalone)
+
+        assert len(created) == 4
+        assert created[0].location == FeatureLocation(30, 430)
+        assert created[0].core_location == FeatureLocation(60, 410)
+        assert created[0].kind == CandidateCluster.kinds.INTERLEAVED
+        assert created[0].protoclusters == tuple(first_hybrid_clusters + second_hybrid_clusters + [single])
+
+        assert created[1].location == FeatureLocation(30, 180)
+        assert created[1].protoclusters == tuple(first_hybrid_clusters)
+        assert created[2].location == FeatureLocation(90, 310)
+        assert created[2].protoclusters == tuple(second_hybrid_clusters)
+        for cand in created[1:3]:
+            assert cand.kind == CandidateCluster.kinds.CHEMICAL_HYBRID
+
+        assert created[3].location == FeatureLocation(1000, 1600)
+        assert created[3].kind == CandidateCluster.kinds.CHEMICAL_HYBRID
+
+    def test_contained_neighbours(self):
+        big = create_cluster(0, 100, 130, 230, "a")
+        small = create_cluster(10, 20, 30, 40, "b")
+
+        created = creator([big, small])
+
+        assert len(created) == 2
+        assert created[0].kind == CandidateCluster.kinds.NEIGHBOURING
+        assert created[0].location == big.location
+
+        assert created[1].kind == CandidateCluster.kinds.SINGLE
+        assert created[1].location == small.location

--- a/antismash/common/secmet/features/cdscollection.py
+++ b/antismash/common/secmet/features/cdscollection.py
@@ -6,7 +6,7 @@
 """
 
 from collections import OrderedDict
-from typing import Any, List, Optional, Sequence, Tuple
+from typing import Any, List, Optional, Sequence, Tuple, Union
 from typing import Dict  # used in comment hints # pylint: disable=unused-import
 
 from Bio.SeqFeature import SeqFeature
@@ -37,16 +37,22 @@ class CDSCollection(Feature):
                 assert isinstance(child, CDSCollection), type(child)
                 child.parent = self
 
-    def __lt__(self, other: "Feature") -> bool:
+    def __lt__(self, other: Union[Feature, FeatureLocation]) -> bool:
         """ Collections differ from other Features in that start ties are
             resolved in the opposite order, from longest to shortest
         """
-        if self.location.start < other.location.start:
+        if isinstance(other, FeatureLocation):
+            location = other
+        else:
+            assert isinstance(other, Feature)
+            location = other.location
+
+        if self.location.start < location.start:
             return True
-        if self.location.start > other.location.start:
+        if self.location.start > location.start:
             return False
         # when starts are equal, sort by largest collection first
-        return self.location.end > other.location.end
+        return self.location.end > location.end
 
     @property
     def parent_record(self) -> Any:  # again, should be Record

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -239,13 +239,18 @@ class Feature:
         assert isinstance(feature.qualifiers, dict)
         return [feature]
 
-    def __lt__(self, other: "Feature") -> bool:
+    def __lt__(self, other: Union["Feature", FeatureLocation]) -> bool:
         """ Allows sorting Features by location without key complication """
-        assert isinstance(other, Feature)
-        if self.location.start < other.location.start:
+        if isinstance(other, FeatureLocation):
+            location = other
+        else:
+            assert isinstance(other, Feature)
+            location = other.location
+
+        if self.location.start < location.start:
             return True
-        elif self.location.start == other.location.start:
-            return self.location.end < other.location.end
+        elif self.location.start == location.start:
+            return self.location.end < location.end
         return False
 
     def __str__(self) -> str:

--- a/antismash/common/secmet/features/test/test_candidate_cluster.py
+++ b/antismash/common/secmet/features/test/test_candidate_cluster.py
@@ -122,6 +122,21 @@ class TestCandidateCluster(unittest.TestCase):
                                    smiles="dummy", polymer="dummy")
         assert cluster.core_location == FeatureLocation(10, 50)
 
+    def test_comparison(self):
+        candidate = CandidateCluster(CandidateClusterKind.NEIGHBOURING, [create_cluster(5, 10, 20, 25, "a")])
+        longer = CandidateCluster(CandidateClusterKind.NEIGHBOURING, [create_cluster(5, 10, 40, 45, "a")])
+        after = CandidateCluster(CandidateClusterKind.NEIGHBOURING, [create_cluster(10, 20, 40, 45, "a")])
+
+        def check(first, second):
+            assert first < second
+            assert first < second.location
+            assert sorted([second, first]) == [first, second]
+
+        check(candidate, after)
+        check(longer, candidate)
+        check(longer, after)
+        assert sorted([after, candidate, longer]) == [longer, candidate, after]
+
 
 class TestCreation(unittest.TestCase):
     def test_creation_empty(self):

--- a/antismash/common/secmet/features/test/test_candidate_cluster.py
+++ b/antismash/common/secmet/features/test/test_candidate_cluster.py
@@ -115,6 +115,13 @@ class TestCandidateCluster(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Not all referenced clusters are present"):
             regenerated.convert_to_real_feature(self.record)
 
+    def test_core(self):
+        protos = [create_cluster(5, 10, 20, 25, "a"),
+                  create_cluster(30, 40, 50, 60, "b")]
+        cluster = CandidateCluster(CandidateClusterKind.NEIGHBOURING, protos,
+                                   smiles="dummy", polymer="dummy")
+        assert cluster.core_location == FeatureLocation(10, 50)
+
 
 class TestCreation(unittest.TestCase):
     def test_creation_empty(self):

--- a/antismash/common/secmet/features/test/test_feature.py
+++ b/antismash/common/secmet/features/test/test_feature.py
@@ -152,6 +152,23 @@ class TestFeature(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "invalid length"):
             Feature(loc, feature_type="A"*16)
 
+    def test_ordering(self):
+        feature = Feature(FeatureLocation(10, 40), feature_type="test")
+        before = Feature(FeatureLocation(5, 30), feature_type="test")
+        after = Feature(FeatureLocation(20, 40), feature_type="test")
+        longer = Feature(FeatureLocation(10, 70), feature_type="test")
+
+        def check(first, second):
+            assert first < second
+            assert first < second.location
+            assert sorted([second, first]) == [first, second]
+
+        check(before, feature)
+        check(feature, after)
+        check(feature, longer)
+
+        assert sorted([feature, before, after, longer]) == [before, feature, longer, after]
+
 
 class TestLocationAdjustment(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
There's a few instances of orphaned protoclusters or incorrect candidate cluster types when a protocluster is fully contained within another. A protocluster fully contained by a chemical hybrid could be orphaned if it was also part of the hybrid. Protoclusters fully contained by the neighbourhood of another protocluster could result in both being 'single' candidate clusters instead of the larger being a 'neighbouring' candidate.

The cause of this was due to candidate formation using only a single pass through for all types, which, while fast, wasn't accurate in this situation. The fix here is to change to a multi-pass creation step, forming all chemical hybrids before moving on to interleaved, and so on. The multi-pass logic is slower, but in tests on my machine the change is from 1ms to 3ms for a full strepomyces genome. Single records/contigs with a large number of protoclusters will be impacted more heavily, but an enormous amount would be needed to match the time taken to find the protoclusters in the first place.

As a development simplification, a semi-related change is that `Feature`s (and subclasses) can now be sorted/compared with both other `Feature`s and `FeatureLocation`s.