### PR TITLE
html: add an option to start the overview in compact mode

### DIFF
--- a/antismash/outputs/html/__init__.py
+++ b/antismash/outputs/html/__init__.py
@@ -38,6 +38,11 @@ def get_arguments() -> ModuleArgs:
                     type=str,
                     default="",
                     help="Custom description to add to the output.")
+    args.add_option("--html-start-compact",
+                    dest="html_start_compact",
+                    action='store_true',
+                    default=False,
+                    help="Use compact view by default for overview page.")
     return args
 
 

--- a/antismash/outputs/html/templates/overview.html
+++ b/antismash/outputs/html/templates/overview.html
@@ -84,7 +84,7 @@
     </div>
     {% if multi_record %}
     <div class="overview-switches">
-     {{switch("Compact view", "overview-switch-compact")}}
+     {{switch("Compact view", "overview-switch-compact", starts_on=options.html_start_compact)}}
     </div>
     {% endif %}
    </div>


### PR DESCRIPTION
Resolves #294 by adding a command line option (`--html-start-compact`) to set the default view for the overview page to compact.