### PR TITLE
Testing fixes

### DIFF
--- a/antismash/test/integration/integration_antismash.py
+++ b/antismash/test/integration/integration_antismash.py
@@ -112,6 +112,10 @@ class TestModuleData(unittest.TestCase):
     def tearDown(self):
         destroy_config()
 
+    def test_check_prereqs(self):
+        options = build_config(["--check-prereqs"], isolated=False, modules=get_all_modules())
+        assert run_antismash("", options) == 0
+
     def test_prepare_module_data(self):
         # make sure there's some to start with
         search = path.get_full_path(antismash.__file__, '**', "*.h3?")

--- a/antismash/test/test_antismash.py
+++ b/antismash/test/test_antismash.py
@@ -36,7 +36,7 @@ class TestAntismash(unittest.TestCase):
         assert main.verify_options(options, modules)
 
     def test_help_options(self):
-        for option in ["--list-plugins", "--check-prereqs"]:
+        for option in ["--list-plugins"]:
             options = build_config([option], isolated=False, modules=self.all_modules)
             ret_val = main.run_antismash("", options)
             assert ret_val == 0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore: .*inspect.getargspec.* is deprecated

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 filterwarnings =
     ignore: .*inspect.getargspec.* is deprecated
+    ignore: .*numpy.* size changed

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
 ]
 
 tests_require = [
-    'pytest >= 3.3.0',
+    'pytest >= 3.4.0, < 5', # pytest 5 breaks compatibility with coverage
     'minimock',
     'coverage',
     'pylint == 1.8.4', # until pylint handles ignore lines the same way


### PR DESCRIPTION
Newest versions of `pytest` are incompatible with `coverage` leading to coverage like shown here:
![image](https://user-images.githubusercontent.com/1700735/63354108-1c45e780-c364-11e9-831f-3b97b9580191.png)

To avoid this, compatible `pytest` versions have been restricted to avoid version 5+, at least until it's no longer a problem.

Other test changes:
- better silencing of warnings (e.g. numpy silences some Cython warnings, pytest unsilenced them)
- shifted a unit test that could result in calling external programs to integration tests