### PR TITLE
config: fix alternative fasttree executable spelling

### DIFF
--- a/antismash/config/executables.py
+++ b/antismash/config/executables.py
@@ -24,7 +24,7 @@ _ALTERNATE_EXECUTABLE_NAMES = {
     ],
     "fasttree": [
         "fasttree",  # general
-        "Fasttree",  # as per install from source instructions
+        "FastTree",  # as per install from source instructions
     ],
 }
 


### PR DESCRIPTION
When installed from source (or homebrew), the fasttree executable is called FastTree, not Fasttree

Signed-off-by: Kai Blin <kblin@biosustain.dtu.dk>