### PR TITLE
Fix candidate cluster creation

### DIFF
--- a/antismash/common/secmet/features/candidate_cluster/formation.py
+++ b/antismash/common/secmet/features/candidate_cluster/formation.py
@@ -105,13 +105,14 @@ def _find_hybrids(clusters: List[Protocluster]) -> Tuple[List[List[Protocluster]
 
     # merge the pairs into larger groups
     merged_groups = _merge_sets(groups)
-    clusters = sorted(unassigned)
+    # sort by core_location to ensure vastly different neighbourhood ranges don't cause issues
+    clusters = sorted(unassigned, key=lambda x: x.core_location.start)
 
     # then find any unassigned cluster that is fully contained by a hybrid group
     for group in merged_groups:
         core = FeatureLocation(min(proto.core_location.start for proto in group),
                                max(proto.core_location.end for proto in group))
-        index = max(0, bisect.bisect_left(clusters, core) - 1)
+        index = max(0, bisect.bisect_left([cluster.core_location.start for cluster in clusters], core.start) - 1)
         for cluster in clusters[index:]:
             if cluster.location.start > core.end:
                 break

--- a/antismash/common/secmet/features/candidate_cluster/test/test_formation.py
+++ b/antismash/common/secmet/features/candidate_cluster/test/test_formation.py
@@ -181,3 +181,19 @@ class TestCreation(unittest.TestCase):
 
         assert created[1].kind == CandidateCluster.kinds.SINGLE
         assert created[1].location == small.location
+
+    def test_multiple_contained_in_hybrid(self):
+        clusters = [
+            create_cluster(142916, 162916, 191227, 209850, "a"),  # covers whole region
+            create_cluster(142916, 162916, 169708, 189708, "b"),  # causes chem hybrid
+            create_cluster(154261, 174261, 175881, 195881, "c"),  # interleaved
+            create_cluster(160464, 180464, 183155, 203155, "d"),  # interleaved
+        ]
+        cds = create_cds(162916, 169708, ["a", "b"])
+        clusters[0].add_cds(cds)
+        clusters[1].add_cds(cds)
+
+        created = creator(clusters)
+        assert len(created) == 1
+        assert created[0].kind == CandidateCluster.kinds.CHEMICAL_HYBRID
+        assert created[0].protoclusters == tuple(clusters)


### PR DESCRIPTION
When multiple protoclusters were fully contained by a hybrid group but didn't contribute to it, sorting by neighbourhood start could cause the first of the protoclusters to be skipped.