### PR TITLE
hmm_detection: find more transAT-PKS clusters

### DIFF
--- a/antismash/detection/hmm_detection/cluster_rules/strict.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/strict.txt
@@ -24,8 +24,12 @@ RULE T3PKS
 RULE transAT-PKS
     CUTOFF 45  # kirromycin (CP006259) has a range of ~42kb
     NEIGHBOURHOOD 20
-    CONDITIONS cds(ATd and (PKS_KS or ene_KS or mod_KS or hyb_KS or itr_KS or tra_KS))
-               and cds(PKS_AT and not (PKS_KS or ene_KS or mod_KS or hyb_KS or itr_KS or tra_KS))
+    CONDITIONS cds(PKS_AT and not (PKS_KS or ene_KS or mod_KS or hyb_KS or itr_KS or tra_KS))
+               and (
+                cds(ATd and (PKS_KS or ene_KS or mod_KS or hyb_KS or itr_KS or tra_KS))
+                # handle CP001511 5k-30k as per https://doi.org/10.1002/ange.201709056
+                or cds(tra_KS and PP-binding)
+               )
 
 RULE hglE-KS
     COMMENT heterocyst glycolipid synthase like PKS such as KC489223


### PR DESCRIPTION
CP001511 contains a transAT cluster around 5k to 30k, as described in
https://doi.org/10.1002/ange.201709056
This was missed with the rules that required an ATd domain.

AB088224 is another example of a transAT without an ATd.