### PR TITLE
Small fixes

### DIFF
--- a/antismash/common/external/rodeo_svm/svm_classify.py
+++ b/antismash/common/external/rodeo_svm/svm_classify.py
@@ -73,7 +73,7 @@ gamma_option = 1.78E-09
 class_weight_option = 'balanced'
 
 # sklearn < 0.17.0 doesn't know 'balanced'
-sklearn_int_versions = list(map(int, sklearn.__version__.split('.')))
+sklearn_int_versions = list(map(int, sklearn.__version__.split('.')[:2]))
 if sklearn_int_versions[0] == 0 and sklearn_int_versions[1] < 17:
     class_weight_option = 'auto'
 

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -252,8 +252,6 @@ class CDSFeature(Feature):
         transl_table = 1
         if record:
             transl_table = record.transl_table
-        if "transl_table" in leftovers:
-            transl_table = int(leftovers.pop("transl_table")[0])
 
         # semi-optional qualifiers
         protein_id = leftovers.pop("protein_id", [None])[0]
@@ -266,6 +264,13 @@ class CDSFeature(Feature):
                 gene = "cds%s_%s"
             gene = gene % (bio_feature.location.start, bio_feature.location.end)
         name = locus_tag or protein_id or gene
+
+        if "transl_table" in leftovers:
+            raw_table = leftovers.pop("transl_table")[0]
+            try:
+                transl_table = int(raw_table)
+            except ValueError:
+                raise SecmetInvalidInputError("invalid translation table '%s' for CDS '%s'" % (raw_table, name))
 
         try:
             _verify_location(bio_feature.location)

--- a/antismash/common/secmet/features/test/test_cds_feature.py
+++ b/antismash/common/secmet/features/test/test_cds_feature.py
@@ -135,6 +135,12 @@ class TestCDSBiopythonConversion(unittest.TestCase):
             with self.assertRaisesRegex(SecmetInvalidInputError, "translation extends out of record"):
                 CDSFeature.from_biopython(bio, record=rec)
 
+    def test_invalid_translation_table(self):
+        bio = self.cds.to_biopython()[0]
+        bio.qualifiers["transl_table"] = ["11a"]
+        with self.assertRaisesRegex(SecmetInvalidInputError, "invalid translation table"):
+            CDSFeature.from_biopython(bio)
+
 
 class TestCDSProteinLocation(unittest.TestCase):
     def setUp(self):

--- a/antismash/common/secmet/qualifiers/nrps_pks.py
+++ b/antismash/common/secmet/qualifiers/nrps_pks.py
@@ -27,7 +27,7 @@ class _HMMResultLike:
         self.bitscore = bitscore
 
 
-class NRPSPKSQualifier(list):
+class NRPSPKSQualifier:
     """ A qualifier for tracking information about NRPS/PKS domains within a CDS.
 
         Can be used directly as a qualifier for Biopython's SeqFeature.
@@ -95,12 +95,6 @@ class NRPSPKSQualifier(list):
     def domain_names(self) -> List[str]:
         """ Returns a list of domain names in order first to last position on the strand """
         return self._domain_names
-
-    def append(self, _value: Any) -> None:
-        raise NotImplementedError("Appending to this list won't work, use add_subtype() or add_domain()")
-
-    def extend(self, _values: Any) -> None:
-        raise NotImplementedError("Extending this list won't work")
 
     def __len__(self) -> int:
         return len(self.subtypes) + len(self._domains)

--- a/antismash/common/secmet/qualifiers/test/test_nrpspks.py
+++ b/antismash/common/secmet/qualifiers/test/test_nrpspks.py
@@ -26,17 +26,8 @@ class TestNRPSPKS(unittest.TestCase):
         assert len(qualifier.domains) == 3 * len(types)
         assert {domain.label for domain in qualifier.domains} == expected
 
-    def test_no_append(self):
-        qualifier = NRPSPKSQualifier(strand=1)
-        with self.assertRaisesRegex(NotImplementedError, "Appending to this list won't work"):
-            qualifier.append("test")
-
-        with self.assertRaisesRegex(NotImplementedError, "Extending this list won't work"):
-            qualifier.extend(["test"])
-
     def test_biopython_compatibility(self):
         qualifier = NRPSPKSQualifier(strand=1)
-        assert isinstance(qualifier, list)
         for pks in ["PKS_AT", "AMP-binding"]:
             qualifier.add_domain(HMMResult(pks, 1, 1, 1, 1), "missing")
             qualifier.add_subtype(pks + "dummy")


### PR DESCRIPTION
A few small code changes to fix some recent issues.

- fixes #246 by focusing on only the relevant parts of the version information
- fixes the conda-specific #237 where multiprocessing handles a class inheriting from list differently than standard python installs
- improves the error message generated when a CDS `transl_table` qualifier is invalid