### PR TITLE
Handle genbank format introducing whitespace in domain names

### DIFF
--- a/antismash/common/external/rodeo_svm/svm_classify.py
+++ b/antismash/common/external/rodeo_svm/svm_classify.py
@@ -51,10 +51,10 @@
 '''
 import csv
 
+import joblib
 import sklearn
 from sklearn import svm
 from sklearn import preprocessing
-from sklearn.externals import joblib
 
 # CONFIGURATION OPTIONS
 # change these as desired

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -98,7 +98,7 @@ def parse_input_sequence(filename: str, taxon: str = "bacteria", minimum_length:
 
     for record in records:
         if isinstance(record.seq.alphabet, Bio.Alphabet.ProteinAlphabet) or not is_nucl_seq(record.seq):
-            raise AntismashInputError("protein records are not supported")
+            raise AntismashInputError("protein records are not supported: %s" % record.id)
 
     # before conversion to secmet records, trim if required
     if start > -1 or end > -1:

--- a/antismash/common/secmet/features/antismash_feature.py
+++ b/antismash/common/secmet/features/antismash_feature.py
@@ -114,9 +114,16 @@ class AntismashFeature(Feature):
 
         # grab optional qualifiers
         feature.domain_id = leftovers.pop("domain_id", [""])[0] or None
+        if feature.domain_id:
+            # long ids causing linebreaks in genbanks can have spaces inserted
+            # strip them out so id-based lookups can function again
+            feature.domain_id = feature.domain_id.replace(" ", "")
         feature.database = leftovers.pop("database", [""])[0] or None
         feature.detection = leftovers.pop("detection", [""])[0] or None
         feature.label = leftovers.pop("label", [""])[0] or None
+        if feature.label:
+            # again, long ids causing linebreaks in genbanks can have spaces inserted
+            feature.label = feature.label.replace(" ", "")
         if not feature.locus_tag:  # may already be populated
             feature.locus_tag = leftovers.pop("locus_tag", [""])[0] or None
         translation = leftovers.pop("translation", [""])[0] or None

--- a/antismash/modules/lanthipeptides/rodeo.py
+++ b/antismash/modules/lanthipeptides/rodeo.py
@@ -15,7 +15,7 @@ import re
 from tempfile import NamedTemporaryFile
 from typing import Dict, List, Set, Tuple
 
-from sklearn.externals import joblib
+import joblib
 
 from antismash.common import path, subprocessing, secmet, utils
 from antismash.config import get_config as get_global_config

--- a/antismash/modules/lassopeptides/specific_analysis.py
+++ b/antismash/modules/lassopeptides/specific_analysis.py
@@ -14,7 +14,7 @@ import os
 from typing import Any, Dict, List, Optional, Set, Tuple, Union  # pylint: disable=unused-import
 
 from helperlibs.wrappers.io import TemporaryFile
-from sklearn.externals import joblib
+import joblib
 
 from antismash.common import all_orfs, module_results, path, subprocessing, utils
 from antismash.common.secmet import Record, CDSFeature, Protocluster, Prepeptide, GeneFunction

--- a/antismash/modules/sactipeptides/specific_analysis.py
+++ b/antismash/modules/sactipeptides/specific_analysis.py
@@ -14,7 +14,7 @@ import re
 from typing import Any, Dict, Set, List, Optional, Tuple, Union
 
 from Bio.SearchIO._model.hsp import HSP
-from sklearn.externals import joblib
+import joblib
 
 from antismash.common import utils, all_orfs, module_results, secmet, subprocessing, path, fasta
 from antismash.common.secmet.qualifiers import SecMetQualifier

--- a/antismash/modules/thiopeptides/rodeo.py
+++ b/antismash/modules/thiopeptides/rodeo.py
@@ -7,7 +7,7 @@ import os
 import re
 from typing import List, Set, Tuple, Optional  # pylint: disable=unused-import
 
-from sklearn.externals import joblib
+import joblib
 
 from antismash.common import path, utils
 

--- a/antismash/outputs/html/css/style.scss
+++ b/antismash/outputs/html/css/style.scss
@@ -821,10 +821,6 @@ table.region-table {
     stroke: rgb(221,6,6);
     fill: rgb(247,129,129);
 }
-.jsdomain-mod-kr {
-    stroke: rgb(10,160,76);
-    fill: rgb(128,246,128);
-}
 .jsdomain-mod-dh {
     stroke: rgb(186,103,15);
     fill: rgb(247,190,129);

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ install_requires = [
     'biopython >= 1.71',
     'helperlibs',
     'jinja2',
+    'joblib',
     'pysvg-py3',
     'bcbio-gff',
     'pyScss',


### PR DESCRIPTION
When domain names are too long for a single line in a genbank qualifier, they introduce a whitespace which causes the `from_biopython()` conversion of an NRPS/PKS module feature to raise an error about unknown domain names.

This fix removes whitespace in domain names when converting from biopython to be consistent.

Two other tiny fixes are included:
- better reporting of which record is at fault if a protein record is detected
- removes some duplicate CSS definitions