### PR TITLE
Added "Open in Colab" button for example of local install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 antiSMASH - the antibiotics and Secondary Metabolite Analysis SHell
 ===================================================================
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/rchurt/rchurt.github.io/blob/master/antiSMASH.ipynb)
 
 Development & Funding
 ---------------------


### PR DESCRIPTION
Just putting this out there as a suggestion: it could be useful to have a button at the top of the README that will open install antiSMASH and run an example in an environment where users can interact with it immediately--all with a single click.

In the example here, this Jupyter Notebook will build antiSMASH, download a sample genome, and run antiSMASH on it. I've also included code for users to run several genomes through it. It's implemented in Google Colab, which allows users to run it on a virtual machine through their browsers, with no need to install any kernel or packages locally.

If you decide to do this, it certainly doesn't have to be using my notebook (in fact I would suggest that you make your own notebook, copying as much or little from mine as you want, and put that in the main directory of this repo, linking to it in this README). Please let me know if you'd like any help with this, would like me to make any changes at all, or have any questions about why this would be valuable to users.