### PR TITLE
Better handling of missing executables when checking prereqs

### DIFF
--- a/antismash/common/hmmer.py
+++ b/antismash/common/hmmer.py
@@ -11,6 +11,7 @@ from antismash.common import fasta, module_results, path, pfamdb, subprocessing
 from antismash.common.secmet import Record, CDSFeature
 from antismash.common.secmet.features import FeatureLocation, PFAMDomain
 from antismash.common.secmet.locations import location_from_string
+from antismash.config import get_config
 
 
 class HmmerResults(module_results.ModuleResults):
@@ -160,6 +161,12 @@ def ensure_database_pressed(filepath: str, return_not_raise: bool = False) -> Li
 
     if path.is_outdated(components, filepath):
         logging.info("%s components missing or obsolete, re-pressing database", filepath)
+        if "hmmpress" not in get_config().executables:
+            msg = "Failed to hmmpress {!r}: cannot find executable for hmmpress".format(filepath)
+            if not return_not_raise:
+                raise RuntimeError(msg)
+            return [msg]
+
         result = subprocessing.run_hmmpress(filepath)
         if not result.successful():
             msg = "Failed to hmmpress {!r}: {}".format(filepath, result.stderr)

--- a/antismash/modules/clusterblast/__init__.py
+++ b/antismash/modules/clusterblast/__init__.py
@@ -103,6 +103,10 @@ def check_prereqs(options: ConfigType) -> List[str]:
         if binary_name not in options.executables:
             failure_messages.append("Failed to locate file: %r" % binary_name)
 
+    if "diamond" not in get_config().executables:
+        failure_messages.append("cannot check clusterblast databases, no diamond executable present")
+        return failure_messages
+
     failure_messages.extend(prepare_data(logging_only=True))
 
     failure_messages.extend(check_known_prereqs(options))


### PR DESCRIPTION
When some prerequisites were missing, they might still get used to check other prereqs (e.g. HMMer databases were pressed). This ensures that `--check-prereqs` doesn't crash out with errors in the process.