### PR TITLE
secmet: fix inconsistent sorting in interleaved candidate construction

### DIFF
--- a/antismash/common/secmet/features/candidate_cluster/formation.py
+++ b/antismash/common/secmet/features/candidate_cluster/formation.py
@@ -137,9 +137,12 @@ def _find_interleaved(clusters: List[Protocluster], candidates: List[CandidateCl
             if locations_overlap(candidate.core_location, other_candidate.core_location):
                 groups.append(set(candidate.protoclusters + other_candidate.protoclusters))
 
+    # sort unassigned by core location, as that's the important part
+    unassigned_by_core = sorted(clusters, key=lambda x: x.core_location.start)
+
     # unassigned overlapping with unassigned
-    for i, cluster in enumerate(clusters[:-1]):
-        for other_cluster in clusters[i + 1:]:
+    for i, cluster in enumerate(unassigned_by_core):
+        for other_cluster in unassigned_by_core[i + 1:]:
             if cluster.core_location.end <= other_cluster.core_location.start:
                 break
             if locations_overlap(cluster.core_location, other_cluster.core_location):
@@ -148,7 +151,7 @@ def _find_interleaved(clusters: List[Protocluster], candidates: List[CandidateCl
                 found.add(other_cluster)
 
     # unassigned overlapping with candidates
-    for cluster in clusters:
+    for cluster in unassigned_by_core:
         index = max(0, bisect.bisect_left(candidates, cluster) - 1)
         for candidate in candidates[index:]:
             if candidate.location.start > cluster.location.end:

--- a/antismash/common/secmet/features/candidate_cluster/test/test_formation.py
+++ b/antismash/common/secmet/features/candidate_cluster/test/test_formation.py
@@ -169,6 +169,20 @@ class TestCreation(unittest.TestCase):
         assert created[3].location == FeatureLocation(1000, 1600)
         assert created[3].kind == CandidateCluster.kinds.CHEMICAL_HYBRID
 
+    def test_interleaving_order(self):
+        clusters = [create_cluster(1000, 1100, 1400, 1500, "a"),
+                    create_cluster(1050, 2000, 3000, 4000, "b"), # sorts second due to neighbouring
+                    create_cluster(1100, 1200, 1500, 1600, "c")]
+        assert sorted(clusters) == clusters
+        created = creator(clusters)
+        assert len(created) == 3
+        assert created[0].kind == CandidateCluster.kinds.NEIGHBOURING
+        assert created[0].location == FeatureLocation(1000, 4000)
+        assert created[1].kind == CandidateCluster.kinds.INTERLEAVED
+        assert created[1].location == FeatureLocation(1000, 1600)
+        assert created[2].kind == CandidateCluster.kinds.SINGLE
+        assert created[2].location == FeatureLocation(1050, 4000)
+
     def test_contained_neighbours(self):
         big = create_cluster(0, 100, 130, 230, "a")
         small = create_cluster(10, 20, 30, 40, "b")


### PR DESCRIPTION
Interleaved cluster formation was using a list sorted by `core_location` in an inner loop, but not the outer loop (instead using `location`, which includes the neighbourhood), leading to early breaks and interleaved clusters being skipped (though singles/neighbouring would still be created).