### PR TITLE
Small fixes and tweaks

### DIFF
--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -74,8 +74,8 @@ def _translation_fits_in_record(translation_length: int, location: Location,
 def _ensure_valid_translation(translation: str, location: Location, transl_table: int,
                               record: Optional[Any]) -> str:
     """ Ensures that a given translation is valid for the matching location
-        and record (if given). If a record is given and a translation is invalid,
-        an attempt will be made to generate a valid translation.
+        and record (if given). If a record is given and a translation contains
+        invalid characters, an attempt will be made to generate a valid translation.
 
         Arguments:
             translation: the existing translation, if any

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any, Dict, List, Optional
 from typing import Union  # comment hints  # pylint: disable=unused-import
 
-from Bio.Data import IUPACData
+from Bio.Data import CodonTable, IUPACData
 from Bio.SeqFeature import SeqFeature
 
 from antismash.common.secmet import features  # comment hints  # pylint:disable=unused-import
@@ -107,7 +107,10 @@ def _ensure_valid_translation(translation: str, location: Location, transl_table
             raise ValueError("feature missing translation and sequence too short")
         if len(location) < 3:
             raise ValueError("CDS too short to generate translation")
-        translation = record.get_aa_translation_from_location(location, transl_table)
+        try:
+            translation = record.get_aa_translation_from_location(location, transl_table)
+        except CodonTable.TranslationError as err:
+            raise ValueError("invalid codon: %s" % err)
 
     assert _is_valid_translation_length(translation, location)
     return translation

--- a/antismash/common/secmet/qualifiers/secmet.py
+++ b/antismash/common/secmet/qualifiers/secmet.py
@@ -24,6 +24,8 @@ def _parse_format(fmt: str, data: str) -> Sequence[str]:
     """
     # escape anything that might cause issues when using it as a regex later
     safe = re.escape(fmt)
+    # treat (escaped) spaces as optional thanks to genbank/biopython conversions
+    safe = safe.replace("\ ", "\ ?")
     # the simple search here would be {.*?} for a non-greedy brace pair, but
     # because python format strings use {{ and }} as literal braces, they need to be excluded
     # e.g. "{{{{{:g}}}}}".format(1e-5) == "{{1e-5}}"

--- a/antismash/common/secmet/qualifiers/test/test_secmet.py
+++ b/antismash/common/secmet/qualifiers/test/test_secmet.py
@@ -80,6 +80,21 @@ class TestDomain(unittest.TestCase):
         assert new.nseeds == old.nseeds == 30
         assert new.tool == old.tool == "tool test"
 
+    def test_string_conversion_post_genbank(self):
+        # occasionally, genbank will split in just the right place (and biopython regenerates just right)
+        # to create a string with missing spaces, like here V
+        string = 'Abhydrolase_6 (E-value: 4.1e-18, bitscore:65.8, seeds: 455, tool: rule-based-clusters)'
+
+        expected = SecMetQualifier.Domain("Abhydrolase_6", 4.1e-18, 65.8, 455, "rule-based-clusters")
+        assert str(expected) == string.replace("bitscore:", "bitscore: ")
+
+        reconstructed = SecMetQualifier.Domain.from_string(string)
+        assert expected == reconstructed
+
+        # and test an aggressive version, just to be sure
+        reconstructed = SecMetQualifier.Domain.from_string(string.replace(" ", ""))
+        assert expected == reconstructed
+
     def test_equality(self):
         first = SecMetQualifier.Domain("name test", 5e-235, 20.17, 30, "tool test")
         second = SecMetQualifier.Domain("name test", 5e-235, 20.17, 30, "tool test")

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -631,7 +631,7 @@ class Record:
         try:
             ensure_valid_locations(seq_record.features, can_be_circular, len(seq_record.seq))
         except ValueError as err:
-            raise SecmetInvalidInputError(str(err))
+            raise SecmetInvalidInputError("%s: %s" % (seq_record.id, str(err)))
 
         for feature in seq_record.features:
             if feature.ref or feature.ref_db:

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -258,6 +258,8 @@ class ReadableFullPathAction(FullPathAction):
     def __call__(self, parser: argparse.ArgumentParser, namespace: argparse.Namespace,  # type: ignore
                  values: AnyStr, option_string: str = None) -> None:
         path = os.path.abspath(values)
+        if os.path.isdir(path):
+            raise argparse.ArgumentError(self, "%s is a directory" % values)
         if not os.path.isfile(path):
             raise argparse.ArgumentError(self, "%s does not exist" % values)
         if not os.access(path, os.R_OK):

--- a/antismash/detection/hmm_detection/__init__.py
+++ b/antismash/detection/hmm_detection/__init__.py
@@ -139,6 +139,8 @@ def run_on_record(record: Record, previous_results: Optional[HMMDetectionResults
         return previous_results
 
     strictness = options.hmmdetection_strictness
+    logging.info("HMM detection using strictness: %s", strictness)
+
     signatures = path.get_full_path(__file__, "data", "hmmdetails.txt")
     seeds = path.get_full_path(__file__, "data", "bgc_seeds.hmm")
     rules = _get_rule_files_for_strictness(strictness)

--- a/antismash/modules/lanthipeptides/templates/details.html
+++ b/antismash/modules/lanthipeptides/templates/details.html
@@ -14,7 +14,7 @@
       <dl class="details-text">
         {% for motif in results[locus] %}
           <dt>
-            {{motif.get_name()}} leader / core peptide
+            <span class="serif">{{motif.get_name()}}</span> leader / core peptide
           </dt>
           <dd>
             {{ motif.leader }}

--- a/antismash/modules/lanthipeptides/templates/sidepanel.html
+++ b/antismash/modules/lanthipeptides/templates/sidepanel.html
@@ -7,7 +7,7 @@
     <dl class ="prediction-text">
     {% for motifs in results.values() %}
     {%- for motif in motifs -%}
-      <dt>{{motif.get_name()}} - {{motif.peptide_subclass}}</dt>
+      <dt><span class="serif">{{motif.get_name()}}</span> - {{motif.peptide_subclass}}</dt>
         <dd>Cleavage pHMM score: {{'%0.2f' | format(motif.score)}}</dd>
         <dd>RODEO score: {{motif.detailed_information.rodeo_score}}</dd>
         <dd>Monoisotopic mass: {{'%0.1f' | format(motif.monoisotopic_mass)}} Da</dd>

--- a/antismash/modules/lanthipeptides/test/integration_lanthipeptides.py
+++ b/antismash/modules/lanthipeptides/test/integration_lanthipeptides.py
@@ -57,7 +57,7 @@ class IntegrationLanthipeptides(unittest.TestCase):
 
     def test_nisin(self):
         "Test lanthipeptide prediction for nisin A"
-        expected_html_snippet = "nisA leader / core peptide"
+        expected_html_snippet = "nisA</span> leader / core peptide"
         genbank = helpers.get_path_to_nisin_genbank()
         rec, _ = self.run_lanthi(genbank, expected_html_snippet)
 

--- a/antismash/modules/lassopeptides/templates/details.html
+++ b/antismash/modules/lassopeptides/templates/details.html
@@ -13,7 +13,7 @@
     <hr>
       <dl class="details-text">
         {% for motif in results[locus] %}
-          <dt>{{motif.get_name()}} leader / core peptide / cleaved tail</dt>
+          <dt><span class="serif">{{motif.get_name()}}</span> leader / core peptide / cleaved tail</dt>
           <dd>
             {{ motif.leader }}
             -

--- a/antismash/modules/lassopeptides/templates/sidepanel.html
+++ b/antismash/modules/lassopeptides/templates/sidepanel.html
@@ -7,7 +7,7 @@
   <dl class ="prediction-text">
     {% for motifs in results.values() %}
     {%- for motif in motifs -%}
-    <dt>{{motif.get_name()}} - {{motif.peptide_subclass}}</dt>
+    <dt><span class="serif">{{motif.get_name()}}</span> - {{motif.peptide_subclass}}</dt>
       <dd>Cleavage pHMM score: {{'%0.2f' | format(motif.score)}}</dd>
       <dd>RODEO score: {{motif.detailed_information.rodeo_score}}</dd>
       <dd>Monoisotopic mass: {{'%0.1f' | format(motif.detailed_information.cut_mass)}} Da</dd>

--- a/antismash/modules/nrps_pks/templates/monomers.html
+++ b/antismash/modules/nrps_pks/templates/monomers.html
@@ -5,7 +5,7 @@
     </div>
   <dl class="prediction-text">
     {% for gene_id in region.sidepanel_features if gene_id in relevant_features %}
-      <strong>{{gene_id}}</strong>: {{relevant_features[gene_id] | join(" - ")}}
+      <strong><span class="serif">{{gene_id}}</span></strong>: {{relevant_features[gene_id] | join(" - ")}}
       {{collapser_start(target=gene_id, level="cds")}}
       <dt></dt>
       {% if gene_id in region.url_strict %}

--- a/antismash/modules/sactipeptides/templates/details.html
+++ b/antismash/modules/sactipeptides/templates/details.html
@@ -13,7 +13,7 @@
     <hr>
       <dl class="details-text">
         {% for motif in results[locus] %}
-        <dt>{{motif.get_name()}} leader / core peptide</dt>
+        <dt><span class="serif">{{motif.get_name()}}</span> leader / core peptide</dt>
         <dd>
           {{ motif.leader }} - {{motif.core}}
         </dd>

--- a/antismash/modules/sactipeptides/templates/sidepanel.html
+++ b/antismash/modules/sactipeptides/templates/sidepanel.html
@@ -7,7 +7,7 @@
   <dl class ="prediction-text">
   {% for motifs in results.values() %}
     {%- for motif in motifs -%}
-    <dt>{{motif.get_name()}}</dt>
+    <dt><span class="serif">{{motif.get_name()}}</span></dt>
       <dd>Putative sactipeptide</dd>
       <dd>RODEO score: {{motif.score}}</dd>
       <dd>Core sequence, approximate: {{motif.core}}</dd>

--- a/antismash/outputs/html/css/style.scss
+++ b/antismash/outputs/html/css/style.scss
@@ -24,6 +24,10 @@ $tool-rule-based-clusters: white;
     user-select: none;
 }
 
+.serif {
+    font-family: "Courier New", serif;
+}
+
 body {
     font-family: Helvetica, Verdana, Tahoma, Sans-Serif;
     color: #555;
@@ -558,9 +562,10 @@ table.region-table {
     stroke: #888;
 }
 .svgene-locustag {
+    @extend .serif;
     fill: $antismash-main;
     display: none;
-    font-size: 80%;
+    font-size: 85%;
 }
 
 .cluster-core {
@@ -742,6 +747,7 @@ table.region-table {
     stroke: #888;
 }
 .jsdomain-orflabel {
+    @extend .serif;
     fill: #444;
 }
 .jsdomain-tooltip {
@@ -753,6 +759,7 @@ table.region-table {
 }
 
 .clusterblast-locustag {
+    @extend .serif;
     fill: $antismash-main;
     display: none;
     font-size: 80%;

--- a/antismash/outputs/html/css/style.scss
+++ b/antismash/outputs/html/css/style.scss
@@ -932,6 +932,10 @@ ul.dropdown-options {
         padding-left: 0.5em;
         padding-right: 0.5em;
 
+        /* solve edge single pixel gap */
+        padding-bottom: 1px;
+        margin-bottom: -1px;
+
         border-top-left-radius: 1em;
         border-top-right-radius: 1em;
 

--- a/antismash/outputs/html/templates/cds_detail.html
+++ b/antismash/outputs/html/templates/cds_detail.html
@@ -1,12 +1,20 @@
+{%- macro identifier(id) -%}
+    {%- if identifier -%}
+        <span class="serif">{{id}}</span>
+    {%- else -%}
+        {{id}}
+    {%- endif -%}
+{%- endmacro -%}
+
 <div class="focus-intro">
- <strong>{{feature.get_name()}}</strong><br>
+ <strong>{{identifier(feature.get_name())}}</strong><br>
  {% if feature.product and feature.gene != feature.get_name() %}
   {{feature.product}}<br>
  {% endif %}
  <br>
- Locus tag: {{feature.locus_tag}}<br>
- Protein ID: {{feature.protein_id}}<br>
- Gene: {{feature.gene}}<br>
+ Locus tag: {{identifier(feature.locus_tag)}}<br>
+ Protein ID: <span class="serif">{{feature.protein_id}}</span><br>
+ Gene: <span class="serif">{{feature.gene}}</span><br>
  {% if ec_numbers %}
   EC-Number(s): {{ec_numbers}}<br>
  {% endif %}

--- a/antismash/outputs/html/templates/overview.html
+++ b/antismash/outputs/html/templates/overview.html
@@ -47,10 +47,11 @@
   <!-- overview page -->
   {% if records %}
   <div class="page" id="overview">
+   {% set intro = "Identified secondary metabolite regions using strictness '{}'".format(options.hmmdetection_strictness) %}
    {% if options.triggered_limit %}
-     <h3>Identified secondary metabolite regions (truncated to the first {{options.limit}} record(s)) <span id="truncated"></span></h3>
+     <h3>{{intro}} (truncated to the first {{options.limit}} record(s)) <span id="truncated"></span></h3>
    {% else %}
-     <h3>Identified secondary metabolite regions<span id="truncated"></span></h3>
+     <h3>{{intro}}<span id="truncated"></span></h3>
    {% endif %}
    <div class="overview-layout">
     <div id="record-tables">


### PR DESCRIPTION
New:
- adds `hmm_detection`'s strictness level to both log and HTML (the HTML version is very simple, for now)
- all CDS names in HMTL use serif fonts to avoid `l`/`I` issues

Fixes:
- some outdated docstring
- slight oddness in HTML when viewed with MS Edge
- CDS `secmet` qualifier parsing being too strict on whitespace
- improved error messages and handling for:
  - command line arguments referring to paths
  - translations of sequences that are invalid
  - invalid feature locations