### PR TITLE
Modules secmet groundwork

### DIFF
--- a/antismash/common/hmmer.py
+++ b/antismash/common/hmmer.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Iterable, List, Optional
 
 from antismash.common import fasta, module_results, path, pfamdb, subprocessing
 from antismash.common.secmet import Record, CDSFeature
-from antismash.common.secmet.features import PFAMDomain
+from antismash.common.secmet.features import FeatureLocation, PFAMDomain
 from antismash.common.secmet.locations import location_from_string
 
 
@@ -75,10 +75,10 @@ class HmmerResults(module_results.ModuleResults):
     def add_to_record(self, record: Record) -> None:
         db_version = pfamdb.get_db_version_from_path(self.database)
         for i, hit in enumerate(self.hits):
+            protein_location = FeatureLocation(hit["protein_start"], hit["protein_end"])
             pfam_feature = PFAMDomain(location_from_string(hit["location"]),
-                                      description=hit["description"], protein_start=hit["protein_start"],
-                                      protein_end=hit["protein_end"], identifier=hit["identifier"],
-                                      tool=self.tool)
+                                      description=hit["description"], protein_location=protein_location,
+                                      identifier=hit["identifier"], tool=self.tool, locus_tag=hit["locus_tag"])
             for key in ["label", "locus_tag", "domain", "evalue",
                         "score", "translation"]:
                 setattr(pfam_feature, key, hit[key])

--- a/antismash/common/json.py
+++ b/antismash/common/json.py
@@ -37,7 +37,7 @@ class JSONDomain(JSONBase):
                  blast_link: str, sequence: str, dna: str) -> None:
         super().__init__(['type', 'start', 'end', 'predictions', 'napdoslink',
                           'blastlink', 'sequence', 'dna_sequence'])
-        self.type = str(domain.name)
+        self.type = str(domain.full_type)
         self.start = int(domain.start)
         self.end = int(domain.end)
         self.predictions = predictions

--- a/antismash/common/secmet/features/antismash_domain.py
+++ b/antismash/common/secmet/features/antismash_domain.py
@@ -4,13 +4,15 @@
 """ A more detailed Domain feature """
 
 from collections import OrderedDict
-from typing import Dict, List
+from typing import Any, Dict, List, Type, TypeVar
 from typing import Optional  # comment hints, pylint: disable=unused-import
 
 from Bio.SeqFeature import SeqFeature
 
 from .domain import Domain
 from .feature import Feature, Location
+
+T = TypeVar("T", bound="AntismashDomain")
 
 
 class AntismashDomain(Domain):
@@ -32,20 +34,20 @@ class AntismashDomain(Domain):
             mine.update(qualifiers)
         return super().to_biopython(mine)
 
-    @staticmethod
-    def from_biopython(bio_feature: SeqFeature, feature: "AntismashDomain" = None,  # type: ignore
-                       leftovers: Dict[str, List[str]] = None) -> "AntismashDomain":
+    @classmethod
+    def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,
+                       leftovers: Dict[str, List[str]] = None, record: Any = None) -> T:
         if leftovers is None:
             leftovers = Feature.make_qualifiers_copy(bio_feature)
         # grab mandatory qualifiers and create the class
         tool = leftovers.pop("aSTool")[0]
-        feature = AntismashDomain(bio_feature.location, tool=tool)
+        feature = cls(bio_feature.location, tool=tool)
 
         # grab optional qualifiers
         feature.domain_subtype = leftovers.pop("domain_subtype", [""])[0] or None
         feature.specificity = leftovers.pop("specificity", [])
 
         # grab parent optional qualifiers
-        super(AntismashDomain, feature).from_biopython(bio_feature, feature=feature, leftovers=leftovers)
+        super().from_biopython(bio_feature, feature=feature, leftovers=leftovers, record=record)
 
         return feature

--- a/antismash/common/secmet/features/antismash_domain.py
+++ b/antismash/common/secmet/features/antismash_domain.py
@@ -18,9 +18,10 @@ T = TypeVar("T", bound="AntismashDomain")
 class AntismashDomain(Domain):
     """ A class to represent a Domain with extra specificities and type information """
     __slots__ = ["domain_subtype", "specificity"]
+    FEATURE_TYPE = "aSDomain"
 
     def __init__(self, location: Location, tool: str) -> None:
-        super().__init__(location, feature_type="aSDomain", tool=tool, created_by_antismash=True)
+        super().__init__(location, feature_type=self.FEATURE_TYPE, tool=tool, created_by_antismash=True)
         self.domain_subtype = None  # type: Optional[str]
         self.specificity = []  # type: List[str]
 

--- a/antismash/common/secmet/features/antismash_feature.py
+++ b/antismash/common/secmet/features/antismash_feature.py
@@ -4,12 +4,14 @@
 """ A base class for all antiSMASH-specific features """
 
 from collections import OrderedDict
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from Bio.SeqFeature import SeqFeature
 
 from ..errors import SecmetInvalidInputError
 from .feature import Feature, Location
+
+T = TypeVar("T", bound="AntismashFeature")
 
 
 class AntismashFeature(Feature):
@@ -96,9 +98,9 @@ class AntismashFeature(Feature):
             mine.update(qualifiers)
         return super().to_biopython(mine)
 
-    @staticmethod
-    def from_biopython(bio_feature: SeqFeature, feature: "AntismashFeature" = None,  # type: ignore
-                       leftovers: Dict[str, List[str]] = None) -> "AntismashFeature":
+    @classmethod
+    def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,
+                       leftovers: Dict[str, List[str]] = None, record: Any = None) -> T:
         if leftovers is None:
             leftovers = Feature.make_qualifiers_copy(bio_feature)
         if not feature:
@@ -125,6 +127,6 @@ class AntismashFeature(Feature):
             feature.score = float(leftovers.pop("score")[0])
 
         # grab parent optional qualifiers
-        updated = super(AntismashFeature, feature).from_biopython(bio_feature, feature=feature, leftovers=leftovers)
+        updated = super().from_biopython(bio_feature, feature=feature, leftovers=leftovers, record=record)
         assert isinstance(updated, AntismashFeature)
         return updated

--- a/antismash/common/secmet/features/antismash_feature.py
+++ b/antismash/common/secmet/features/antismash_feature.py
@@ -117,7 +117,8 @@ class AntismashFeature(Feature):
         feature.database = leftovers.pop("database", [""])[0] or None
         feature.detection = leftovers.pop("detection", [""])[0] or None
         feature.label = leftovers.pop("label", [""])[0] or None
-        feature.locus_tag = leftovers.pop("locus_tag", [""])[0] or None
+        if not feature.locus_tag:  # may already be populated
+            feature.locus_tag = leftovers.pop("locus_tag", [""])[0] or None
         translation = leftovers.pop("translation", [""])[0] or None
         if translation is not None:
             feature.translation = translation

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -130,11 +130,12 @@ class CDSFeature(Feature):
     __slots__ = ["_translation", "protein_id", "locus_tag", "gene", "product",
                  "transl_table", "_sec_met", "_gene_functions",
                  "unique_id", "_nrps_pks", "motifs", "region"]
+    FEATURE_TYPE = "CDS"
 
     def __init__(self, location: Location, translation: str, locus_tag: str = None,
                  protein_id: str = None, product: str = "", gene: str = None,
                  translation_table: int = 1) -> None:
-        super().__init__(location, feature_type="CDS")
+        super().__init__(location, feature_type=self.FEATURE_TYPE)
         _verify_location(location)
         # mandatory
         self._gene_functions = GeneFunctionAnnotations()

--- a/antismash/common/secmet/features/cds_motif.py
+++ b/antismash/common/secmet/features/cds_motif.py
@@ -17,11 +17,12 @@ T = TypeVar("T", bound="CDSMotif")
 class CDSMotif(Domain):
     """ A base class for features that represent a motif within a CDSFeature """
     __slots__ = ["motif"]
+    FEATURE_TYPE = "CDS_motif"
 
     def __init__(self, location: Location, tool: Optional[str] = None) -> None:
         # if there's a tool, it was created by antismash
         created = tool is not None
-        super().__init__(location, feature_type="CDS_motif", tool=tool, created_by_antismash=created)
+        super().__init__(location, feature_type=self.FEATURE_TYPE, tool=tool, created_by_antismash=created)
 
     @classmethod
     def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,

--- a/antismash/common/secmet/features/cds_motif.py
+++ b/antismash/common/secmet/features/cds_motif.py
@@ -4,12 +4,14 @@
 """ A class for CDS motif features """
 
 from collections import OrderedDict
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from Bio.SeqFeature import SeqFeature
 
 from .domain import Domain
 from .feature import Feature, Location
+
+T = TypeVar("T", bound="CDSMotif")
 
 
 class CDSMotif(Domain):
@@ -21,15 +23,15 @@ class CDSMotif(Domain):
         created = tool is not None
         super().__init__(location, feature_type="CDS_motif", tool=tool, created_by_antismash=created)
 
-    @staticmethod
-    def from_biopython(bio_feature: SeqFeature, feature: Optional["CDSMotif"] = None,  # type: ignore
-                       leftovers: Optional[Dict[str, List[str]]] = None) -> "CDSMotif":
+    @classmethod
+    def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,
+                       leftovers: Optional[Dict[str, List[str]]] = None, record: Any = None) -> T:
         if leftovers is None:
             leftovers = Feature.make_qualifiers_copy(bio_feature)
         if not feature:
-            feature = CDSMotif(bio_feature.location, leftovers.pop("aSTool", [""])[0] or None)
+            feature = cls(bio_feature.location, leftovers.pop("aSTool", [""])[0] or None)
 
-        updated = super(CDSMotif, feature).from_biopython(bio_feature, feature, leftovers)
+        updated = super().from_biopython(bio_feature, feature, leftovers, record=record)
         assert updated is feature
         assert isinstance(updated, CDSMotif)
         return updated

--- a/antismash/common/secmet/features/cdscollection.py
+++ b/antismash/common/secmet/features/cdscollection.py
@@ -126,7 +126,7 @@ class CDSCollection(Feature):
         if leftovers is None:
             leftovers = Feature.make_qualifiers_copy(bio_feature)
 
-        contig_edge = leftovers.pop("contig_edge", [None])[0] == "True"
+        contig_edge = leftovers.pop("contig_edge", [""])[0] == "True"
         if not feature:
             feature = CDSCollection(bio_feature.location, bio_feature.type)
             feature._contig_edge = contig_edge  # pylint: disable=protected-access

--- a/antismash/common/secmet/features/domain.py
+++ b/antismash/common/secmet/features/domain.py
@@ -10,18 +10,52 @@ from Bio.SeqFeature import SeqFeature
 
 from antismash.common.secmet.qualifiers import ActiveSiteFinderQualifier
 
-from .feature import Feature, Location
+from .feature import Feature, FeatureLocation, Location
 from .antismash_feature import AntismashFeature
 
 T = TypeVar("T", bound="Domain")
 
 
+def generate_protein_location_from_qualifiers(qualifiers: Dict[str, List[str]], record: Any) -> FeatureLocation:
+    """ Generates a protein location from the expected qualifiers of a Domain subclass.
+        If older qualifiers are provided and the containing record is provided,
+        including the CDS containing the domain, the location will be generated.
+
+        Arguments:
+            qualifiers: the raw qualifiers of the feature, expecting:
+                     "protein_start" and "protein_end" for the simple case
+                     "locus_tag" and "translation" for the regeneration case
+            record: optionally, the containing Record
+
+        Returns:
+            the location within the parent CDS translation as a FeatureLocation
+    """
+    raw_start = qualifiers.get("protein_start", [""])[0]
+    raw_end = qualifiers.get("protein_end", [""])[0]
+
+    if raw_start:
+        start = int(raw_start)
+    else:
+        if not record:
+            raise ValueError("missing record for protein location regeneration")
+        parent = record.get_cds_by_name(qualifiers["locus_tag"][0])
+        start = parent.translation.find(qualifiers["translation"][0])
+        raw_end = ""  # don't trust an end with no start
+
+    if raw_end:
+        end = int(raw_end)
+    else:
+        end = start + len(qualifiers["translation"])
+
+    return FeatureLocation(start, end)
+
+
 class Domain(AntismashFeature):
     """ A base class for features which represent a domain type """
-    __slots__ = ["domain", "_asf"]
+    __slots__ = ["domain", "_asf", "protein_location"]
 
-    def __init__(self, location: Location, feature_type: str,
-                 domain: Optional[str] = None, tool: str = None,
+    def __init__(self, location: Location, feature_type: str, protein_location: FeatureLocation,
+                 locus_tag: str, domain: Optional[str] = None, tool: str = None,
                  created_by_antismash: bool = True) -> None:
         super().__init__(location, feature_type, tool=tool, created_by_antismash=created_by_antismash)
         if domain is not None:
@@ -30,6 +64,13 @@ class Domain(AntismashFeature):
             if not domain:
                 raise ValueError("Domain cannot be an empty string")
         self.domain = domain
+        self.protein_location = protein_location
+        if not isinstance(protein_location, FeatureLocation):
+            raise TypeError("protein location must be a FeatureLocation, not %s" % type(protein_location))
+        if not locus_tag:
+            raise ValueError("locus tag cannot be an empty string")
+        # mypy struggles with this next line, considering it an optional string, fixed with a typehint
+        self.locus_tag = str(locus_tag)  # type: str
         self._asf = ActiveSiteFinderQualifier()
 
     @property
@@ -39,6 +80,8 @@ class Domain(AntismashFeature):
 
     def to_biopython(self, qualifiers: Dict[str, List[str]] = None) -> List[SeqFeature]:
         mine = OrderedDict()  # type: Dict[str, List[str]]
+        mine["protein_start"] = [str(int(self.protein_location.start))]
+        mine["protein_end"] = [str(int(self.protein_location.end))]
         if self.domain:
             mine["aSDomain"] = [self.domain]
         if self._asf:
@@ -56,6 +99,10 @@ class Domain(AntismashFeature):
             raise ValueError("Domain shouldn't be instantiated directly")
         else:
             assert isinstance(feature, Domain), type(feature)
+
+        # clean up qualifiers that must have been used already
+        leftovers.pop("protein_start", None)
+        leftovers.pop("protein_end", None)
 
         # grab optional qualifiers
         feature.domain = leftovers.pop("aSDomain", [""])[0] or None

--- a/antismash/common/secmet/features/domain.py
+++ b/antismash/common/secmet/features/domain.py
@@ -4,7 +4,7 @@
 """ A base class for all domain sub-features """
 
 from collections import OrderedDict
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from Bio.SeqFeature import SeqFeature
 
@@ -12,6 +12,8 @@ from antismash.common.secmet.qualifiers import ActiveSiteFinderQualifier
 
 from .feature import Feature, Location
 from .antismash_feature import AntismashFeature
+
+T = TypeVar("T", bound="Domain")
 
 
 class Domain(AntismashFeature):
@@ -45,9 +47,9 @@ class Domain(AntismashFeature):
             mine.update(qualifiers)
         return super().to_biopython(mine)
 
-    @staticmethod
-    def from_biopython(bio_feature: SeqFeature, feature: "Domain" = None,  # type: ignore
-                       leftovers: Dict[str, List[str]] = None) -> "Domain":
+    @classmethod
+    def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,
+                       leftovers: Dict[str, List[str]] = None, record: Any = None) -> T:
         if leftovers is None:
             leftovers = Feature.make_qualifiers_copy(bio_feature)
         if not feature:
@@ -61,7 +63,7 @@ class Domain(AntismashFeature):
             feature.asf.add(asf_label)
 
         # grab parent optional qualifiers
-        updated = super(Domain, feature).from_biopython(bio_feature, feature=feature, leftovers=leftovers)
+        updated = super().from_biopython(bio_feature, feature=feature, leftovers=leftovers, record=record)
         assert updated is feature
         assert isinstance(updated, Domain)
         return updated

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -65,6 +65,7 @@ class Feature:
     """
     __slots__ = ["location", "notes", "type", "_qualifiers", "created_by_antismash",
                  "_original_codon_start"]
+    FEATURE_TYPE = ""  # not well defined for the base class
 
     def __init__(self, location: Location, feature_type: str,
                  created_by_antismash: bool = False) -> None:

--- a/antismash/common/secmet/features/gene.py
+++ b/antismash/common/secmet/features/gene.py
@@ -15,11 +15,12 @@ T = TypeVar("T", bound="Gene")
 class Gene(Feature):
     """ A feature representing a Gene (more general than a CDS) """
     __slots__ = ["locus_tag", "gene_name"]
+    FEATURE_TYPE = "gene"
 
     def __init__(self, location: Location, locus_tag: Optional[str] = None,
                  gene_name: Optional[str] = None, created_by_antismash: bool = False,
                  qualifiers: Optional[Dict[str, List[str]]] = None) -> None:
-        super().__init__(location, feature_type="gene",
+        super().__init__(location, feature_type=self.FEATURE_TYPE,
                          created_by_antismash=created_by_antismash)
         self.locus_tag = str(locus_tag) if locus_tag else None
         self.gene_name = str(gene_name) if gene_name else None

--- a/antismash/common/secmet/features/gene.py
+++ b/antismash/common/secmet/features/gene.py
@@ -3,11 +3,13 @@
 
 """ A feature to represent a gene """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from Bio.SeqFeature import SeqFeature
 
 from .feature import Feature, Location
+
+T = TypeVar("T", bound="Gene")
 
 
 class Gene(Feature):
@@ -49,9 +51,9 @@ class Gene(Feature):
             qualifiers["gene"] = [self.gene_name]
         return super().to_biopython(qualifiers)
 
-    @staticmethod
-    def from_biopython(bio_feature: SeqFeature, feature: "Gene" = None,  # type: ignore
-                       leftovers: Dict[str, List[str]] = None) -> "Gene":
+    @classmethod
+    def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,
+                       leftovers: Dict[str, List[str]] = None, record: Any = None) -> T:
         if leftovers is None:
             leftovers = Feature.make_qualifiers_copy(bio_feature)
         # grab mandatory qualifiers and create the class
@@ -59,6 +61,6 @@ class Gene(Feature):
         name = leftovers.pop("gene", [""])[0] or None
         if not (locus or name):
             name = "gene%s_%s" % (bio_feature.location.start, bio_feature.location.end)
-        feature = Gene(bio_feature.location, locus_tag=locus, gene_name=name)
-        super(Gene, feature).from_biopython(bio_feature, feature=feature, leftovers=leftovers)
+        feature = cls(bio_feature.location, locus_tag=locus, gene_name=name)
+        super().from_biopython(bio_feature, feature=feature, leftovers=leftovers, record=record)
         return feature

--- a/antismash/common/secmet/features/pfam_domain.py
+++ b/antismash/common/secmet/features/pfam_domain.py
@@ -22,6 +22,7 @@ class PFAMDomain(Domain):
     """
     __slots__ = ["description", "probability", "protein_start", "protein_end",
                  "gene_ontologies", "identifier", "version"]
+    FEATURE_TYPE = "PFAM_domain"
 
     def __init__(self, location: Location, description: str, protein_start: int,
                  protein_end: int, identifier: str, tool: str, domain: Optional[str] = None,
@@ -36,7 +37,7 @@ class PFAMDomain(Domain):
                 domain: the name for the domain (e.g. p450 or 'Type III restriction enzyme')
         """
         assert tool in ["test", "clusterhmmer", "fullhmmer", "toolname"], tool
-        super().__init__(location, feature_type="PFAM_domain", domain=domain, tool=tool)
+        super().__init__(location, feature_type=self.FEATURE_TYPE, domain=domain, tool=tool)
         if not isinstance(description, str):
             raise TypeError("PFAMDomain description must be a string, not %s" % type(description))
         if not description:

--- a/antismash/common/secmet/features/prepeptide.py
+++ b/antismash/common/secmet/features/prepeptide.py
@@ -10,7 +10,7 @@ from Bio.SeqFeature import SeqFeature
 
 from ..errors import SecmetInvalidInputError
 from .cds_motif import CDSMotif
-from .feature import Feature, Location
+from .feature import Feature, FeatureLocation, Location
 from ..locations import build_location_from_others, location_from_string
 from ..qualifiers.prepeptide_qualifiers import RiPPQualifier  # comment hints, pylint: disable=unused-import
 from ..qualifiers.prepeptide_qualifiers import rebuild_qualifier
@@ -43,7 +43,7 @@ class Prepeptide(CDSMotif):  # pylint: disable=too-many-instance-attributes
         """
         if not tool:
             raise ValueError("tool must not be empty or None")
-        super().__init__(location, tool=tool)
+        super().__init__(location, locus_tag, protein_location=FeatureLocation(0, len(location)), tool=tool)
         for arg in [peptide_class, core, leader, tail]:
             assert isinstance(arg, str), type(arg)
         self._leader = leader

--- a/antismash/common/secmet/features/protocluster.py
+++ b/antismash/common/secmet/features/protocluster.py
@@ -28,11 +28,12 @@ class Protocluster(CDSCollection):
     core_seqfeature_type = "proto_core"
     __slots__ = ["core_location", "detection_rule", "product", "tool", "cutoff",
                  "_definition_cdses", "neighbourhood_range", "t2pks"]
+    FEATURE_TYPE = "protocluster"  # primary type only
 
     def __init__(self, core_location: FeatureLocation, surrounding_location: FeatureLocation,
                  tool: str, product: str, cutoff: int, neighbourhood_range: int,
                  detection_rule: str) -> None:
-        super().__init__(surrounding_location, feature_type="protocluster")
+        super().__init__(surrounding_location, feature_type=self.FEATURE_TYPE)
         # cluster-wide
         self.detection_rule = detection_rule
         if not product.replace("-", "").replace("_", "").isalnum() or product[0] in "-_" or product[-1] in "-_":

--- a/antismash/common/secmet/features/region.py
+++ b/antismash/common/secmet/features/region.py
@@ -33,6 +33,7 @@ class Region(CDSCollection):
     """
     __slots__ = ["_subregions", "_candidate_clusters", "clusterblast",
                  "knownclusterblast", "subclusterblast"]
+    FEATURE_TYPE = "region"
 
     def __init__(self, candidate_clusters: List[CandidateCluster] = None,
                  subregions: List[SubRegion] = None) -> None:
@@ -55,7 +56,7 @@ class Region(CDSCollection):
 
         location = combine_locations(child.location for child in children)
 
-        super().__init__(location, feature_type="region", child_collections=children)
+        super().__init__(location, feature_type=self.FEATURE_TYPE, child_collections=children)
         self._subregions = subregions
         self._candidate_clusters = candidate_clusters
 
@@ -181,7 +182,7 @@ class Region(CDSCollection):
             first_cluster = 0
         first_subregion = min(sub.get_subregion_number() for sub in self.subregions) if self.subregions else 0
         for feature in cluster_record.features:
-            if feature.type == "region":
+            if feature.type == Region.FEATURE_TYPE:
                 candidates = feature.qualifiers.get("candidate_cluster_numbers")
                 if not candidates:
                     continue

--- a/antismash/common/secmet/features/subregion.py
+++ b/antismash/common/secmet/features/subregion.py
@@ -18,9 +18,10 @@ class SubRegion(CDSCollection):
         without being considered a cluster.
     """
     __slots__ = ["tool", "probability", "label"]
+    FEATURE_TYPE = "subregion"
 
     def __init__(self, location: FeatureLocation, tool: str, probability: float = None, label: str = "") -> None:
-        super().__init__(location, feature_type="subregion")
+        super().__init__(location, feature_type=self.FEATURE_TYPE)
         self.tool = tool
         self.probability = probability
         self.label = label  # if anchored to a gene/CDS, this is the name

--- a/antismash/common/secmet/features/subregion.py
+++ b/antismash/common/secmet/features/subregion.py
@@ -3,12 +3,14 @@
 
 """ A class for subregion features """
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from Bio.SeqFeature import SeqFeature
 
 from .cdscollection import CDSCollection
 from .feature import FeatureLocation, Feature
+
+T = TypeVar("T", bound="SubRegion")
 
 
 class SubRegion(CDSCollection):
@@ -43,9 +45,9 @@ class SubRegion(CDSCollection):
             qualifiers["label"] = [self.label]
         return super().to_biopython(qualifiers)
 
-    @staticmethod
-    def from_biopython(bio_feature: SeqFeature, feature: "SubRegion" = None,  # type: ignore
-                       leftovers: Optional[Dict] = None) -> "SubRegion":
+    @classmethod
+    def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,
+                       leftovers: Optional[Dict] = None, record: Any = None) -> T:
         if leftovers is None:
             leftovers = Feature.make_qualifiers_copy(bio_feature)
 
@@ -57,11 +59,11 @@ class SubRegion(CDSCollection):
         if not label:
             label = leftovers.pop("anchor", [""])[0]  # backwards compatibility
         if not feature:
-            feature = SubRegion(bio_feature.location, tool, probability, label)
+            feature = cls(bio_feature.location, tool, probability, label)
 
         # remove the subregion_number, as it's not relevant
         leftovers.pop("subregion_number", "")
 
         # grab parent optional qualifiers
-        super(SubRegion, feature).from_biopython(bio_feature, feature=feature, leftovers=leftovers)
+        super().from_biopython(bio_feature, feature=feature, leftovers=leftovers, record=record)
         return feature

--- a/antismash/common/secmet/features/subregion.py
+++ b/antismash/common/secmet/features/subregion.py
@@ -15,6 +15,8 @@ class SubRegion(CDSCollection):
     """ A feature which marks a specific region of a record as interesting,
         without being considered a cluster.
     """
+    __slots__ = ["tool", "probability", "label"]
+
     def __init__(self, location: FeatureLocation, tool: str, probability: float = None, label: str = "") -> None:
         super().__init__(location, feature_type="subregion")
         self.tool = tool

--- a/antismash/common/secmet/features/test/test_antismash_domain.py
+++ b/antismash/common/secmet/features/test/test_antismash_domain.py
@@ -11,13 +11,16 @@ from antismash.common.secmet.features import AntismashDomain, FeatureLocation
 
 class TestConversion(unittest.TestCase):
     def test_conversion(self):
-        domain = AntismashDomain(FeatureLocation(1, 3, 1), tool="test")
+        protein_location = FeatureLocation(0, 1)
+        domain = AntismashDomain(FeatureLocation(1, 3, 1), locus_tag="locus",
+                                 tool="test", protein_location=protein_location)
         domain.domain_subtype = "subtest"
         domain.specificity = ["a", "c", "f"]
         domain.asf.add("first")
         domain.asf.add("second")
         assert domain.tool == "test"
         assert domain.created_by_antismash
+        assert domain.locus_tag == "locus"
 
         bio = domain.to_biopython()
         assert len(bio) == 1
@@ -30,3 +33,5 @@ class TestConversion(unittest.TestCase):
         assert new_domain.asf.hits == ["first", "second"]
         assert new_domain.tool == domain.tool == "test"
         assert new_domain.created_by_antismash
+        assert new_domain.locus_tag == "locus"
+        assert new_domain.protein_location == protein_location

--- a/antismash/common/secmet/features/test/test_domain.py
+++ b/antismash/common/secmet/features/test/test_domain.py
@@ -13,15 +13,18 @@ from antismash.common.secmet.features.domain import Domain
 class TestDomain(unittest.TestCase):
     def test_construction(self):
         loc = FeatureLocation(1, 15, 1)
-        domain = Domain(loc, "test_type", tool="test")
+        protein_location = FeatureLocation(0, 3)
+        domain = Domain(loc, "test_type", tool="test", protein_location=protein_location, locus_tag="locus")
         assert domain.type == "test_type"
         assert domain.location == loc
         assert domain.created_by_antismash
         assert domain.tool == "test"
         assert domain.domain is None
+        assert domain.protein_location == protein_location
 
     def test_translation(self):
-        domain = Domain(FeatureLocation(1, 15, 1), "test_type", tool="test")
+        domain = Domain(FeatureLocation(1, 15, 1), "test_type", tool="test",
+                        protein_location=FeatureLocation(0, 3), locus_tag="locus")
         with self.assertRaisesRegex(ValueError, "has no translation"):
             assert domain.translation is None
         domain.translation = "AAA"

--- a/antismash/common/secmet/features/test/test_pfam.py
+++ b/antismash/common/secmet/features/test/test_pfam.py
@@ -13,8 +13,8 @@ from antismash.common.secmet.qualifiers import GOQualifier
 class TestConversion(unittest.TestCase):
     def test_pfam_domain(self):
         original = PFAMDomain(FeatureLocation(2, 5), description="test",
-                              protein_start=5, protein_end=10, identifier="PF00002.17",
-                              domain="p450", tool="toolname")
+                              protein_location=FeatureLocation(5, 10), identifier="PF00002.17",
+                              domain="p450", tool="toolname", locus_tag="dummyCDS")
         original.domain_id = "domain_id"
         original.database = "db"
         original.detection = "someprogram"
@@ -29,25 +29,20 @@ class TestConversion(unittest.TestCase):
         new = PFAMDomain.from_biopython(original.to_biopython()[0])
         for slot in ["tool", "domain_id", "database", "detection",
                      "evalue", "score", "locus_tag", "label", "translation", "domain",
-                     "protein_start", "protein_end", "identifier", "version"]:
+                     "protein_location", "identifier", "version"]:
             assert getattr(original, slot) == getattr(new, slot)
         assert original.gene_ontologies.go_entries == new.gene_ontologies.go_entries
         assert original.full_identifier == new.full_identifier
 
     def test_bad_pfam_domain(self):
+        protein_location = FeatureLocation(5, 10)
         with self.assertRaisesRegex(TypeError, "PFAMDomain description must be a string"):
-            PFAMDomain(FeatureLocation(2, 5), description=None, protein_start=5,
-                       protein_end=10, identifier="PF00002", tool="test")
+            PFAMDomain(FeatureLocation(2, 5), description=None, protein_location=protein_location,
+                       identifier="PF00002", tool="test", locus_tag="dummy")
         with self.assertRaisesRegex(TypeError, "Domain must be given domain as a string"):
-            PFAMDomain(FeatureLocation(2, 5), description="desc", protein_start=5,
-                       protein_end=10, identifier="PF00002", domain=5, tool="test")
-        with self.assertRaisesRegex(ValueError, "A PFAMDomain protein location cannot end before it starts"):
-            PFAMDomain(FeatureLocation(2, 5), description="desc", protein_start=10,
-                       protein_end=5, identifier="PF00002", tool="test")
-        with self.assertRaisesRegex(ValueError, "invalid literal for int()"):
-            PFAMDomain(FeatureLocation(2, 5), description="desc", protein_start=10,
-                       protein_end="nope", identifier="PF00002", tool="test")
+            PFAMDomain(FeatureLocation(2, 5), description="desc", protein_location=protein_location,
+                       identifier="PF00002", domain=5, tool="test", locus_tag="dummy")
         for ident in ["PF0002", "FAKE003", "PF", "PF000003", "PF00003.a"]:
             with self.assertRaisesRegex(ValueError, "invalid"):
-                PFAMDomain(FeatureLocation(2, 5), description="desc", protein_start=10,
-                           protein_end="nope", identifier=ident, tool="test")
+                PFAMDomain(FeatureLocation(2, 5), description="desc", protein_location=protein_location,
+                           identifier=ident, tool="test", locus_tag="dummy")

--- a/antismash/common/secmet/qualifiers/nrps_pks.py
+++ b/antismash/common/secmet/qualifiers/nrps_pks.py
@@ -9,7 +9,7 @@ from typing import Dict  # used in comment hints # pylint: disable=unused-import
 
 from .secmet import _parse_format
 
-_DOMAIN_FORMAT = "Domain: {} ({}-{}). E-value: {}. Score: {}. Matches aSDomain: {}"
+_DOMAIN_FORMAT = "Domain: {} ({:d}-{:d}). E-value: {}. Score: {}. Matches aSDomain: {}"
 _SUBTYPE_FORMAT = "subtype: {}"
 _TYPE_FORMAT = "type: {}"
 
@@ -40,10 +40,10 @@ class NRPSPKSQualifier(list):
             this same information
         """
         __slots__ = ["name", "label", "start", "end", "evalue", "bitscore",
-                     "predictions", "feature_name"]
+                     "predictions", "feature_name", "subtype"]
 
         def __init__(self, name: str, label: str, start: int, end: int,
-                     evalue: float, bitscore: float, feature_name: str) -> None:
+                     evalue: float, bitscore: float, feature_name: str, subtype: str = "") -> None:
             self.label = str(label)
             self.name = str(name)
             self.start = int(start)
@@ -54,13 +54,21 @@ class NRPSPKSQualifier(list):
                 raise ValueError("a Domain must belong to a feature, feature_name is required")
             self.feature_name = str(feature_name)
             self.predictions = {}  # type: Dict[str, str] # method to prediction name
+            self.subtype = str(subtype)
 
         def __lt__(self, other: "NRPSPKSQualifier.Domain") -> bool:
             return (self.start, self.end) < (other.start, other.end)
 
         def __repr__(self) -> str:
             return "NRPSPKSQualifier.Domain(%s, label=%s, start=%d, end=%d)" % (
-                        self.name, self.label, self.start, self.end)
+                        self.full_type, self.label, self.start, self.end)
+
+        @property
+        def full_type(self) -> str:
+            """ Returns the type of a domain, including subtype, if present """
+            if not self.subtype:
+                return self.name
+            return "{}({})".format(self.name, self.subtype)
 
     def __init__(self, strand: int) -> None:
         super().__init__()
@@ -99,7 +107,7 @@ class NRPSPKSQualifier(list):
 
     def __iter__(self) -> Iterator[str]:
         for domain in self.domains:
-            yield _DOMAIN_FORMAT.format(domain.name, domain.start, domain.end,
+            yield _DOMAIN_FORMAT.format(domain.full_type, domain.start, domain.end,
                                         domain.evalue, domain.bitscore, domain.feature_name)
         if self.type != "uninitialised":
             yield _TYPE_FORMAT.format(self.type)
@@ -114,7 +122,7 @@ class NRPSPKSQualifier(list):
         self.subtypes.append(subtype)
 
     # the domain type Any is only to avoid circular dependencies
-    def add_domain(self, domain: Any, feature_name: str) -> None:
+    def add_domain(self, domain: Any, feature_name: str, subtype: str = "") -> None:
         """ Adds a domain to the current set.
 
             Arguments:
@@ -122,11 +130,14 @@ class NRPSPKSQualifier(list):
             (see: antismash.common.hmmscan_refinement.HMMResult).
                 feature_name: the name of the matching AntismashDomain feature
                               in the same record as this qualifier
+                subtype: a specific subtype of the domain type, if any
 
             Returns:
                 None
         """
         assert not isinstance(domain, str)
+        if subtype:
+            assert domain.hit_id == "PKS_KS", domain.hit_id
         if domain.hit_id == "PKS_AT":
             self.at_counter += 1
             suffix = "_AT%d" % self.at_counter
@@ -148,7 +159,7 @@ class NRPSPKSQualifier(list):
 
         new = NRPSPKSQualifier.Domain(domain.hit_id, suffix,
                                       domain.query_start, domain.query_end,
-                                      domain.evalue, domain.bitscore, feature_name)
+                                      domain.evalue, domain.bitscore, feature_name, subtype)
         bisect.insort_right(self._domains, new)
         # update the domain name list
         self._domain_names = [domain.name for domain in self._domains]
@@ -160,9 +171,15 @@ class NRPSPKSQualifier(list):
         for qualifier in qualifiers:
             if qualifier.startswith("Domain: "):
                 parts = _parse_format(_DOMAIN_FORMAT, qualifier)
-                domain = _HMMResultLike(parts[0], int(parts[1]), int(parts[2]),
+                if parts[0].endswith(")"):
+                    name, sub = parts[0].split("(", 1)
+                    sub = sub.rstrip(")")
+                else:
+                    name = parts[0]
+                    sub = ""
+                domain = _HMMResultLike(name, int(parts[1]), int(parts[2]),
                                         float(parts[3]), float(parts[4]))
-                self.add_domain(domain, parts[5])
+                self.add_domain(domain, parts[5], sub)
             elif qualifier.startswith("subtype: "):
                 self.add_subtype(_parse_format(_SUBTYPE_FORMAT, qualifier)[0])
             elif qualifier.startswith("type: "):

--- a/antismash/common/secmet/qualifiers/secmet.py
+++ b/antismash/common/secmet/qualifiers/secmet.py
@@ -36,6 +36,10 @@ def _parse_format(fmt: str, data: str) -> Sequence[str]:
     # but from the outside in, so reverse the search and reverse the replacement
     safe = safe[::-1].replace("}}", "}\\")[::-1]  # not a raw string because that breaks the interpreter
     # step 3: replace all unescaped brace pairs with a capture group
+    # first do an integer-only pass
+    sub_search = r"(?<!\\)({\:d})"
+    safe = safe.replace("{\:d}", r"([0-9]+)")
+    # then a generic step
     sub_search = r"(?<!\\)({.*?(?<!\\)})"
     # core    "({.*?})" any brace pair and its contents
     # special "(?<!\\)" disallows any core starting or ending with an escaped brace

--- a/antismash/common/secmet/qualifiers/test/test_secmet.py
+++ b/antismash/common/secmet/qualifiers/test/test_secmet.py
@@ -29,6 +29,21 @@ class TestReverseParse(unittest.TestCase):
             assert len(parsed) == 1
             assert float(parsed[0]) == value
 
+    def test_explicit_int(self):
+        fmt = "{:d}"
+        with self.assertRaisesRegex(ValueError, "could not match format"):
+            _parse_format(fmt, "A")
+        assert _parse_format(fmt, "0152")[0] == "0152"
+
+    def test_lookalikes(self):
+        fmt = "{} ({}-{})"  # the problem case
+        parsed = _parse_format(fmt, fmt.format("a(b-c)", 5, 10))
+        assert list(parsed) == ["a", "b", "c) (5-10"]
+        # and that it's fixed by explicit int formatters
+        fmt = "{} ({:d}-{:d})"
+        parsed = _parse_format(fmt, fmt.format("a(b-c)", 5, 10))
+        assert list(parsed) == ["a(b-c)", "5", "10"]
+
     def test_literal_braces(self):
         fmt = "{{{}}}"
         formatted = fmt.format("stuff")

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -569,24 +569,24 @@ class Record:
         """ Convert a biopython feature to SecMet feature, then add it to the
             record.
         """
-        if feature.type == 'CDS':
+        if feature.type == CDSFeature.FEATURE_TYPE:
             self.add_cds_feature(CDSFeature.from_biopython(feature, record=self))
-        elif feature.type == 'gene':
-            self.add_gene(Gene.from_biopython(feature))
-        elif feature.type == "protocluster":
-            self.add_protocluster(Protocluster.from_biopython(feature))
+        elif feature.type == Gene.FEATURE_TYPE:
+            self.add_gene(Gene.from_biopython(feature, record=self))
+        elif feature.type == Protocluster.FEATURE_TYPE:
+            self.add_protocluster(Protocluster.from_biopython(feature, record=self))
         elif feature.type == "proto_core":
             # discard this, as info contained in it is in "protocluster" features
             pass
-        elif feature.type == 'CDS_motif':
+        elif feature.type == CDSMotif.FEATURE_TYPE:
             # skip component parts of prepeptides and regenerate from the core
             prepeptide = feature.qualifiers.get("prepeptide", [""])[0]
             if prepeptide:
                 if prepeptide != "core":
                     return
-                self.add_cds_motif(Prepeptide.from_biopython(feature))
+                self.add_cds_motif(Prepeptide.from_biopython(feature, record=self))
                 return
-            motif = CDSMotif.from_biopython(feature)
+            motif = CDSMotif.from_biopython(feature, record=self)
             if not motif.domain_id and not motif.created_by_antismash:
                 counter = 1
                 template = "non_aS_motif_%d_%d_{}" % (motif.location.start, motif.location.end)
@@ -594,16 +594,16 @@ class Record:
                     counter += 1
                 motif.domain_id = template.format(counter)
             self.add_cds_motif(motif)
-        elif feature.type == 'PFAM_domain':
-            self.add_pfam_domain(PFAMDomain.from_biopython(feature))
-        elif feature.type == 'aSDomain':
-            self.add_antismash_domain(AntismashDomain.from_biopython(feature))
+        elif feature.type == PFAMDomain.FEATURE_TYPE:
+            self.add_pfam_domain(PFAMDomain.from_biopython(feature, record=self))
+        elif feature.type == AntismashDomain.FEATURE_TYPE:
+            self.add_antismash_domain(AntismashDomain.from_biopython(feature, record=self))
         elif feature.type == CandidateCluster.FEATURE_TYPE:
-            raise ValueError("CandidateCluster features cannot be directly added from biopython")
-        elif feature.type == 'region':
-            raise ValueError("Region features cannot be directly added from biopython")
-        elif feature.type == 'subregion':
-            self.add_subregion(SubRegion.from_biopython(feature))
+            self.add_candidate_cluster(CandidateCluster.from_biopython(feature, record=self))
+        elif feature.type == Region.FEATURE_TYPE:
+            self.add_region(Region.from_biopython(feature, record=self))
+        elif feature.type == SubRegion.FEATURE_TYPE:
+            self.add_subregion(SubRegion.from_biopython(feature, record=self))
         else:
             self.add_feature(Feature.from_biopython(feature))
 

--- a/antismash/common/secmet/test/helpers.py
+++ b/antismash/common/secmet/test/helpers.py
@@ -24,13 +24,16 @@ from ..locations import FeatureLocation
 class DummyAntismashDomain(AntismashDomain):
     counter = 0
 
-    def __init__(self, start=0, end=3, strand=1, location=None, domain_id=None, tool="test_tool"):
+    def __init__(self, start=0, end=3, strand=1, location=None, domain_id=None, tool="test_tool",
+                 protein_start=0, protein_end=1, protein_location=None, locus_tag="dummyCDS"):
         if location is None:
             location = FeatureLocation(start, end, strand=strand)
+        if protein_location is None:
+            protein_location = FeatureLocation(protein_start, protein_end)
         if not domain_id:
             domain_id = "test_asDom_%d" % DummyAntismashDomain.counter
             DummyAntismashDomain.counter += 1
-        super().__init__(location, tool=tool)
+        super().__init__(location, tool, protein_location, locus_tag)
         self.domain_id = domain_id
 
 
@@ -60,8 +63,11 @@ class DummyCDS(CDSFeature):
 class DummyCDSMotif(CDSMotif):
     counter = 0
 
-    def __init__(self, start=0, end=6, strand=1, tool=None, domain_id=None):
-        super().__init__(FeatureLocation(start, end, strand), tool)
+    def __init__(self, start=0, end=6, strand=1, tool="test", domain_id=None,
+                 protein_start=0, protein_end=1, protein_location=None, locus_tag="dummyCDS"):
+        if not protein_location:
+            protein_location = FeatureLocation(protein_start, protein_end)
+        super().__init__(FeatureLocation(start, end, strand), locus_tag, protein_location, tool)
         if not domain_id:
             domain_id = "dummy_domain%d_%d_%d" % (DummyCDSMotif.counter, start, end)
             DummyCDSMotif.counter += 1
@@ -92,13 +98,15 @@ class DummyPFAMDomain(PFAMDomain):
     counter = 0
 
     def __init__(self, start=0, end=3, location=None, description="desc",  # pylint: disable=too-many-arguments
-                 protein_start=0, protein_end=1, identifier=None, tool="test",
-                 domain_id=None):
+                 protein_start=0, protein_end=1, identifier=None, tool="test", domain=None,
+                 domain_id=None, protein_location=None, locus_tag="dummyCDS"):
         if location is None:
             location = FeatureLocation(start, end)
         if identifier is None:
             identifier = "PF00001"
-        super().__init__(location, description, protein_start, protein_end, identifier, tool)
+        if protein_location is None:
+            protein_location = FeatureLocation(protein_start, protein_end)
+        super().__init__(location, description, protein_location, identifier, tool, locus_tag, domain=domain)
         self.domain_id = domain_id or "dummy_pfam_%d" % DummyPFAMDomain.counter
         DummyPFAMDomain.counter += 1
 

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -508,8 +508,8 @@ class TestCandidateClusterManipulation(unittest.TestCase):
 
     def test_add_biopython(self):
         bio = self.candidate_cluster.to_biopython()[0]
-        with self.assertRaisesRegex(ValueError, "cannot be directly added from biopython"):
-            self.record.add_biopython_feature(bio)
+        self.record.add_biopython_feature(bio)
+        assert self.record.get_candidate_clusters()
 
     def test_cds_linking_cds_first(self):
         inside = self.add_cds_features()
@@ -734,8 +734,8 @@ class TestRegionManipulation(unittest.TestCase):
         bio = self.region_sup.to_biopython()[0]
         # it can be converted with a record, but it won't have a region number
         assert "region_number" not in bio.qualifiers
-        with self.assertRaisesRegex(ValueError, "cannot be directly added from biopython"):
-            self.record.add_biopython_feature(bio)
+        self.record.add_biopython_feature(bio)
+        assert self.record.get_regions()
 
 
 class TestCDSUniqueness(unittest.TestCase):

--- a/antismash/common/test/helpers.py
+++ b/antismash/common/test/helpers.py
@@ -21,9 +21,12 @@ from antismash.common import serialiser, path
 from antismash.common.module_results import ModuleResults
 from antismash.common.secmet import Record
 from antismash.common.secmet.test.helpers import (  # for import by others, pylint: disable=unused-import
+    DummyAntismashDomain,
     DummyCandidateCluster,
     DummyCDS,
+    DummyCDSMotif,
     DummyFeature,
+    DummyPFAMDomain,
     DummyProtocluster,
 )
 from antismash.config import update_config

--- a/antismash/common/test/test_hmmscan_refinement.py
+++ b/antismash/common/test/test_hmmscan_refinement.py
@@ -56,6 +56,31 @@ class TestHMMResult(unittest.TestCase):
         result = refinement.HMMResult("dummy_hit", 1, 5, 3e-10, 53.5)
         assert str(result) == "HMMResult(dummy_hit, 1, 5, evalue=3e-10, bitscore=53.5)"
 
+    def test_equality(self):
+        first = refinement.HMMResult("dummy_hit", 1, 5, 3e-10, 53.5)
+        second = refinement.HMMResult("dummy_hit", 1, 5, 3e-10, 53.5)
+        assert first == second and first is not second
+        second._hit_id = "dummy"
+        assert first != second
+        second._hit_id = first._hit_id
+        second._evalue /= 10
+        assert first != second
+
+    def test_hashability(self):
+        first = refinement.HMMResult("dummy_hit", 1, 5, 3e-10, 53.5)
+        second = refinement.HMMResult("dummy_hit", 1, 5, 3e-10, 53.5)
+        different = refinement.HMMResult("dummy_hit", 1, 5, 3e-1, 53.5)
+
+        assert hash(first) == hash(second) and first is not second
+        assert hash(first) != hash(different)
+
+        used = {}
+        used[first] = 1
+        used[second] = 2
+        used[different] = 3
+
+        assert used == {first: 2, different: 3}
+
 
 class TestRefinement(unittest.TestCase):
     def setUp(self):
@@ -153,11 +178,11 @@ class TestRefinement(unittest.TestCase):
         results = [first, second]
         assert len(refinement._remove_overlapping(results, {"dummy_hit": 20})) == 2
         assert len(refinement._remove_overlapping(results, {"dummy_hit": 100})) == 2
-        first.query_end = 16
+        first._query_end = 16
         assert len(refinement._remove_overlapping(results, {"dummy_hit": 20})) == 1
         assert len(refinement._remove_overlapping(results, {"dummy_hit": 100})) == 2
 
-        first.query_end = 13
+        first._query_end = 13
         assert len(refinement._remove_overlapping(results, {"dummy_hit": 10})) == 1
         assert len(refinement._remove_overlapping(results, {"dummy_hit": 100})) == 2
 

--- a/antismash/detection/clusterfinder_probabilistic/test/test_clusterfinder.py
+++ b/antismash/detection/clusterfinder_probabilistic/test/test_clusterfinder.py
@@ -9,8 +9,8 @@ import unittest
 
 from Bio.Seq import Seq
 
-from antismash.common.secmet.features import CDSFeature, PFAMDomain, FeatureLocation
-from antismash.common.test.helpers import DummyRecord
+from antismash.common.secmet.features import CDSFeature, FeatureLocation
+from antismash.common.test.helpers import DummyRecord, DummyPFAMDomain
 from antismash.config import build_config, update_config, destroy_config
 from antismash.detection import clusterfinder_probabilistic as clusterfinder
 
@@ -45,8 +45,8 @@ class ClusterFinderTest(unittest.TestCase):
                                                  (1110, 1120, 1.0, 'PF00128')]:
             location = FeatureLocation(start, end, strand=1)
             self.record.add_cds_feature(CDSFeature(location, locus_tag=str(start), translation="A"))
-            pfam = PFAMDomain(location, "dummy_description", protein_start=start + 1,
-                              protein_end=end-1, identifier=pfam_id, tool="test")
+            pfam = DummyPFAMDomain(location=location, protein_start=start + 1,
+                                   protein_end=end-1, identifier=pfam_id)
             pfam.domain_id = "pfam_%d" % start
             pfam.probability = probability
             self.record.add_pfam_domain(pfam)

--- a/antismash/detection/genefunctions/smcogs.py
+++ b/antismash/detection/genefunctions/smcogs.py
@@ -8,6 +8,7 @@
 from typing import Dict, List
 
 from antismash.common import path
+from antismash.common.hmmscan_refinement import HMMResult
 from antismash.common.secmet import GeneFunction, CDSFeature
 from antismash.config import ConfigType
 
@@ -33,7 +34,8 @@ def classify(record_id: str, cds_features: List[CDSFeature],  # an API, so hide 
     for cds_name, result in hits.items():
         smcog_id = result.hit_id.split(":", 1)[0]
         cds_name_to_function[cds_name] = ids_to_function[smcog_id]
-        result.hit_id = result.hit_id.replace('_', ' ')
+        hits[cds_name] = HMMResult(result.hit_id.replace("_", " "), result.query_start,
+                                   result.query_end, result.evalue, result.bitscore)
     return FunctionResults(record_id, "smcogs", hits, cds_name_to_function)
 
 

--- a/antismash/detection/nrps_pks_domains/domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/domain_identification.py
@@ -14,6 +14,7 @@ from antismash.common.fasta import get_fasta_from_features
 from antismash.common.hmmscan_refinement import refine_hmmscan_results, HMMResult
 from antismash.common.secmet.record import Record
 from antismash.common.secmet.features import AntismashDomain, CDSFeature, CDSMotif
+from antismash.common.secmet.locations import FeatureLocation
 
 
 class CDSResult:
@@ -312,9 +313,11 @@ def generate_domain_features(gene: CDSFeature, domains: List[HMMResult]) -> Dict
     domain_counts = defaultdict(int)  # type: Dict[str, int]
     for domain in domains:
         loc = gene.get_sub_location_from_protein_coordinates(domain.query_start, domain.query_end)
+        prot_loc = FeatureLocation(domain.query_start, domain.query_end)
 
         # set up new feature
-        new_feature = AntismashDomain(loc, tool="nrps_pks_domains")
+        new_feature = AntismashDomain(loc, tool="nrps_pks_domains", protein_location=prot_loc,
+                                      locus_tag=gene.get_name())
         new_feature.domain = domain.hit_id
         new_feature.locus_tag = gene.locus_tag or gene.get_name()
         new_feature.detection = "hmmscan"
@@ -345,7 +348,8 @@ def generate_motif_features(feature: CDSFeature, motifs: List[HMMResult]) -> Lis
     for i, motif in enumerate(motifs):
         i += 1  # user facing, so 1-indexed
         loc = feature.get_sub_location_from_protein_coordinates(motif.query_start, motif.query_end)
-        new_motif = CDSMotif(loc, tool="nrps_pks_domains")
+        prot_loc = FeatureLocation(motif.query_start, motif.query_end)
+        new_motif = CDSMotif(loc, feature.get_name(), prot_loc, tool="nrps_pks_domains")
         new_motif.label = motif.hit_id
         new_motif.domain_id = 'nrpspksmotif_{}_{:04d}'.format(locus_tag, i)
         new_motif.evalue = motif.evalue

--- a/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
@@ -33,7 +33,7 @@ class TestTerminalRemoval(unittest.TestCase):
         hits = [dummy_hmm(start=5 + i * 10) for i in range(2)]
         for name in {'NRPS-COM_Nterm', 'NRPS-COM_Cterm', 'PKS_Docking_Cterm',
                      'PKS_Docking_Nterm'}:
-            hits[0].hit_id = name
+            hits[0]._hit_id = name
             results = self.func(self.record, {self.cds.locus_tag: hits})
             assert results[self.cds.locus_tag] == hits
 
@@ -41,18 +41,16 @@ class TestTerminalRemoval(unittest.TestCase):
         hits = [dummy_hmm(start=50 + i * 10) for i in range(2)]
         for name in {'NRPS-COM_Nterm', 'NRPS-COM_Cterm', 'PKS_Docking_Cterm',
                      'PKS_Docking_Nterm'}:
-            hits[0].hit_id = name
+            hits[0]._hit_id = name
             results = self.func(self.record, {self.cds.locus_tag: hits})
             assert results[self.cds.locus_tag] == hits[1:]
 
     def test_trailing_terminal(self):
         hits = [dummy_hmm(start=5 + i * 50) for i in range(4)]
-        print(hits)
         for name in {'NRPS-COM_Nterm', 'NRPS-COM_Cterm', 'PKS_Docking_Cterm',
                      'PKS_Docking_Nterm'}:
-            hits[-1].hit_id = name
+            hits[-1]._hit_id = name
             results = self.func(self.record, {self.cds.locus_tag: hits})
-            print(results)
             assert results[self.cds.locus_tag] == hits
 
 

--- a/antismash/modules/active_site_finder/test/test_analysis.py
+++ b/antismash/modules/active_site_finder/test/test_analysis.py
@@ -13,7 +13,7 @@ from minimock import mock, restore
 
 from antismash.common import subprocessing  # mocked, pylint: disable=unused-import
 from antismash.common import fasta, path, secmet
-from antismash.common.test.helpers import DummyRecord
+from antismash.common.test.helpers import DummyAntismashDomain, DummyRecord, DummyPFAMDomain
 from antismash.modules import active_site_finder
 from antismash.modules.active_site_finder import analysis
 
@@ -26,12 +26,10 @@ def parse_hmmpfam_results(filename):
 def rebuild_domains(filename, domain_type):
     full_path = path.get_full_path(__file__, 'data', filename)
     domain_fasta = fasta.read_fasta(full_path)
-    dummy_location = secmet.features.FeatureLocation(1, 100)
     domains = []
     for name, translation in domain_fasta.items():
-        domain = secmet.features.AntismashDomain(dummy_location, tool="test")
+        domain = DummyAntismashDomain(start=1, end=100, domain_id=domain_type + name)
         domain.domain = domain_type
-        domain.domain_id = domain_type + name
         domain.translation = translation
         domains.append(domain)
     return domains
@@ -60,15 +58,10 @@ class TestAnalyses(unittest.TestCase):
                 self.record.add_antismash_domain(domain)
         # these PFAMs found in BN001301.1 with clusterhmmer, one was excluded
         # to avoid a Biopython SearchIO bug
-        dummy_location = secmet.features.FeatureLocation(1, 100)
         domain_fasta = fasta.read_fasta(path.get_full_path(__file__, 'data', "p450.input"))
         for name, translation in domain_fasta.items():
-            pfam_domain = secmet.features.PFAMDomain(dummy_location, protein_start=5, protein_end=10,
-                                                     description="test", identifier="PF00001",
-                                                     tool="test")
+            pfam_domain = DummyPFAMDomain(domain="p450", domain_id="PFAM_p450_" + name)
             pfam_domain.translation = translation
-            pfam_domain.domain_id = "PFAM_p450_" + name
-            pfam_domain.domain = "p450"
             self.record.add_pfam_domain(pfam_domain)
 
     def tearDown(self):

--- a/antismash/modules/nrps_pks/test/test_nrps_predictor.py
+++ b/antismash/modules/nrps_pks/test/test_nrps_predictor.py
@@ -10,7 +10,7 @@ from jinja2 import Markup
 from minimock import mock, restore
 
 from antismash.common import path, fasta, subprocessing  # mocked # pylint: disable=unused-import
-from antismash.common.secmet import AntismashDomain, FeatureLocation
+from antismash.common.test.helpers import DummyAntismashDomain
 from antismash.modules.nrps_pks import nrps_predictor, data_structures
 
 
@@ -209,8 +209,7 @@ class TestAngstromGeneration(unittest.TestCase):
         restore()
 
     def test_angstrom(self):
-        domain = AntismashDomain(FeatureLocation(1, 2), "test")
-        domain.domain_id = "query"
+        domain = DummyAntismashDomain(domain_id="query")
         domain.translation = self.aligns[domain.domain_id].replace("-", "")
 
         sig = nrps_predictor.get_34_aa_signature(domain)

--- a/antismash/modules/pfam2go/test/integration_pfam2go.py
+++ b/antismash/modules/pfam2go/test/integration_pfam2go.py
@@ -8,7 +8,6 @@ import unittest
 
 import antismash
 from antismash.common import record_processing
-from antismash.common.secmet import PFAMDomain, FeatureLocation
 from antismash.common.test import helpers
 from antismash.config import build_config, destroy_config
 from antismash.modules import pfam2go
@@ -28,10 +27,7 @@ class PfamToGoTest(unittest.TestCase):
         assert not record.get_pfam_domains()
 
         # add a test PFAM
-        pfam = PFAMDomain(FeatureLocation(2, 5), description="test",
-                          protein_start=5, protein_end=10, identifier="PF00005",
-                          domain="PF00005", tool="test")
-        pfam.domain_id = "test"
+        pfam = helpers.DummyPFAMDomain(identifier="PF00005", domain="PF00005")
         record.add_pfam_domain(pfam)
         assert len(record.get_pfam_domains()) == 1
 

--- a/antismash/modules/pfam2go/test/test_pfam2go.py
+++ b/antismash/modules/pfam2go/test/test_pfam2go.py
@@ -14,18 +14,17 @@ from Bio.Seq import Seq
 from Bio.SeqFeature import FeatureLocation
 
 from antismash.common import path
-from antismash.common.secmet.features import PFAMDomain
 from antismash.common.secmet.record import Record
-from antismash.common.test.helpers import DummyRecord
+from antismash.common.test.helpers import DummyRecord, DummyPFAMDomain
 from antismash.modules.pfam2go import pfam2go
 
 
 def set_dummy_with_pfams(pfam_ids: Dict[str, FeatureLocation]) -> DummyRecord:
     pfam_domains = []
     for pfam_id, pfam_location in pfam_ids.items():
-        pfam_domain = PFAMDomain(location=pfam_location, description='FAKE', protein_start=0, protein_end=5,
-                                 identifier=pfam_id, tool="test")
-        pfam_domain.domain_id = '%s.%d.%d' % (pfam_id, pfam_location.start, pfam_location.end)
+        domain_id = '%s.%d.%d' % (pfam_id, pfam_location.start, pfam_location.end)
+        pfam_domain = DummyPFAMDomain(location=pfam_location, protein_start=0, protein_end=5,
+                                      identifier=pfam_id, domain_id=domain_id)
         pfam_domains.append(pfam_domain)
     return DummyRecord(features=pfam_domains)
 
@@ -102,10 +101,7 @@ class PfamToGoTest(unittest.TestCase):
     def test_blank_records(self):
         blank_no_pfams = DummyRecord()
         blank_no_ids = Record(Seq("ATGTTATGAGGGTCATAACAT", generic_dna))
-        fake_pfam_location = FeatureLocation(0, 12)
-        fake_pfam = PFAMDomain(location=fake_pfam_location, description='MCPsignal', protein_start=0, protein_end=5,
-                               identifier="PF00000", tool="test")
-        fake_pfam.domain_id = 'BLANK'
+        fake_pfam = DummyPFAMDomain(identifier="PF00000")
         blank_no_ids.add_pfam_domain(fake_pfam)
 
         assert not pfam2go.get_gos_for_pfams(blank_no_pfams)
@@ -126,9 +122,7 @@ class PfamToGoTest(unittest.TestCase):
         pfams = {'PF00015.2': FeatureLocation(0, 3), 'PF00351.1': FeatureLocation(0, 3),
                  'PF00015.27': FeatureLocation(3, 6)}
         fake_record = set_dummy_with_pfams(pfams)
-        fake_duplicate_pfam = PFAMDomain(location=FeatureLocation(6, 9), description='DUPLICATE', protein_start=0,
-                                         protein_end=5, identifier="PF00015.2", tool="test")
-        fake_duplicate_pfam.domain_id = 'DUPLICATE'
+        fake_duplicate_pfam = DummyPFAMDomain(identifier="PF00015.2")
         fake_record.add_pfam_domain(fake_duplicate_pfam)
         assert fake_duplicate_pfam in fake_record.get_pfam_domains()
         gos_for_fake_pfam = pfam2go.get_gos_for_pfams(fake_record)

--- a/antismash/modules/t2pks/t2pks_analysis.py
+++ b/antismash/modules/t2pks/t2pks_analysis.py
@@ -74,9 +74,9 @@ def run_starter_unit_blastp(cds_hmm_hits: Dict[CDSFeature, List[HMMResult]]
 
     results = refine_hmmscan_results(blastp_results, fasta_lengths)
     for hits in results.values():
-        for hit in hits:
+        for i, hit in enumerate(hits):
             if not hit.hit_id.endswith("-CoA"):
-                hit.hit_id += "-CoA"
+                hits[i] = HMMResult(hit.hit_id + "-CoA", hit.query_start, hit.query_end, hit.evalue, hit.bitscore)
     return results
 
 

--- a/antismash/outputs/html/js.py
+++ b/antismash/outputs/html/js.py
@@ -251,7 +251,7 @@ def generate_asf_tooltip_section(record: Record, feature: CDSFeature) -> Dict[Tu
         if not pfam.domain:
             continue
         if pfam.asf.hits:
-            asf_notes[(pfam.domain, pfam.protein_start, pfam.protein_end)] = pfam.asf.hits
+            asf_notes[(pfam.domain, pfam.protein_location.start, pfam.protein_location.end)] = pfam.asf.hits
     return asf_notes
 
 


### PR DESCRIPTION
Makes required changes for a good implementation of #182 storing modules in genbank. Most changes are for consistency between features.

- `HMMResult` now hides attributes in order to be more safely hashable and compared in a dict
- all `Domain` subclasses are required to have locus tag and protein location provided, rather than just in `PFAMDomain`s