### PR TITLE
Misc small fixes

### DIFF
--- a/antismash/common/gff_parser.py
+++ b/antismash/common/gff_parser.py
@@ -77,8 +77,10 @@ def check_gff_suitability(gff_file: str, sequences: List[SeqRecord]) -> None:
             raise AntismashInputError('GFF3 structure is not suitable.')
 
     except AssertionError as err:
-        logging.error('Parsing %r failed: %s', gff_file, err)
-        raise AntismashInputError(str(err)) from err
+        # usually the assertion "assert len(parts) >= 8, line"
+        # so strip the newline and improve the error message
+        message = str(err).strip()
+        raise AntismashInputError("parsing GFF failed with invalid format: %r" % message) from err
 
 
 def get_features_from_file(handle: IO) -> Dict[str, List[SeqFeature]]:

--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -167,7 +167,7 @@ def find_protoclusters(record: Record, cds_by_cluster_type: Dict[str, Set[str]],
         cutoff = rule.cutoff
         core_location = cds_features[0].location
         for cds in cds_features[1:]:
-            if cds.overlaps_with(FeatureLocation(core_location.start - cutoff,
+            if cds.overlaps_with(FeatureLocation(max(0, core_location.start - cutoff),
                                                  core_location.end + cutoff)):
                 core_location = FeatureLocation(min(cds.location.start, core_location.start),
                                                 max(cds.location.end, core_location.end))
@@ -346,7 +346,7 @@ def apply_cluster_rules(record: Record, results_by_id: Dict[str, List[HSP]],
         info_by_range = {}  # type: Dict[int, Tuple[Dict[str, CDSFeature], Dict[str, List[HSP]]]]
         for rule in rules:
             if rule.cutoff not in info_by_range:
-                location = FeatureLocation(feature_start - rule.cutoff, feature_end + rule.cutoff)
+                location = FeatureLocation(max(0, feature_start - rule.cutoff), feature_end + rule.cutoff)
                 nearby = record.get_cds_features_within_location(location, with_overlapping=True)
                 nearby_features = {neighbour.get_name(): neighbour for neighbour in nearby}
                 nearby_results = {neighbour: results_by_id[neighbour]

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -75,6 +75,8 @@ class Feature:
         if location_contains_overlapping_exons(location):
             raise ValueError("location contains overlapping exons: %s" % location)
         assert location.start <= location.end, "Feature location invalid: %s" % location
+        if location.start < 0:
+            raise ValueError("location contains negative coordinate: %s" % location)
         self.location = location
         self.notes = []  # type: List[str]
         if not 1 <= len(feature_type) < 16:  # at 16 the name merges with location in genbanks

--- a/antismash/common/secmet/features/module.py
+++ b/antismash/common/secmet/features/module.py
@@ -145,6 +145,10 @@ class Module(Feature):
         """ Returns True if the module contains domains from multiple CDS features """
         return len(self._parent_cds_names) > 1
 
+    def get_substrate_monomer_pairs(self) -> Tuple[Tuple[str, str], ...]:
+        """ Returns the substrate/monomer pairings as a tuple of tuples """
+        return tuple(self._substrate_monomer_pairs)
+
     def to_biopython(self, qualifiers: Dict[str, Any] = None) -> List[SeqFeature]:
         new = {
             "domains": [domain.get_name() for domain in self.domains],

--- a/antismash/common/secmet/features/test/test_feature.py
+++ b/antismash/common/secmet/features/test/test_feature.py
@@ -169,6 +169,11 @@ class TestFeature(unittest.TestCase):
 
         assert sorted([feature, before, after, longer]) == [before, feature, longer, after]
 
+    def test_negative_locations(self):
+        loc = FeatureLocation(-2, 500, strand=1)
+        with self.assertRaisesRegex(ValueError, "negative coordinate"):
+            Feature(loc, feature_type="")
+
 
 class TestLocationAdjustment(unittest.TestCase):
     def setUp(self):

--- a/antismash/common/secmet/features/test/test_module.py
+++ b/antismash/common/secmet/features/test/test_module.py
@@ -23,7 +23,8 @@ def add_module_references_to_record(module, record):
         try:
             record.get_cds_by_name(domain.locus_tag)
         except KeyError:
-            record.add_cds_feature(DummyCDS(start=module.location.start - 10, end=module.location.end + 10,
+            record.add_cds_feature(DummyCDS(start=max(0, module.location.start - 10),
+                                            end=module.location.end + 10,
                                             locus_tag=domain.locus_tag))
 
 

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -441,6 +441,10 @@ class Record:
                     index -= 1
             return index
 
+        if location.start < 0:
+            assert isinstance(location, FeatureLocation)
+            location = FeatureLocation(0, max(1, location.end))
+
         results = []  # type: List[CDSFeature]
         # shortcut if no CDS features exist
         if not self._cds_features:

--- a/antismash/detection/genefinding/test/integration_glimmerhmm.py
+++ b/antismash/detection/genefinding/test/integration_glimmerhmm.py
@@ -35,3 +35,14 @@ class TestGlimmerHMM(TestCase):
         assert record.get_feature_count() == 11
         # and make sure they're all CDS features
         assert len(record.get_cds_features()) == 11
+
+    def test_records_with_bad_names(self):
+        # reuse fumigatus and change the id to bad ids
+        for bad in [
+            ".",  # changes due to glimmerhmm
+            "-bad",  # could cause a fasta file to be created that is interpreted as an arg
+        ]:
+            record = parse_input_sequence(self.data_file('fumigatus.cluster1.fna'), taxon="fungi")[0]
+            record.id = bad
+            record = pre_process_sequences([record], self.options, genefinding)[0]
+            assert record.get_cds_features()

--- a/antismash/detection/nrps_pks_domains/domain_drawing.py
+++ b/antismash/detection/nrps_pks_domains/domain_drawing.py
@@ -160,8 +160,8 @@ def generate_js_domains(region: Region, record: Record) -> Dict[str, Union[str, 
                 monomer = module.monomers[0][1]
                 if monomer.endswith("pk"):
                     monomer = monomer[:-2] + "?"
-                if monomer.endswith("nrp"):
-                    monomer = monomer[:-3] + "?"
+                if monomer.endswith("X"):
+                    monomer = monomer[:-1] + "?"
             js_module = JSONModule(module.protein_location.start, module.protein_location.end,
                                    module.is_complete(), module.is_iterative(), monomer)
             js_orf.add_module(js_module)

--- a/antismash/outputs/html/js.py
+++ b/antismash/outputs/html/js.py
@@ -111,6 +111,8 @@ def convert_cds_features(record: Record, features: Iterable[CDSFeature], options
             "type": str(gene_function),
             "description": description,
         })
+        if feature.gene_functions.get_by_tool("resist"):  # don't add to every gene for size reasons
+            js_orfs[-1]["resistance"] = True
     return js_orfs
 
 


### PR DESCRIPTION
Better input handling:
- records named `.` no longer cause a crash after running glimmerhmm
- negative coordinates no longer permitted (also prevents creation of some empty translations)
- improved error handling on badly formatted GFF inputs

Visualisation:
- resistance indicators shown again in HTML
- module lids replace `X` substrates with `?` as per the original version (lost after change from `nrp` to `X`)

Also adds a getter for pairings of substrate and monomer to `secmet.Module` features.