### PR TITLE
clusterfinder: fix subregions being added twice

### DIFF
--- a/antismash/detection/clusterfinder_probabilistic/__init__.py
+++ b/antismash/detection/clusterfinder_probabilistic/__init__.py
@@ -172,7 +172,4 @@ def generate_results(record: Record, options: ConfigType) -> ClusterFinderResult
     for prediction in predictions:
         new_areas.append(SubRegion(prediction.location, tool="clusterfinder",
                                    probability=prediction.probability))
-    if options.cf_create_clusters:
-        for area in new_areas:
-            record.add_subregion(area)
     return ClusterFinderResults(record.id, new_areas, create=options.cf_create_clusters)

--- a/antismash/detection/clusterfinder_probabilistic/test/test_clusterfinder.py
+++ b/antismash/detection/clusterfinder_probabilistic/test/test_clusterfinder.py
@@ -93,11 +93,12 @@ class ClusterFinderTest(unittest.TestCase):
 
     def test_no_overlaps(self):
         results = clusterfinder.generate_results(self.record, self.config)
-        areas = self.record.get_subregions()
 
-        assert len(results.areas) == 2
+        # ensure subregions aren't added to record by generation
+        assert not self.record.get_subregions()
+
+        areas = results.areas
         assert len(areas) == 2
-        assert list(areas) == results.areas
 
         area = areas[0]
         assert area.location.start == 30


### PR DESCRIPTION
Fixes #251 

The adding of subregions is handled in [antismash.main](https://github.com/antismash/antismash/blob/master/antismash/main.py#L173), but clusterfinder also had a separate add, which is removed with these changes.