### PR TITLE
Update minimum python version to 3.7

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,6 +3,10 @@ ignore=external
 reports=y
 disable=bad-continuation,too-few-public-methods
 
+[MESSAGES CONTROL]
+# raising 'from' is almost entirely false positives
+disable=raise-missing-from
+
 [TYPECHECK]
 ignored-classes=Config,TestCase,Namespace
 
@@ -20,7 +24,7 @@ method-rgx=[a-z_][a-z0-9_]{2,40}$
 # same is true for variables
 variable-rgx=[a-z_][a-z0-9_]{1,40}$
 # some names are shorter than 3 chars but informative
-good-names=i,j,k,ex,Run,_,id
+good-names=i,j,k,ex,Run,_,id,T
 
 [DESIGN]
 # having details provided as args is common, bump from default of 5

--- a/antismash/common/all_orfs.py
+++ b/antismash/common/all_orfs.py
@@ -129,7 +129,7 @@ def find_all_orfs(record: Record, area: Optional[CDSCollection] = None) -> List[
     # Get sequence for the range
     offset = 0
     seq = record.seq
-    existing = record.get_cds_features()  # type: Iterable[CDSFeature]
+    existing: Iterable[CDSFeature] = record.get_cds_features()
     if area:
         seq = area.extract(seq)
         offset = area.location.start

--- a/antismash/common/all_orfs.py
+++ b/antismash/common/all_orfs.py
@@ -9,8 +9,7 @@
 """
 
 
-from typing import List, Optional
-from typing import Iterable  # comment hints, pylint: disable=unused-import
+from typing import Iterable, List, Optional
 
 from Bio.SeqFeature import FeatureLocation, BeforePosition, AfterPosition
 

--- a/antismash/common/errors.py
+++ b/antismash/common/errors.py
@@ -1,6 +1,8 @@
 # License: GNU Affero General Public License v3 or later
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
+# pylint: disable=unnecessary-pass
+
 """ Contains various error classes for use throughout antiSMASH """
 
 

--- a/antismash/common/fasta.py
+++ b/antismash/common/fasta.py
@@ -83,7 +83,7 @@ def read_fasta(filename: str) -> Dict[str, str]:
     ids = []
     sequence_info = []
     with open(filename, "r") as fasta:
-        current_seq = []  # type: List[str]
+        current_seq: List[str] = []
         for line in fasta:
             line = line.strip()
             if not line:

--- a/antismash/common/gff_parser.py
+++ b/antismash/common/gff_parser.py
@@ -39,7 +39,7 @@ def check_gff_suitability(gff_file: str, sequences: List[SeqRecord]) -> None:
         # file handle is automatically closed by GFF lib
         gff_data = examiner.available_limits(open(gff_file))
         # Check if at least one GFF locus appears in sequence
-        gff_ids = set([n[0] for n in gff_data['gff_id']])
+        gff_ids = set(n[0] for n in gff_data['gff_id'])
 
         if len(gff_ids) == 1 and len(sequences) == 1:
             # If both inputs only have one record, assume is the same,
@@ -72,7 +72,7 @@ def check_gff_suitability(gff_file: str, sequences: List[SeqRecord]) -> None:
             raise AntismashInputError("no CDS features in GFF3 file.")
 
         # Check CDS are childless but not parentless
-        if 'CDS' in set([n for key in examiner.parent_child_map(open(gff_file)) for n in key]):
+        if 'CDS' in set(n for key in examiner.parent_child_map(open(gff_file)) for n in key):
             logging.error('GFF3 structure is not suitable. CDS features must be childless but not parentless.')
             raise AntismashInputError('GFF3 structure is not suitable.')
 

--- a/antismash/common/gff_parser.py
+++ b/antismash/common/gff_parser.py
@@ -201,10 +201,10 @@ def check_sub(feature: SeqFeature) -> List[SeqFeature]:
         appropriate SeqFeature instances from them.
     """
     new_features = []
-    locations = []  # type: List[FeatureLocation]
-    trans_locations = []  # type: List[FeatureLocation]
-    qualifiers = {}  # type: Dict[str, List[str]]
-    mismatching_qualifiers = set()  # type: Set[str]
+    locations: List[FeatureLocation] = []
+    trans_locations: List[FeatureLocation] = []
+    qualifiers: Dict[str, List[str]] = {}
+    mismatching_qualifiers: Set[str] = set()
     for sub in feature.sub_features:
         if sub.sub_features:  # If there are sub_features, go deeper
             new_features.extend(check_sub(sub))

--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -100,7 +100,7 @@ class RuleDetectionResults:
 
     def to_json(self) -> Dict[str, Any]:
         """ Constructs a JSON representation from the RuleDetectionResults instance """
-        cds_results_json = []  # type: List[Tuple[Dict[str, Any], List[Dict[str, Any]]]]
+        cds_results_json: List[Tuple[Dict[str, Any], List[Dict[str, Any]]]] = []
         json = {
             "schema_version": self.schema_version,
             "tool": self.tool,
@@ -134,7 +134,7 @@ def remove_redundant_protoclusters(clusters: List[Protocluster],
                                    ) -> List[Protocluster]:
     """ Removes clusters which have superiors covering the same (or larger) region
     """
-    clusters_by_rule = defaultdict(list)  # type: Dict[str, List[Protocluster]]
+    clusters_by_rule: Dict[str, List[Protocluster]] = defaultdict(list)
     for cluster in clusters:
         clusters_by_rule[cluster.product].append(cluster)
 
@@ -157,7 +157,7 @@ def remove_redundant_protoclusters(clusters: List[Protocluster],
 def find_protoclusters(record: Record, cds_by_cluster_type: Dict[str, Set[str]],
                        rules_by_name: Dict[str, rule_parser.DetectionRule]) -> List[Protocluster]:
     """ Detects gene clusters based on the identified core genes """
-    clusters = []  # type: List[Protocluster]
+    clusters: List[Protocluster] = []
 
     cds_feature_by_name = record.get_cds_name_mapping()
 
@@ -233,14 +233,14 @@ def filter_results(results: List[HSP], results_by_id: Dict[str, List[HSP]], filt
         unknown = equivalence_group - signature_names
         if unknown:
             raise ValueError("Equivalence group contains unknown identifiers: %s" % (unknown))
-        removed_ids = set()  # type: Set[int]
+        removed_ids: Set[int] = set()
         for cds, cdsresults in results_by_id.items():
             # Check if multiple competing HMM hits are present
             hits = set(hit.query_id for hit in cdsresults)
             if len(hits & equivalence_group) < 2:
                 continue
             # Identify overlapping hits
-            overlapping_groups = []  # type: List[Set[HSP]]
+            overlapping_groups: List[Set[HSP]] = []
             for hit in cdsresults:
                 for otherhit in cdsresults:
                     if hit == otherhit or hsp_overlap_size(hit, otherhit) <= 20:
@@ -275,7 +275,7 @@ def filter_results(results: List[HSP], results_by_id: Dict[str, List[HSP]], filt
 def filter_result_multiple(results: List[HSP], results_by_id: Dict[str, HSP]) -> Tuple[List[HSP], Dict[str, HSP]]:
     """ Filter multiple results of the same model within a gene """
     for cds, hits in results_by_id.items():
-        query_scores = {}  # type: Dict[str, Tuple[int, HSP, float]]
+        query_scores: Dict[str, Tuple[int, HSP, float]] = {}
         for i, hit in enumerate(hits):
             if query_scores.get(hit.query_id, (0, 0, -1))[2] < hit.bitscore:
                 query_scores[hit.query_id] = (i, hit, hit.bitscore)
@@ -337,13 +337,13 @@ def apply_cluster_rules(record: Record, results_by_id: Dict[str, List[HSP]],
 
     cds_with_hits = sorted(results_by_id, key=lambda gene_id: record.get_cds_by_name(gene_id).location.start)
 
-    cds_domains_by_cluster_type = defaultdict(lambda: defaultdict(set))  # type: Dict[str, Dict[str, Set[str]]]
-    cluster_type_hits = defaultdict(set)  # type: Dict[str, Set[str]]
+    cds_domains_by_cluster_type: Dict[str, Dict[str, Set[str]]] = defaultdict(lambda: defaultdict(set))
+    cluster_type_hits: Dict[str, Set[str]] = defaultdict(set)
     for cds_name in cds_with_hits:
         feature = record.get_cds_by_name(cds_name)
         feature_start, feature_end = sorted([feature.location.start, feature.location.end])
         rule_texts = []
-        info_by_range = {}  # type: Dict[int, Tuple[Dict[str, CDSFeature], Dict[str, List[HSP]]]]
+        info_by_range: Dict[int, Tuple[Dict[str, CDSFeature], Dict[str, List[HSP]]]] = {}
         for rule in rules:
             if rule.cutoff not in info_by_range:
                 location = FeatureLocation(max(0, feature_start - rule.cutoff), feature_end + rule.cutoff)
@@ -386,11 +386,11 @@ def detect_protoclusters_and_signatures(record: Record, signature_file: str, see
     if not full_fasta:
         return RuleDetectionResults({}, tool)
     sig_by_name = {sig.name: sig for sig in get_signature_profiles(signature_file)}
-    rules = []  # type: List[rule_parser.DetectionRule]
+    rules: List[rule_parser.DetectionRule] = []
     for rule_file in rule_files:
         rules = create_rules(rule_file, set(sig_by_name), rules)
     results = []
-    results_by_id = {}  # type: Dict[str, HSP]
+    results_by_id: Dict[str, HSP] = {}
 
     runresults = run_hmmsearch(seeds_file, full_fasta, use_tempfile=True)
     for runresult in runresults:

--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -243,8 +243,8 @@ class Tokeniser:  # pylint: disable=too-few-public-methods
 
     def __init__(self, text: str) -> None:
         self.text = text
-        self.tokens = []  # type: List[Token]
-        self.current_symbol = []  # type: List[str]
+        self.tokens: List[Token] = []
+        self.current_symbol: List[str] = []
         self.tokenise()
 
     def tokenise(self) -> None:
@@ -379,7 +379,7 @@ class ConditionMet:  # pylint: disable=too-few-public-methods
                  ancillary_hits: Dict[str, Set[str]] = None) -> None:
         assert isinstance(met, bool)
         self.met = met
-        self.matches = set()  # type: Set[str]
+        self.matches: Set[str] = set()
         self.ancillary_hits = ancillary_hits or defaultdict(set)
         if isinstance(matches, ConditionMet):
             self.matches = matches.matches
@@ -414,18 +414,18 @@ class Conditions:
         # just make sure that it's empty or that we have binary ops (a OR b..)
         assert not sub_conditions or len(sub_conditions) % 2 == 1
 
-        self._operands = []  # type: List[Conditions]
+        self._operands: List[Conditions] = []
         for sub in self.sub_conditions[::2]:
             assert isinstance(sub, Conditions)
             self._operands.append(sub)
 
-        self._operators = []  # type: List[TokenTypes]
+        self._operators: List[TokenTypes] = []
         for sub in self.sub_conditions[1::2]:
             assert isinstance(sub, TokenTypes)
             assert sub in [TokenTypes.AND, TokenTypes.OR]
             self._operators.append(sub)
 
-        unique_operands = set()  # type: Set[str]
+        unique_operands: Set[str] = set()
         for operand in map(str, self.operands):
             if operand in unique_operands:
                 raise ValueError("Rule contains repeated condition: %s\nfrom rule %s"
@@ -455,9 +455,9 @@ class Conditions:
         assert all(operator == TokenTypes.OR for operator in self.operators)
         # which means a simple any() will cover us
         sub_results = [sub.get_satisfied(details, local_only) for sub in self.operands]
-        matching = set()  # type: Set[str]
+        matching: Set[str] = set()
         met = False
-        ancillary_hits = defaultdict(set)  # type: Dict[str, Set[str]]
+        ancillary_hits: Dict[str, Set[str]] = defaultdict(set)
         for sub_result in sub_results:
             matching |= sub_result.matches
             met |= sub_result.met
@@ -526,9 +526,9 @@ class AndCondition(Conditions):
 
     def is_satisfied(self, details: Details, local_only: bool = False) -> ConditionMet:
         results = [sub.get_satisfied(details, local_only) for sub in self.operands]
-        matched = set()  # type: Set[str]
+        matched: Set[str] = set()
         met = True
-        ancillary_hits = defaultdict(set)  # type: Dict[str, Set[str]]
+        ancillary_hits: Dict[str, Set[str]] = defaultdict(set)
         for result in results:
             matched |= result.matches
             met = met and result.met
@@ -567,7 +567,7 @@ class MinimumCondition(Conditions):
 
         # track other CDS hits in case the minimum is part of another condition
         # that would extend the search distance
-        other_cds_hits = defaultdict(set)  # type: Dict[str, Set[str]]
+        other_cds_hits: Dict[str, Set[str]] = defaultdict(set)
 
         # check to see if the remaining hits are in nearby CDSs
         for other_id, other_feature in details.features_by_id.items():
@@ -876,7 +876,7 @@ class Parser:  # pylint: disable=too-few-public-methods
         if self.current_token.type == TokenTypes.COMMENT:
             comments = self._parse_comments()
             prev = TokenTypes.COMMENT
-        related = []  # type: List[str]
+        related: List[str] = []
         if self.current_token.type == TokenTypes.RELATED:
             related = self._parse_related()
             prev = TokenTypes.RELATED
@@ -935,7 +935,7 @@ class Parser:  # pylint: disable=too-few-public-methods
         """ CONDITION and CONDITION { and CONDITION}
             ^ lvalue being passed in
         """
-        and_conditions = [lvalue]  # type: List[Union[Conditions, TokenTypes]]
+        and_conditions: List[Union[Conditions, TokenTypes]] = [lvalue]
         and_conditions.append(self._consume(TokenTypes.AND).type)
         and_conditions.append(self._parse_single_condition(allow_cds))
         while self.current_token and self.current_token.type == TokenTypes.AND:
@@ -947,7 +947,7 @@ class Parser:  # pylint: disable=too-few-public-methods
     def _parse_conditions(self, allow_cds: bool = True, is_group: bool = False) -> ConditionList:
         """    CONDITIONS = CONDITION {BINARY_OP CONDITIONS}*;
         """
-        conditions = []  # type: List[Union[Conditions, TokenTypes]]
+        conditions: List[Union[Conditions, TokenTypes]] = []
         lvalue = self._parse_single_condition(allow_cds)
         append_lvalue = True  # capture the lvalue if it's the only thing
         while self.current_token and self.current_token.type in [TokenTypes.AND,

--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -166,7 +166,7 @@ class RuleSyntaxError(SyntaxError):
     """ Specifically for errors resulting from bad syntax in the rules being
         parsed.
     """
-    pass
+    pass  # pylint: disable=unnecessary-pass
 
 
 class TokenTypes(IntEnum):
@@ -224,7 +224,7 @@ class TokenTypes(IntEnum):
         """ Returns True if the token is a rule structure keyword such as
             RULE, COMMENT, CONDITIONS, etc
         """
-        return 15 <= self.value <= 21
+        return 15 <= self.value <= 21  # pylint: disable=comparison-with-callable
 
 
 class Tokeniser:  # pylint: disable=too-few-public-methods
@@ -318,7 +318,7 @@ class Token:  # pylint: disable=too-few-public-methods
             if self.type != TokenTypes.INT:
                 raise AttributeError("Token is not numeric")
             return int(self.token_text)
-        elif key == 'identifier':
+        if key == 'identifier':
             if self.type != TokenTypes.IDENTIFIER:
                 raise AttributeError("Token has no identifier")
             return self.token_text
@@ -996,11 +996,11 @@ class Parser:  # pylint: disable=too-few-public-methods
             raise RuleSyntaxError("Rules cannot end in not")
         if self.current_token.type == TokenTypes.GROUP_OPEN:
             return Conditions(negated, self._parse_group(allow_cds))
-        elif allow_cds and self.current_token.type == TokenTypes.MINIMUM:
+        if allow_cds and self.current_token.type == TokenTypes.MINIMUM:
             return self._parse_minimum(negated=negated)
-        elif allow_cds and self.current_token.type == TokenTypes.CDS:
+        if allow_cds and self.current_token.type == TokenTypes.CDS:
             return CDSCondition(negated, self._parse_cds())
-        elif self.current_token.type == TokenTypes.SCORE:
+        if self.current_token.type == TokenTypes.SCORE:
             return self._parse_score(negated=negated)
         return SingleCondition(negated, self._consume_identifier())
 

--- a/antismash/common/hmmscan_refinement.py
+++ b/antismash/common/hmmscan_refinement.py
@@ -155,7 +155,7 @@ def _remove_incomplete(domains: List[HMMResult], hmm_lengths: Dict[str, int],
 
 def _merge_domain_list(domains: List[HMMResult], hmm_lengths: Dict[str, int]) -> List[HMMResult]:
     """ Merges domains of the same kind if they would not be too long """
-    categories = defaultdict(list)  # type: Dict[str, List[HMMResult]]
+    categories: Dict[str, List[HMMResult]] = defaultdict(list)
     for domain in domains:
         categories[domain.hit_id].append(domain)
     remaining = []
@@ -196,7 +196,7 @@ def gather_by_query(results: List[HSP]) -> Dict[str, Set[HMMResult]]:
             a dictionary mapping query gene id to a set of HMMResults within that
             gene
     """
-    results_by_id = defaultdict(set)  # type: Dict[str, Set[HMMResult]]
+    results_by_id: Dict[str, Set[HMMResult]] = defaultdict(set)
     for result in results:
         for hsp in result.hsps:
             results_by_id[hsp.query_id].add(HMMResult(hsp.hit_id, hsp.query_start,

--- a/antismash/common/html_renderer.py
+++ b/antismash/common/html_renderer.py
@@ -37,8 +37,8 @@ class HTMLSections:
     """
     def __init__(self, name: str) -> None:
         self.name = name
-        self.sidepanel_sections = []  # type: List[HTMLSection]
-        self.detail_sections = []  # type: List[HTMLSection]
+        self.sidepanel_sections: List[HTMLSection] = []
+        self.detail_sections: List[HTMLSection] = []
 
     def add_detail_section(self, label: str, section: Markup, class_name: str = "") -> None:
         """ Add a detail section with the given tab name, using the markup provided. """
@@ -165,7 +165,7 @@ class _Template:  # pylint: disable=too-few-public-methods
         Non-functional on its own, requires self.template to be set to a jinja Template
     """
     def __init__(self, template_dir: Optional[str] = None) -> None:
-        self.template = None  # type: Optional[_jinja2.Template]
+        self.template: Optional[_jinja2.Template] = None
         if not template_dir:
             loader = _jinja2.BaseLoader()
         else:

--- a/antismash/common/html_renderer.py
+++ b/antismash/common/html_renderer.py
@@ -6,8 +6,7 @@
 """
 
 import os
-from typing import Any, Optional
-from typing import List  # comment hints, pylint: disable=unused-import
+from typing import Any, List, Optional
 
 import jinja2 as _jinja2
 from jinja2 import Markup

--- a/antismash/common/json.py
+++ b/antismash/common/json.py
@@ -67,8 +67,8 @@ class JSONOrf(JSONBase):
         super().__init__(["id", "sequence", "domains", "modules"])
         self.sequence = feature.translation
         self.id = feature.get_name()
-        self.domains = []  # type: List[JSONDomain]
-        self.modules = []  # type: List[JSONModule]
+        self.domains: List[JSONDomain] = []
+        self.modules: List[JSONModule] = []
 
     def add_domain(self, domain: JSONDomain) -> None:
         """ Add a JSONDomain to the list of domains in this ORF """

--- a/antismash/common/layers.py
+++ b/antismash/common/layers.py
@@ -59,7 +59,7 @@ class RecordLayer:
         self.results = results
         self.seq_record = record
         self.options = options
-        self.regions = []  # type: List[RegionLayer]
+        self.regions: List[RegionLayer] = []
         for region in record.get_regions():
             self.regions.append(RegionLayer(self, region))
 
@@ -95,14 +95,14 @@ class RegionLayer:
     def __init__(self, record: RecordLayer, region_feature: Region) -> None:
         assert isinstance(region_feature, Region), type(region_feature)
         assert region_feature.parent_record
-        self.record = record  # type: RecordLayer
+        self.record: RecordLayer = record
         self.anchor_id = self.build_anchor_id(region_feature)
-        self.handlers = []  # type: List[AntismashModule]
-        self.region_feature = region_feature  # type: Region
+        self.handlers: List[AntismashModule] = []
+        self.region_feature: Region = region_feature
 
-        self.cluster_blast = []  # type: List[Tuple[str, str]]
-        self.knowncluster_blast = []  # type: List[Tuple[str, str]]
-        self.subcluster_blast = []  # type: List[Tuple[str, str]]
+        self.cluster_blast: List[Tuple[str, str]] = []
+        self.knowncluster_blast: List[Tuple[str, str]] = []
+        self.subcluster_blast: List[Tuple[str, str]] = []
         if self.region_feature.knownclusterblast:
             self.knowncluster_blast = self.knowncluster_blast_generator()
         if self.region_feature.subclusterblast:

--- a/antismash/common/logs.py
+++ b/antismash/common/logs.py
@@ -7,8 +7,7 @@ import contextlib
 import logging
 import os
 import sys
-from typing import Any, Generator
-from typing import Dict  # comment hints, pylint: disable=unused-import
+from typing import Any, Dict, Generator
 
 
 @contextlib.contextmanager

--- a/antismash/common/logs.py
+++ b/antismash/common/logs.py
@@ -50,7 +50,7 @@ def changed_logging(logfile: str = None, verbose: bool = False, debug: bool = Fa
         logger.setLevel(log_level)
 
         handler = None
-        original_levels = {}  # type: Dict[logging.Handler, int]
+        original_levels: Dict[logging.Handler, int] = {}
 
         if logfile:
             # since INFO is always wanted in the logfile, set the global level to that

--- a/antismash/common/pfamdb.py
+++ b/antismash/common/pfamdb.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 
 from antismash.common import path
 
-KNOWN_MAPPINGS = {}  # type: Dict[str, Dict[str, str]] # tracks name mappings per database
+KNOWN_MAPPINGS: Dict[str, Dict[str, str]] = {}  # tracks name mappings per database
 
 
 def find_latest_database_version(database_dir: str) -> str:

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -408,7 +408,7 @@ def sanitise_sequence(record: Record) -> Record:
     for char in record.seq.upper():
         if char == "-":
             continue
-        elif char in "ACGT":
+        if char in "ACGT":
             sanitised.append(char)
             has_real_content = True
         else:
@@ -434,7 +434,7 @@ def trim_sequence(record: SeqRecord, start: int, end: int) -> SeqRecord:
         raise ValueError('Specified analysis start point of %r is outside record' % start)
     if end > len(record):
         raise ValueError('Specified analysis end point of %r is outside record' % end)
-    if end > -1 and end <= start:
+    if -1 < end <= start:
         raise ValueError("Trim region start cannot be greater than or equal to end")
 
     if start < 0:
@@ -581,6 +581,6 @@ def generate_unique_id(prefix: str, existing_ids: Set[str], start: int = 0,
     while name in existing_ids:
         counter += 1
         name = format_string % counter
-    if max_length > 0 and len(name) > max_length:
+    if 0 < max_length < len(name):
         raise RuntimeError("Could not generate unique id for %s after %d iterations" % (prefix, counter - start))
     return name, counter

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -82,7 +82,7 @@ def parse_input_sequence(filename: str, taxon: str = "bacteria", minimum_length:
     if not isinstance(minimum_length, int):
         raise TypeError("minimum_length must be an int")
 
-    records = []  # type: List[SeqRecord]
+    records: List[SeqRecord] = []
 
     for record in _strict_parse(filename):
         if minimum_length < 1 \

--- a/antismash/common/secmet/errors.py
+++ b/antismash/common/secmet/errors.py
@@ -1,6 +1,8 @@
 # License: GNU Affero General Public License v3 or later
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
+# pylint: disable=unnecessary-pass
+
 """ Contains Exception subclasses for more specific communication of issues """
 
 

--- a/antismash/common/secmet/features/antismash_domain.py
+++ b/antismash/common/secmet/features/antismash_domain.py
@@ -22,11 +22,11 @@ class AntismashDomain(Domain):
     def __init__(self, location: Location, tool: str, protein_location: FeatureLocation, locus_tag: str) -> None:
         super().__init__(location, self.FEATURE_TYPE, protein_location, locus_tag,
                          tool=tool, created_by_antismash=True)
-        self.domain_subtype = None  # type: Optional[str]
-        self.specificity = []  # type: List[str]
+        self.domain_subtype: Optional[str] = None
+        self.specificity: List[str] = []
 
     def to_biopython(self, qualifiers: Dict[str, List[str]] = None) -> List[SeqFeature]:
-        mine = OrderedDict()  # type: Dict[str, List[str]]
+        mine: Dict[str, List[str]] = OrderedDict()
         if self.domain_subtype:
             mine["domain_subtype"] = [self.domain_subtype]
         if self.specificity:

--- a/antismash/common/secmet/features/antismash_domain.py
+++ b/antismash/common/secmet/features/antismash_domain.py
@@ -4,8 +4,7 @@
 """ A more detailed Domain feature """
 
 from collections import OrderedDict
-from typing import Any, Dict, List, Type, TypeVar
-from typing import Optional  # comment hints, pylint: disable=unused-import
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from Bio.SeqFeature import SeqFeature
 

--- a/antismash/common/secmet/features/antismash_feature.py
+++ b/antismash/common/secmet/features/antismash_feature.py
@@ -25,13 +25,13 @@ class AntismashFeature(Feature):
             raise ValueError("an AntismashFeature created by antiSMASH must have a tool supplied")
         super().__init__(location, feature_type, created_by_antismash=created_by_antismash)
         self.tool = tool
-        self.domain_id = None  # type: Optional[str]
-        self.database = None  # type: Optional[str]
-        self.detection = None  # type: Optional[str]
-        self._evalue = None  # type: Optional[float]
-        self.label = None  # type: Optional[str]
-        self.locus_tag = None  # type: Optional[str]
-        self._score = None  # type: Optional[float]
+        self.domain_id: Optional[str] = None
+        self.database: Optional[str] = None
+        self.detection: Optional[str] = None
+        self._evalue: Optional[float] = None
+        self.label: Optional[str] = None
+        self.locus_tag: Optional[str] = None
+        self._score: Optional[float] = None
 
         self._translation = ""
 
@@ -75,7 +75,7 @@ class AntismashFeature(Feature):
         return self.domain_id
 
     def to_biopython(self, qualifiers: Dict[str, List[str]] = None) -> List[SeqFeature]:
-        mine = OrderedDict()  # type: Dict[str, List[str]]
+        mine: Dict[str, List[str]] = OrderedDict()
         if self.label:
             mine["label"] = [self.label]
         if self.score is not None:

--- a/antismash/common/secmet/features/candidate_cluster/formation.py
+++ b/antismash/common/secmet/features/candidate_cluster/formation.py
@@ -32,7 +32,7 @@ def create_candidates_from_protoclusters(protoclusters: List[Protocluster]) -> L
         return []
 
     # ensure that only one candidate cluster can be created for each specific start/end combination
-    existing = set()  # type: Set[Tuple[int, int]]
+    existing: Set[Tuple[int, int]] = set()
 
     def build_candidates(groups: List[List[Protocluster]], kind: CandidateClusterKind) -> List[CandidateCluster]:
         """ Creates candidates of the given kind, one for each group

--- a/antismash/common/secmet/features/candidate_cluster/structures.py
+++ b/antismash/common/secmet/features/candidate_cluster/structures.py
@@ -97,7 +97,7 @@ class CandidateCluster(CDSCollection):
         """ Returns all unique products from contained protoclusters
             in the order they are found.
         """
-        unique_products = OrderedDict()  # type: Dict[str, None]
+        unique_products: Dict[str, None] = OrderedDict()
         for cluster in self._protoclusters:
             unique_products[cluster.product] = None
         return list(unique_products)

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -6,12 +6,11 @@
 from collections import OrderedDict
 import logging
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
-from typing import Union  # comment hints  # pylint: disable=unused-import
 
 from Bio.Data import CodonTable, IUPACData
 from Bio.SeqFeature import SeqFeature
 
-from antismash.common.secmet import features  # comment hints  # pylint:disable=unused-import
+from antismash.common.secmet import features
 from antismash.common.secmet.qualifiers import (
     GeneFunction,
     GeneFunctionAnnotations,

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -156,12 +156,12 @@ class CDSFeature(Feature):
         self._sec_met = SecMetQualifier()
         self._nrps_pks = NRPSPKSQualifier(self.location.strand)
 
-        self._modules = []  # type: List[Module]
-        self.motifs = []  # type: List[features.CDSMotif]
+        self._modules: List[Module] = []
+        self.motifs: List[features.CDSMotif] = []
 
         # runtime-only data
-        self.region = None  # type: Optional[features.Region]
-        self.unique_id = None  # type: Optional[str] # set only when added to a record
+        self.region: Optional[features.Region] = None
+        self.unique_id: Optional[str] = None  # set only when added to a record
 
     @property
     def gene_functions(self) -> GeneFunctionAnnotations:
@@ -303,7 +303,7 @@ class CDSFeature(Feature):
         return feature
 
     def to_biopython(self, qualifiers: Dict[str, List[str]] = None) -> SeqFeature:
-        mine = OrderedDict()  # type: Dict[str, List[str]]
+        mine: Dict[str, List[str]] = OrderedDict()
         # mandatory
         mine["translation"] = [self.translation]
         # optional

--- a/antismash/common/secmet/features/cds_motif.py
+++ b/antismash/common/secmet/features/cds_motif.py
@@ -44,7 +44,7 @@ class CDSMotif(Domain):
         return updated
 
     def to_biopython(self, qualifiers: Dict[str, List] = None) -> List[SeqFeature]:
-        mine = OrderedDict()  # type: Dict[str, List[str]]
+        mine: Dict[str, List[str]] = OrderedDict()
         if qualifiers:
             mine.update(qualifiers)
         return super().to_biopython(mine)

--- a/antismash/common/secmet/features/cdscollection.py
+++ b/antismash/common/secmet/features/cdscollection.py
@@ -28,11 +28,11 @@ class CDSCollection(Feature):
     def __init__(self, location: FeatureLocation, feature_type: str,
                  child_collections: Sequence["CDSCollection"] = None) -> None:
         super().__init__(location, feature_type, created_by_antismash=True)
-        self._parent_record = None  # type: Any  # should be Record but will cause circular dependencies
+        self._parent_record: Any = None  # should be Record but will cause circular dependencies
         self._contig_edge = False
-        self._cdses = OrderedDict()  # type: Dict[CDSFeature, None]
+        self._cdses: Dict[CDSFeature, None] = OrderedDict()
         self._children = child_collections
-        self._parent = None  # type: Optional["CDSCollection"]
+        self._parent: Optional["CDSCollection"] = None
         if self._children:
             for child in self._children:
                 assert isinstance(child, CDSCollection), type(child)

--- a/antismash/common/secmet/features/cdscollection.py
+++ b/antismash/common/secmet/features/cdscollection.py
@@ -6,8 +6,7 @@
 """
 
 from collections import OrderedDict
-from typing import Any, List, Optional, Sequence, Tuple, Type, TypeVar, Union
-from typing import Dict  # used in comment hints # pylint: disable=unused-import
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, TypeVar, Union
 
 from Bio.SeqFeature import SeqFeature
 

--- a/antismash/common/secmet/features/domain.py
+++ b/antismash/common/secmet/features/domain.py
@@ -96,8 +96,7 @@ class Domain(AntismashFeature):
             leftovers = Feature.make_qualifiers_copy(bio_feature)
         if not feature:
             raise ValueError("Domain shouldn't be instantiated directly")
-        else:
-            assert isinstance(feature, Domain), type(feature)
+        assert isinstance(feature, Domain), type(feature)
 
         # clean up qualifiers that must have been used already
         leftovers.pop("protein_start", None)

--- a/antismash/common/secmet/features/domain.py
+++ b/antismash/common/secmet/features/domain.py
@@ -69,8 +69,7 @@ class Domain(AntismashFeature):
             raise TypeError("protein location must be a FeatureLocation, not %s" % type(protein_location))
         if not locus_tag:
             raise ValueError("locus tag cannot be an empty string")
-        # mypy struggles with this next line, considering it an optional string, fixed with a typehint
-        self.locus_tag = str(locus_tag)  # type: str
+        self.locus_tag: str = str(locus_tag)
         self._asf = ActiveSiteFinderQualifier()
 
     @property
@@ -79,7 +78,7 @@ class Domain(AntismashFeature):
         return self._asf
 
     def to_biopython(self, qualifiers: Dict[str, List[str]] = None) -> List[SeqFeature]:
-        mine = OrderedDict()  # type: Dict[str, List[str]]
+        mine: Dict[str, List[str]] = OrderedDict()
         mine["protein_start"] = [str(int(self.protein_location.start))]
         mine["protein_end"] = [str(int(self.protein_location.end))]
         if self.domain:

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -253,7 +253,7 @@ class Feature:
 
         if self.location.start < location.start:
             return True
-        elif self.location.start == location.start:
+        if self.location.start == location.start:
             return self.location.end < location.end
         return False
 
@@ -265,7 +265,8 @@ class Feature:
 
     @classmethod
     def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,
-                       leftovers: Dict[str, List[str]] = None, record: Any = None) -> T:
+                       leftovers: Dict[str, List[str]] = None, record: Any = None,   # pylint: disable=unused-argument
+                       ) -> T:
         """ Converts a SeqFeature into a single Feature instance.
 
             Arguments:

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -77,13 +77,13 @@ class Feature:
         if location.start < 0:
             raise ValueError("location contains negative coordinate: %s" % location)
         self.location = location
-        self.notes = []  # type: List[str]
+        self.notes: List[str] = []
         if not 1 <= len(feature_type) < 16:  # at 16 the name merges with location in genbanks
             raise ValueError("feature type has invalid length: '%s'" % feature_type)
         self.type = str(feature_type)
-        self._qualifiers = OrderedDict()  # type: Dict[str, Optional[List[str]]]
+        self._qualifiers: Dict[str, Optional[List[str]]] = OrderedDict()
         self.created_by_antismash = bool(created_by_antismash)
-        self._original_codon_start = None  # type: Optional[int]
+        self._original_codon_start: Optional[int] = None
 
     @property
     def strand(self) -> int:

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -5,8 +5,7 @@
 
 from collections import OrderedDict
 import logging
-from typing import Any, Dict, List, Tuple, Type, TypeVar, Union
-from typing import Optional  # comment hints  # pylint: disable=unused-import
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 from Bio.SeqFeature import SeqFeature, FeatureLocation, CompoundLocation
 from Bio.Seq import Seq

--- a/antismash/common/secmet/features/module.py
+++ b/antismash/common/secmet/features/module.py
@@ -4,8 +4,7 @@
 """ NRPS/PKS Module features """
 
 from enum import Enum, unique
-from typing import Any, Dict, List, Tuple, Type, TypeVar
-from typing import Optional  # comment hint, pylint: disable=unused-import
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
 
 from .antismash_domain import AntismashDomain
 from .feature import Feature, FeatureLocation, SeqFeature

--- a/antismash/common/secmet/features/module.py
+++ b/antismash/common/secmet/features/module.py
@@ -69,7 +69,7 @@ class Module(Feature):
 
         self._parent_cds_names = sorted({dom.locus_tag for dom in domains})
         self._domains = domains
-        self._substrate_monomer_pairs = []  # type: List[Tuple[str, str]]
+        self._substrate_monomer_pairs: List[Tuple[str, str]] = []
         self._complete = complete
         self._is_starter = starter
         self._is_final = final
@@ -149,11 +149,11 @@ class Module(Feature):
         return tuple(self._substrate_monomer_pairs)
 
     def to_biopython(self, qualifiers: Dict[str, Any] = None) -> List[SeqFeature]:
-        new = {
+        new: Dict[str, Optional[List[str]]] = {
             "domains": [domain.get_name() for domain in self.domains],
             "locus_tags": sorted(self._parent_cds_names),
             "type": [str(self.module_type)],
-        }  # type: Dict[str, Optional[List[str]]]
+        }
 
         if self.is_complete():
             new["complete"] = None

--- a/antismash/common/secmet/features/pfam_domain.py
+++ b/antismash/common/secmet/features/pfam_domain.py
@@ -44,7 +44,7 @@ class PFAMDomain(Domain):
         if not description:
             raise ValueError("PFAMDomain description cannot be empty")
         self.description = description
-        self.probability = None  # type: Optional[float]
+        self.probability: Optional[float] = None
         self.version = None
         if not identifier:
             raise ValueError("Pfam identifier cannot be empty")
@@ -54,7 +54,7 @@ class PFAMDomain(Domain):
         if not (len(identifier) == 7 and identifier.startswith('PF') and identifier[2:].isdecimal()):
             raise ValueError("invalid Pfam identifier: %s" % identifier)
         self.identifier = str(identifier)
-        self.gene_ontologies = None  # type: Optional[GOQualifier]
+        self.gene_ontologies: Optional[GOQualifier] = None
 
     @property
     def full_identifier(self) -> str:
@@ -66,7 +66,7 @@ class PFAMDomain(Domain):
         return "%s.%d" % (self.identifier, self.version)
 
     def to_biopython(self, qualifiers: Dict[str, List[str]] = None) -> List[SeqFeature]:
-        mine = OrderedDict()  # type: Dict[str, List[str]]
+        mine: Dict[str, List[str]] = OrderedDict()
         mine["description"] = [self.description]
         if self.probability is not None:
             mine["probability"] = [str(self.probability)]

--- a/antismash/common/secmet/features/prepeptide.py
+++ b/antismash/common/secmet/features/prepeptide.py
@@ -3,8 +3,7 @@
 
 """ A class for representing RiPP prepeptides """
 
-from typing import Any, Dict, List, Type, TypeVar
-from typing import Optional  # comment hints, pylint: disable=unused-import
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from Bio.SeqFeature import SeqFeature
 
@@ -12,7 +11,7 @@ from ..errors import SecmetInvalidInputError
 from .cds_motif import CDSMotif
 from .feature import Feature, FeatureLocation, Location
 from ..locations import build_location_from_others, location_from_string
-from ..qualifiers.prepeptide_qualifiers import RiPPQualifier  # comment hints, pylint: disable=unused-import
+from ..qualifiers.prepeptide_qualifiers import RiPPQualifier
 from ..qualifiers.prepeptide_qualifiers import rebuild_qualifier
 
 T = TypeVar("T", bound="Prepeptide")

--- a/antismash/common/secmet/features/prepeptide.py
+++ b/antismash/common/secmet/features/prepeptide.py
@@ -5,6 +5,7 @@
 
 from typing import Any, Dict, List, Optional, Type, TypeVar
 
+
 from Bio.SeqFeature import SeqFeature
 
 from ..errors import SecmetInvalidInputError
@@ -58,11 +59,11 @@ class Prepeptide(CDSMotif):  # pylint: disable=too-many-instance-attributes
         self.score = float(score)
         self.monoisotopic_mass = float(monoisotopic_mass)
         self.molecular_weight = float(molecular_weight)
-        self.alternative_weights = []  # type: List[float]
+        self.alternative_weights: List[float] = []
         if alternative_weights is not None:
             self.alternative_weights = [float(weight) for weight in alternative_weights]
 
-        self.detailed_information = None  # type: Optional[RiPPQualifier]
+        self.detailed_information: Optional[RiPPQualifier] = None
 
     @property
     def translation(self) -> str:

--- a/antismash/common/secmet/features/prepeptide.py
+++ b/antismash/common/secmet/features/prepeptide.py
@@ -197,7 +197,7 @@ class Prepeptide(CDSMotif):  # pylint: disable=too-many-instance-attributes
         section = leftovers.pop("prepeptide", [""])[0]
         if not section:
             raise SecmetInvalidInputError("cannot reconstruct Prepeptide from biopython feature %s" % bio_feature)
-        elif section != "core":
+        if section != "core":
             raise SecmetInvalidInputError("Prepeptide can only be reconstructed from core feature")
         alt_weights = [float(weight) for weight in leftovers.pop("alternative_weights", [])]
         leader = leftovers.pop("leader_sequence", [""])[0]

--- a/antismash/common/secmet/features/protocluster.py
+++ b/antismash/common/secmet/features/protocluster.py
@@ -42,15 +42,15 @@ class Protocluster(CDSCollection):
         self.tool = tool
 
         # core specific
-        self.core_location = core_location  # type: FeatureLocation
+        self.core_location = core_location
         self.cutoff = cutoff
-        self._definition_cdses = set()  # type: Set[CDSFeature]
+        self._definition_cdses: Set[CDSFeature] = set()
 
         # neighbourhood specific
         self.neighbourhood_range = neighbourhood_range
 
         # analysis annotations
-        self.t2pks = None  # type: Optional[T2PKSQualifier]
+        self.t2pks: Optional[T2PKSQualifier] = None
 
     def __str__(self) -> str:
         return "Protocluster(%s, product=%s)" % (self.location, self.product)

--- a/antismash/common/secmet/features/region.py
+++ b/antismash/common/secmet/features/region.py
@@ -5,8 +5,7 @@
 
 from collections import OrderedDict
 import os
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
-from typing import Set  # used in comment hints, pylint: disable=unused-import
+from typing import Any, Dict, List, Optional, Set, Tuple, Type, TypeVar
 import warnings
 
 from Bio.SeqFeature import SeqFeature

--- a/antismash/common/secmet/features/region.py
+++ b/antismash/common/secmet/features/region.py
@@ -44,7 +44,7 @@ class Region(CDSCollection):
         if not candidate_clusters and not subregions:
             raise ValueError("A Region requires at least one child SubRegion or CandidateCluster")
 
-        children = []  # type: List[CDSCollection]
+        children: List[CDSCollection] = []
 
         if subregions is None:
             subregions = []
@@ -64,9 +64,9 @@ class Region(CDSCollection):
         self._subregions = subregions
         self._candidate_clusters = candidate_clusters
 
-        self.clusterblast = None  # type: Optional[List[str]]
-        self.knownclusterblast = None  # type: Any
-        self.subclusterblast = None  # type: Optional[List[str]]
+        self.clusterblast: Optional[List[str]] = None
+        self.knownclusterblast: Any = None
+        self.subclusterblast: Optional[List[str]] = None
 
     @property
     def subregions(self) -> Tuple[SubRegion, ...]:
@@ -85,7 +85,7 @@ class Region(CDSCollection):
         """ Returns a list of unique products collected from all contained
             CandidateClusters
         """
-        products = OrderedDict()  # type: Dict[str, None]
+        products: Dict[str, None] = OrderedDict()
         for cluster in self._candidate_clusters:
             for product in cluster.products:
                 products[product] = None
@@ -102,7 +102,7 @@ class Region(CDSCollection):
         """ Returns a list of unique detection rules collected from all
             contained CandidateClusters
         """
-        rules = OrderedDict()  # type: Dict[str, str]
+        rules: Dict[str, str] = OrderedDict()
         for cluster in self._candidate_clusters:
             for product, rule in zip(cluster.products, cluster.detection_rules):
                 rules[product] = rule
@@ -135,7 +135,7 @@ class Region(CDSCollection):
             without duplicating them if multiple CandidateClusters contain the same
             Protocluster
         """
-        clusters = set()  # type: Set[Protocluster]
+        clusters: Set[Protocluster] = set()
         for candidate_cluster in self._candidate_clusters:
             clusters.update(candidate_cluster.protoclusters)
         return sorted(clusters)

--- a/antismash/common/secmet/features/test/test_prepeptide.py
+++ b/antismash/common/secmet/features/test/test_prepeptide.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=no-self-use,protected-access,missing-docstring,unbalanced-tuple-unpacking
 
 import unittest
 

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -4,8 +4,7 @@
 """ Helper functions for location operations """
 
 import logging
-from typing import Iterable, List, Sequence, Tuple, Union
-from typing import Optional  # in comment hints, pylint: disable=unused-import
+from typing import Iterable, List, Optional, Sequence, Tuple, Union
 
 from Bio.SeqFeature import (
     AbstractPosition,

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -180,8 +180,8 @@ def split_origin_bridging_location(location: CompoundLocation) -> Tuple[
         Returns:
             a tuple of lists, each list containing one or more FeatureLocations
     """
-    lower = []  # type: List[FeatureLocation]
-    upper = []  # type: List[FeatureLocation]
+    lower: List[FeatureLocation] = []
+    upper: List[FeatureLocation] = []
     if location.strand == 1:
         for i, part in enumerate(location.parts):
             if not upper or part.start > upper[-1].start:
@@ -264,7 +264,7 @@ def location_from_string(data: str) -> Location:
 
         strand_text = string[-2]  # [<1:6](-) -> -
         if strand_text == '-':
-            strand = -1  # type: Optional[int]
+            strand: Optional[int] = -1
         elif strand_text == '+':
             strand = 1
         elif strand_text == '?':

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -389,7 +389,8 @@ def ensure_valid_locations(features: List[SeqFeature], can_be_circular: bool, se
 
     if standard and non_standard:
         raise ValueError("inconsistent exon ordering for features in non-circular record")
-    elif non_standard:
+
+    if non_standard:
         for feature in features:
             if not feature.location.strand:
                 continue

--- a/antismash/common/secmet/qualifiers/asf.py
+++ b/antismash/common/secmet/qualifiers/asf.py
@@ -3,8 +3,7 @@
 
 """ A qualifier for ActiveSiteFinder annotations """
 
-from typing import List
-from typing import Set  # comment hint  # pylint: disable=unused-import
+from typing import List, Set
 
 
 class ActiveSiteFinderQualifier:

--- a/antismash/common/secmet/qualifiers/asf.py
+++ b/antismash/common/secmet/qualifiers/asf.py
@@ -10,7 +10,7 @@ class ActiveSiteFinderQualifier:
     """ A qualifier for tracking active sites found (or not found) within a CDS.
     """
     def __init__(self) -> None:
-        self._hits = set()  # type: Set[str]
+        self._hits: Set[str] = set()
 
     @property
     def hits(self) -> List[str]:

--- a/antismash/common/secmet/qualifiers/gene_functions.py
+++ b/antismash/common/secmet/qualifiers/gene_functions.py
@@ -104,9 +104,9 @@ class GeneFunctionAnnotations:
     slots = ["_annotations", "_by_tool", "_by_function"]
 
     def __init__(self) -> None:
-        self._annotations = []  # type: List["_GeneFunctionAnnotation"]
-        self._by_tool = defaultdict(list)  # type: Dict[str, List["_GeneFunctionAnnotation"]]
-        self._by_function = defaultdict(list)  # type: Dict[GeneFunction, List["_GeneFunctionAnnotation"]]
+        self._annotations: List["_GeneFunctionAnnotation"] = []
+        self._by_tool: Dict[str, List[_GeneFunctionAnnotation]] = defaultdict(list)
+        self._by_function: Dict[GeneFunction, List[_GeneFunctionAnnotation]] = defaultdict(list)
 
     def __iter__(self) -> Iterator["_GeneFunctionAnnotation"]:
         for annotation in self._annotations:

--- a/antismash/common/secmet/qualifiers/gene_functions.py
+++ b/antismash/common/secmet/qualifiers/gene_functions.py
@@ -5,8 +5,7 @@
 
 from collections import defaultdict
 from enum import Enum, unique
-from typing import Any, Iterator, List, Optional
-from typing import Dict  # comment hints  # pylint: disable=unused-import
+from typing import Any, Dict, Iterator, List, Optional
 
 from .secmet import _parse_format
 

--- a/antismash/common/secmet/qualifiers/nrps_pks.py
+++ b/antismash/common/secmet/qualifiers/nrps_pks.py
@@ -52,7 +52,7 @@ class NRPSPKSQualifier:
             if not feature_name:
                 raise ValueError("a Domain must belong to a feature, feature_name is required")
             self.feature_name = str(feature_name)
-            self.predictions = {}  # type: Dict[str, str] # method to prediction name
+            self.predictions: Dict[str, str] = {}  # method to prediction name
             self.subtype = str(subtype)
 
         def __lt__(self, other: "NRPSPKSQualifier.Domain") -> bool:
@@ -75,9 +75,9 @@ class NRPSPKSQualifier:
             raise ValueError("strand must be 1 or -1, not %s" % strand)
         self.strand = strand
         self.type = "uninitialised"
-        self.subtypes = []  # type: List[str]
-        self._domains = []  # type: List["NRPSPKSQualifier.Domain"]
-        self._domain_names = []  # type: List[str]
+        self.subtypes: List[str] = []
+        self._domains: List["NRPSPKSQualifier.Domain"] = []
+        self._domain_names: List[str] = []
         self.cal_counter = 0
         self.at_counter = 0
         self.kr_counter = 0

--- a/antismash/common/secmet/qualifiers/nrps_pks.py
+++ b/antismash/common/secmet/qualifiers/nrps_pks.py
@@ -4,8 +4,7 @@
 """ Annotations for NRPS/PKS domains """
 
 import bisect
-from typing import Any, Iterator, List, Tuple
-from typing import Dict  # used in comment hints # pylint: disable=unused-import
+from typing import Any, Dict, Iterator, List, Tuple
 
 from .secmet import _parse_format
 

--- a/antismash/common/secmet/qualifiers/prepeptide_qualifiers.py
+++ b/antismash/common/secmet/qualifiers/prepeptide_qualifiers.py
@@ -161,11 +161,11 @@ def rebuild_qualifier(data: Dict[str, List[str]], kind: str) -> Optional[RiPPQua
     """
     if not data or "RODEO_score" not in data:
         return None
-    classes = {
+    classes: Dict[str, Type[RiPPQualifier]] = {
         "lanthipeptide": LanthiQualifier,
         "thiopeptide": ThioQualifier,
         "lassopeptide": LassoQualifier,
-    }  # type: Dict[str, Type[RiPPQualifier]]
+    }
     if kind not in classes:
         raise ValueError("no known qualifier builder for prepeptide kind: %s" % kind)
     return classes[kind].from_biopython_qualifiers(data)

--- a/antismash/common/secmet/qualifiers/prepeptide_qualifiers.py
+++ b/antismash/common/secmet/qualifiers/prepeptide_qualifiers.py
@@ -4,8 +4,7 @@
 """ Qualifiers to contain extra annotations for RiPP prepeptides
 """
 
-from typing import Dict, List, Optional
-from typing import Type  # comment hints, pylint: disable=unused-import
+from typing import Dict, List, Optional, Type
 
 
 class RiPPQualifier:

--- a/antismash/common/secmet/qualifiers/secmet.py
+++ b/antismash/common/secmet/qualifiers/secmet.py
@@ -102,9 +102,9 @@ class SecMetQualifier:
             return cls(str(json[0]), float(json[1]), float(json[2]), int(json[3]), str(json[4]))
 
     def __init__(self, domains: List["SecMetQualifier.Domain"] = None) -> None:
-        self._domains = []  # type: List["SecMetQualifier.Domain"]
-        self.domain_ids = []  # type: List[str]
-        self.unique_domain_ids = set()  # type: Set[str]
+        self._domains: List["SecMetQualifier.Domain"] = []
+        self.domain_ids: List[str] = []
+        self.unique_domain_ids: Set[str] = set()
         if domains is not None:
             self.add_domains(domains)
         super().__init__()

--- a/antismash/common/secmet/qualifiers/secmet.py
+++ b/antismash/common/secmet/qualifiers/secmet.py
@@ -24,7 +24,7 @@ def _parse_format(fmt: str, data: str) -> Sequence[str]:
     # escape anything that might cause issues when using it as a regex later
     safe = re.escape(fmt)
     # treat (escaped) spaces as optional thanks to genbank/biopython conversions
-    safe = safe.replace("\ ", "\ ?")
+    safe = safe.replace(r"\ ", r"\ ?")
     # the simple search here would be {.*?} for a non-greedy brace pair, but
     # because python format strings use {{ and }} as literal braces, they need to be excluded
     # e.g. "{{{{{:g}}}}}".format(1e-5) == "{{1e-5}}"

--- a/antismash/common/secmet/qualifiers/secmet.py
+++ b/antismash/common/secmet/qualifiers/secmet.py
@@ -4,8 +4,7 @@
 """ Annotations for secondary metabolites """
 
 import re
-from typing import Any, Iterator, List, Sequence, Union
-from typing import Set  # comment hints  # pylint: disable=unused-import
+from typing import Any, Iterator, List, Sequence, Set, Union
 
 
 def _parse_format(fmt: str, data: str) -> Sequence[str]:

--- a/antismash/common/secmet/qualifiers/test/test_genefunction.py
+++ b/antismash/common/secmet/qualifiers/test/test_genefunction.py
@@ -14,7 +14,7 @@ class TestGeneFunction(unittest.TestCase):
     def test_membership(self):
         assert GeneFunction.OTHER
         with self.assertRaises(AttributeError):
-            print(GeneFunction.non_existant)
+            print(GeneFunction.non_existant)  # pylint: disable=no-member
 
     def test_equality(self):
         assert GeneFunction.OTHER == GeneFunction.OTHER

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -66,38 +66,38 @@ class Record:
         if isinstance(seq, str):
             seq = Seq(seq)
         self._record = SeqRecord(seq, **kwargs)
-        self.record_index = None  # type: Optional[int]
+        self.record_index: Optional[int] = None
         self.original_id = None
-        self.skip = None  # type: Optional[str] # TODO: move to yet another abstraction layer?
-        self._genes = []  # type: List[Gene]
+        self.skip: Optional[str] = None  # TODO: move to yet another abstraction layer?
+        self._genes: List[Gene] = []
 
-        self._cds_features = []  # type: List[CDSFeature]
-        self._cds_by_name = {}  # type: Dict[str, CDSFeature]
+        self._cds_features: List[CDSFeature] = []
+        self._cds_by_name: Dict[str, CDSFeature] = {}
 
-        self._cds_motifs = []  # type: List[CDSMotif]
+        self._cds_motifs: List[CDSMotif] = []
 
-        self._pfam_domains = []  # type: List[PFAMDomain]
-        self._pfams_by_cds_name = defaultdict(list)  # type: Dict[str, List[PFAMDomain]]
+        self._pfam_domains: List[PFAMDomain] = []
+        self._pfams_by_cds_name: Dict[str, List[PFAMDomain]] = defaultdict(list)
 
-        self._antismash_domains = []  # type: List[AntismashDomain]
-        self._modules = []  # type: List[Module]
+        self._antismash_domains: List[AntismashDomain] = []
+        self._modules: List[Module] = []
 
         # includes PFAMDomains and AntismashDomains
-        self._domains_by_name = {}  # type: Dict[str, Domain]  # for use as x[domain.get_name()] = domain
+        self._domains_by_name: Dict[str, Domain] = {}  # for use as x[domain.get_name()] = domain
 
-        self._nonspecific_features = []  # type: List[Feature]
+        self._nonspecific_features: List[Feature] = []
 
-        self._protoclusters = []  # type: List[Protocluster]
-        self._protocluster_numbering = {}  # type: Dict[Protocluster, int]
+        self._protoclusters: List[Protocluster] = []
+        self._protocluster_numbering: Dict[Protocluster, int] = {}
 
-        self._candidate_clusters = []  # type: List[CandidateCluster]
-        self._candidate_clusters_numbering = {}  # type: Dict[CandidateCluster, int]
+        self._candidate_clusters: List[CandidateCluster] = []
+        self._candidate_clusters_numbering: Dict[CandidateCluster, int] = {}
 
-        self._subregions = []  # type: List[SubRegion]
-        self._subregion_numbering = {}  # type: Dict[SubRegion, int]
+        self._subregions: List[SubRegion] = []
+        self._subregion_numbering: Dict[SubRegion, int] = {}
 
-        self._regions = []  # type: List[Region]
-        self._region_numbering = {}  # type: Dict[Region, int]
+        self._regions: List[Region] = []
+        self._region_numbering: Dict[Region, int] = {}
 
         self._transl_table = int(transl_table)
 
@@ -444,7 +444,7 @@ class Record:
             assert isinstance(location, FeatureLocation)
             location = FeatureLocation(0, max(1, location.end))
 
-        results = []  # type: List[CDSFeature]
+        results: List[CDSFeature] = []
         # shortcut if no CDS features exist
         if not self._cds_features:
             return results
@@ -465,7 +465,7 @@ class Record:
     def to_biopython(self) -> SeqRecord:
         """Returns a Bio.SeqRecord instance of the record"""
         features = self.get_all_features()
-        bio_features = []  # type: List[SeqFeature]
+        bio_features: List[SeqFeature] = []
         for feature in sorted(features):
             bio_features.extend(feature.to_biopython())
         return SeqRecord(self.seq, id=self._record.id, name=self._record.name,
@@ -649,7 +649,7 @@ class Record:
         """ Constructs a new Record instance from a biopython SeqRecord,
             also replaces biopython SeqFeatures with Feature subclasses
         """
-        postponed_features = OrderedDict()  # type: Dict[str, Tuple[Type[Feature], List[SeqFeature]]]
+        postponed_features: Dict[str, Tuple[Type[Feature], List[SeqFeature]]] = OrderedDict()
         for kind in [CandidateCluster, Region, Module]:  # type: Type[Feature]
             postponed_features[kind.FEATURE_TYPE] = (kind, [])
 
@@ -786,8 +786,11 @@ class Record:
                 cds.region = region
 
         # for other collections, since they may overlap heavily, exhaustive search required
-        other_collections = [self._protoclusters, self._candidate_clusters,
-                             self._subregions]  # type: Sequence[Sequence[CDSCollection]]
+        other_collections: Sequence[Sequence[CDSCollection]] = [
+            self._protoclusters,
+            self._candidate_clusters,
+            self._subregions
+        ]
         for collections in other_collections:
             for collection in collections:
                 if cds.is_contained_by(collection):
@@ -839,7 +842,7 @@ class Record:
         """ Returns all CDS features in the record that are located within a
             region of interest
         """
-        features = []  # type: List[CDSFeature]
+        features: List[CDSFeature] = []
         for region in self._regions:
             features.extend(region.cds_children)
         return features
@@ -878,7 +881,7 @@ class Record:
         if not candidate_clusters and not subregions:
             return 0
 
-        areas = []  # type: List[CDSCollection]
+        areas: List[CDSCollection] = []
         areas.extend(candidate_clusters)
         areas.extend(subregions)
         areas.sort()

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -279,8 +279,7 @@ class Record:
             if region < existing_region:
                 index = i  # before
                 break
-            else:
-                index = i + 1  # after
+            index = i + 1  # after
         self._regions.insert(index, region)
         region.parent_record = self
         # update numbering

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -14,8 +14,7 @@
 import bisect
 from collections import Counter, defaultdict, OrderedDict
 import logging
-from typing import Any, Dict, List, Tuple, Union, cast
-from typing import Optional, Sequence, Set, Type  # comment hints # pylint: disable=unused-import
+from typing import Any, Dict, List, Optional, Sequence, Type, Tuple, Union, cast
 
 from Bio import Alphabet, SeqIO
 from Bio.Seq import Seq
@@ -38,7 +37,7 @@ from .features import (
     Region,
     SubRegion,
 )
-from .features import CDSCollection  # comment hints, pylint: disable=unused-import
+from .features import CDSCollection
 from .features.candidate_cluster import create_candidates_from_protoclusters
 
 from .locations import (

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -3,6 +3,8 @@
 
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=no-self-use,protected-access,missing-docstring
+# reusing variables in different argument positions seems to trick pylint
+# pylint: disable=arguments-out-of-order
 
 import unittest
 from unittest.mock import patch

--- a/antismash/common/serialiser.py
+++ b/antismash/common/serialiser.py
@@ -58,7 +58,7 @@ class AntismashResults:
 
     def to_json(self) -> Dict[str, Any]:
         """ Constructs a JSON representation of the instance """
-        res = OrderedDict()  # type: Dict[str, Any]
+        res: Dict[str, Any] = OrderedDict()
         res["version"] = self.version
         res["input_file"] = self.input_file
         biopython = [rec.to_biopython() for rec in self.records]
@@ -94,7 +94,7 @@ def dump_records(records: List[SeqRecord], results: List[Dict[str, Union[Dict[st
     assert isinstance(results, list)
     for record, result in zip(records, results):
         json_record = record_to_json(record)
-        modules = OrderedDict()  # type: Dict[str, Dict]
+        modules: Dict[str, Dict] = OrderedDict()
         if result:
             logging.debug("Record %s has results for modules: %s", record.id,
                           ", ".join([mod.rsplit('.', 1)[-1] for mod, resultv in result.items() if resultv]))
@@ -137,7 +137,7 @@ def record_to_json(record: SeqRecord) -> Dict[str, Any]:
             res["references"].append(ref)
         return res
 
-    result = OrderedDict()  # type: Dict[str, Any]
+    result: Dict[str, Any] = OrderedDict()
     result["id"] = record.id
     result["seq"] = sequence_to_json(record.seq)
     result["features"] = list(map(feature_to_json, record.features))

--- a/antismash/common/subprocessing/base.py
+++ b/antismash/common/subprocessing/base.py
@@ -76,8 +76,8 @@ def execute(commands: List[str], stdin: Optional[str] = None, stdout: Union[int,
         commands[0] = getattr(options.executables, commands[0])
 
     if stdin is not None:
-        stdin_redir = PIPE  # type: Optional[int]
-        input_bytes = stdin.encode("utf-8")  # type: Optional[bytes]
+        stdin_redir: Optional[int] = PIPE
+        input_bytes: Optional[bytes] = stdin.encode("utf-8")
     else:
         stdin_redir = None
         input_bytes = None

--- a/antismash/common/subprocessing/blast.py
+++ b/antismash/common/subprocessing/blast.py
@@ -40,7 +40,7 @@ def run_blastp(target_blastp_database: str, query_sequence: str,
         command.extend(opts)
 
     if results_file is not None:
-        handle = open(results_file)  # type: IO[Any]
+        handle: IO[Any] = open(results_file)
     else:
         handle = NamedTemporaryFile()
 

--- a/antismash/common/subprocessing/blast.py
+++ b/antismash/common/subprocessing/blast.py
@@ -5,8 +5,7 @@
 """
 
 from tempfile import NamedTemporaryFile
-from typing import List
-from typing import Any, IO  # comment hints, pylint: disable=unused-import
+from typing import Any, IO, List
 
 from .base import execute, get_config, SearchIO
 

--- a/antismash/common/test/helpers.py
+++ b/antismash/common/test/helpers.py
@@ -34,6 +34,8 @@ from antismash.config import update_config
 from antismash.config.args import build_parser
 from antismash.main import get_all_modules, canonical_base_filename
 
+from .test_hmmer import create_hmmer_hit as DummyHmmerHit  # for import by others, pylint: disable=unused-import
+
 
 def get_simple_options(module, args):
     modules = get_all_modules()

--- a/antismash/common/test/test_hmmer.py
+++ b/antismash/common/test/test_hmmer.py
@@ -1,0 +1,70 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+# for test files, silence irrelevant and noisy pylint warnings
+# pylint: disable=no-self-use,protected-access,missing-docstring
+
+from dataclasses import FrozenInstanceError
+import json
+import unittest
+
+from antismash.common.hmmer import HmmerHit
+
+
+def create_hmmer_hit(location="[500:700]", label="ref_name", locus_tag="locus",
+                     domain="hit", evalue=1e-10, score=40.5, translation=None,
+                     identifier="TESTID_0005", description="some description",
+                     protein_start=9, protein_end=None):
+    if translation is None:
+        if protein_end is None:
+            protein_end = 13
+        translation = "M" * (protein_end - protein_start)
+
+    protein_end = protein_end or (protein_start + len(translation))
+
+    return HmmerHit(
+        location=location,
+        label=label,
+        locus_tag=locus_tag,
+        domain=domain,
+        evalue=evalue,
+        score=score,
+        translation=translation,
+        identifier=identifier,
+        description=description,
+        protein_start=protein_start,
+        protein_end=protein_end
+    )
+
+
+class TestHmmerHit(unittest.TestCase):
+    def test_immutable(self):
+        hit = create_hmmer_hit()
+        with self.assertRaisesRegex(FrozenInstanceError, "cannot assign to field 'invalid'"):
+            hit.invalid = "test"
+        assert hit.protein_start
+        with self.assertRaisesRegex(FrozenInstanceError, "cannot assign to field 'protein_start'"):
+            hit.protein_start = 7
+
+    def test_length(self):
+        hit = create_hmmer_hit(protein_start=9, protein_end=13)
+        assert len(hit) == 4
+        hit = create_hmmer_hit(protein_start=1, protein_end=23)
+        assert len(hit) == 22
+
+    def test_invalid_positions(self):
+        with self.assertRaisesRegex(ValueError, "inverted start and end"):
+            create_hmmer_hit(protein_start=9, protein_end=9)
+        with self.assertRaisesRegex(ValueError, "inverted start and end"):
+            create_hmmer_hit(protein_start=5, protein_end=3)
+
+    def test_mismatching_lengths(self):
+        hit = create_hmmer_hit(protein_start=5, protein_end=15, translation="A"*10)
+        assert len(hit) == len(hit.translation) == hit.protein_end - hit.protein_start
+        with self.assertRaisesRegex(ValueError, "translation length does not match"):
+            create_hmmer_hit(protein_start=5, protein_end=15, translation="A"*4)
+
+    def test_json_conversion(self):
+        hit = create_hmmer_hit()
+        as_json = json.loads(json.dumps(hit.to_json()))
+        assert hit == HmmerHit.from_json(as_json)

--- a/antismash/common/test/test_logs.py
+++ b/antismash/common/test/test_logs.py
@@ -22,7 +22,6 @@ class LogTest(unittest.TestCase):
     # grab the pytest logging capture fixture
     @pytest.fixture(autouse=True)
     def inject_fixtures(self, caplog):
-        caplog.set_level(logging.WARNING)
         self.caplog = caplog  # pylint: disable=attribute-defined-outside-init
 
     def test_debug(self):
@@ -32,6 +31,7 @@ class LogTest(unittest.TestCase):
             logging.debug("during")
         assert self.logger.getEffectiveLevel() == logging.WARNING
         logging.debug("after")
+        assert len(self.caplog.record_tuples) == 1
         for _, level, msg in self.caplog.record_tuples:
             assert level == logging.DEBUG
             assert "during" in msg
@@ -44,6 +44,7 @@ class LogTest(unittest.TestCase):
             assert self.logger.getEffectiveLevel() == logging.INFO
         logging.info("after")
         assert self.logger.getEffectiveLevel() == logging.WARNING
+        assert len(self.caplog.record_tuples) == 1
         for _, level, msg in self.caplog.record_tuples:
             assert level == logging.INFO
             assert "during" in msg

--- a/antismash/common/utils.py
+++ b/antismash/common/utils.py
@@ -37,10 +37,10 @@ class RobustProteinAnalysis(ProteinAnalysis):
         # remove all invalids
         prot_sequence = "".join(filter(lambda x: x in RobustProteinAnalysis.PROTEIN_LETTERS,
                                        self.original_sequence))
-        super(RobustProteinAnalysis, self).__init__(prot_sequence, monoisotopic)
+        super().__init__(prot_sequence, monoisotopic)
 
     def molecular_weight(self) -> float:
-        weight = super(RobustProteinAnalysis, self).molecular_weight()
+        weight = super().molecular_weight()
         if not self._ignore_invalid:
             aa_difference = len(self.original_sequence) - len(self.sequence)
             weight += 110 * aa_difference

--- a/antismash/config/__init__.py
+++ b/antismash/config/__init__.py
@@ -77,7 +77,7 @@ class Config:  # since it's a glorified namespace, pylint: disable=too-few-publi
 
     def __new__(cls, namespace: Union[Namespace, Dict[str, Any]] = None) -> ConfigType:
         if namespace is None:
-            values = {}  # type: Dict[str, Any]
+            values: Dict[str, Any] = {}
         elif isinstance(namespace, dict):
             values = namespace
         else:

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -152,8 +152,8 @@ class AntismashParser(argparse.ArgumentParser):
             values = {}
 
         outfile = open(filename, 'w')
-        dests = set()  # type: Set[str] # set of processed destinations
-        titles = defaultdict(lambda: defaultdict(list))  # type: Dict[str, Dict[str, List[str]]]
+        dests: Set[str] = set()  # set of processed destinations
+        titles: Dict[str, Dict[str, List[str]]] = defaultdict(lambda: defaultdict(list))
         for parent in sorted(self.parents, key=lambda group: group.title):
             for arg in parent.parser.get_actions():
                 titles[parent.title][parent.prefix].extend(construct_arg_text(arg, dests, values))
@@ -316,7 +316,7 @@ class ModuleArgs:
         self.prefix = prefix
 
         self.skip_type_check = self.override
-        self.args = []  # type: List[argparse.Action]
+        self.args: List[argparse.Action] = []
         self.basic = basic_help
 
     def add_option(self, name: str, *args: Any, **kwargs: Any) -> None:

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -11,8 +11,7 @@ import argparse
 from collections import defaultdict
 import multiprocessing
 import os
-from typing import (Any, AnyStr, IO, List, Optional,   # pylint: disable=unused-import
-                    Dict, Set, Tuple)
+from typing import Any, AnyStr, Dict, IO, List, Optional, Set, Tuple
 
 from antismash.custom_typing import AntismashModule
 

--- a/antismash/config/executables.py
+++ b/antismash/config/executables.py
@@ -55,7 +55,7 @@ def get_default_paths() -> Dict[str, str]:
     """ Builds a default set of paths, one for each
         executable in _ALTERNATE_EXECUTABLE_NAMES.
     """
-    binaries = OrderedDict()  # type: Dict[str, str]
+    binaries: Dict[str, str] = OrderedDict()
     for name, alternates in _ALTERNATE_EXECUTABLE_NAMES.items():
         if name in binaries:
             continue
@@ -74,7 +74,7 @@ def get_executable_paths(binaries_arg: str) -> Dict[str, str]:
             diamond=/full/path/to/executable,hmmpfam2=hmm2pfam
         into a Namespace, provided each binary name is in _ALTERNATE_EXECUTABLE_NAMES.
     """
-    binaries = {}  # type: Dict[str, str]
+    binaries: Dict[str, str] = {}
     for part in binaries_arg.split(","):
         if not part:
             continue

--- a/antismash/detection/cassis/__init__.py
+++ b/antismash/detection/cassis/__init__.py
@@ -37,8 +37,8 @@ class CassisResults(module_results.DetectionResults):
     """ Contains the subregions predicted by cassis """
     def __init__(self, record_id: str) -> None:
         super().__init__(record_id)
-        self.subregions = []  # type: List[SubRegion]
-        self.promoters = []  # type: List[Promoter]
+        self.subregions: List[SubRegion] = []
+        self.promoters: List[Promoter] = []
 
     def to_json(self) -> Dict[str, Any]:
         subregions = []
@@ -67,7 +67,7 @@ class CassisResults(module_results.DetectionResults):
             return None
 
         subregions = []
-        promoters = []  # type: List[Promoter]
+        promoters: List[Promoter] = []
         for cluster in json["subregions"]:
             subregions.append(SubRegion.from_biopython(feature_from_json(cluster)))
         for promoter in json["promoters"]:
@@ -341,7 +341,7 @@ def filter_subregions(subregions: List[SubRegion]) -> List[SubRegion]:
     if not subregions:
         return subregions
 
-    by_anchor = defaultdict(list)  # type: Dict[str, List[SubRegion]]
+    by_anchor: Dict[str, List[SubRegion]] = defaultdict(list)
     # sort from largest to smallest to avoid complicated replacement logic
     # any sharing an anchor will overlap on that gene anyway
     for sub in sorted(subregions, key=lambda x: x.location.end - x.location.start, reverse=True):
@@ -361,7 +361,7 @@ def filter_subregions(subregions: List[SubRegion]) -> List[SubRegion]:
 def create_subregions(anchor: str, cluster_preds: List[ClusterPrediction],
                       record: Record) -> List[SubRegion]:
     """ Create the predicted subregions """
-    subregions = []  # type: List[SubRegion]
+    subregions: List[SubRegion] = []
     if not cluster_preds:
         return subregions
     for i, cluster in enumerate(cluster_preds):

--- a/antismash/detection/cassis/__init__.py
+++ b/antismash/detection/cassis/__init__.py
@@ -212,10 +212,11 @@ def detect(record: Record, options: ConfigType) -> CassisResults:
     if not promoters:
         logging.debug("CASSIS found zero promoter regions, skipping CASSIS analysis")
         return results
-    elif len(promoters) < 3:
+    if len(promoters) < 3:
         logging.debug("Sequence %r yields less than 3 promoter regions, skipping CASSIS analysis", record.name)
         return results
-    elif len(promoters) < 40:
+
+    if len(promoters) < 40:
         logging.debug("Sequence %r yields only %d promoter regions", record.name, len(promoters))
         logging.debug("Cluster detection on small sequences may lead to incomplete cluster predictions")
 

--- a/antismash/detection/cassis/cluster_prediction.py
+++ b/antismash/detection/cassis/cluster_prediction.py
@@ -248,11 +248,11 @@ def create_predictions(islands: List[Island]) -> List[ClusterPrediction]:
             ends[island.end.get_gene_names()[-1]] = ClusterMarker(island.end.get_gene_names()[-1], island.motif)
 
     # compute sum of start and end abundance, remove duplicates, sort descending
-    abundances_sum_sorted = sorted(set([s.abundance + e.abundance
-                                        for s in starts.values() for e in ends.values()]), reverse=True)
+    abundances_sum_sorted = sorted(set(s.abundance + e.abundance
+                                       for s in starts.values() for e in ends.values()), reverse=True)
     # compute sum of start and end motif score, remove duplicates, sort ascending
-    scores_sum_sorted = sorted(set([s.score + e.score
-                                    for s in starts.values() for e in ends.values()]))
+    scores_sum_sorted = sorted(set(s.score + e.score
+                                   for s in starts.values() for e in ends.values()))
     # sort by value (=abundance) of start, descending
     starts_sorted = sorted(starts, key=lambda x: starts[x].abundance, reverse=True)
     # sort by value (=abundance) of end, descending

--- a/antismash/detection/cassis/cluster_prediction.py
+++ b/antismash/detection/cassis/cluster_prediction.py
@@ -31,7 +31,7 @@ class ClusterMarker(Pairing):
         self.abundance = 1
         assert motif.score is not None
         self.score = float(motif.score)
-        self.promoter = None  # type: Optional[str]
+        self.promoter: Optional[str] = None
 
     def update(self, motif: Motif) -> None:
         """ Uses the given motif's values instead of the old ones, if the given
@@ -230,8 +230,8 @@ def create_predictions(islands: List[Island]) -> List[ClusterPrediction]:
     """
     # count border abundance
     # start/end are treated independently!
-    starts = {}  # type: Dict[str, ClusterMarker]
-    ends = {}  # type: Dict[str, ClusterMarker]
+    starts: Dict[str, ClusterMarker] = {}
+    ends: Dict[str, ClusterMarker] = {}
     for island in islands:
         if island.start.gene_name in starts:
             scorer = starts[island.start.gene_name]

--- a/antismash/detection/cassis/cluster_prediction.py
+++ b/antismash/detection/cassis/cluster_prediction.py
@@ -5,7 +5,7 @@
 
 import logging
 import os
-from typing import Any, Dict, List, Optional  # pylint: disable=unused-import
+from typing import Any, Dict, List, Optional
 
 from antismash.common.secmet import Record, Gene
 from antismash.config import ConfigType

--- a/antismash/detection/cassis/motifs.py
+++ b/antismash/detection/cassis/motifs.py
@@ -199,13 +199,13 @@ def filter_fimo_results(motifs: List[Motif], fimo_dir: str, promoters: List[Prom
                 logging.debug("FIMO: motif %s; occurs in %d promoters (no hits)",
                               motif, len(motif.hits))
             continue
-        elif percentage > cassis.MAX_PERCENTAGE:
+        if percentage > cassis.MAX_PERCENTAGE:
             # too high
             if cassis.VERBOSE_DEBUG:
                 logging.debug("FIMO: %s; occurs in %d promoters; %.2f%% of all promoters (too many)",
                               motif, len(motif.hits), percentage)
             continue
-        elif promoters[anchor_promoter].get_id() not in motif.hits:  # not in achor promoter
+        if promoters[anchor_promoter].get_id() not in motif.hits:  # not in achor promoter
             # no site in anchor promoter
             if cassis.VERBOSE_DEBUG:
                 logging.debug("FIMO: motif %s; no hits in the promoter of the anchor gene", motif)

--- a/antismash/detection/cassis/motifs.py
+++ b/antismash/detection/cassis/motifs.py
@@ -26,11 +26,11 @@ class Motif(Pairing):
     def __init__(self, plus: int, minus: int, score: Optional[float] = None,
                  hits: Optional[Dict[str, int]] = None) -> None:
         super().__init__(plus, minus)
-        self._score = None  # type: Optional[float]
+        self._score: Optional[float] = None
         if score:
             self.score = score
-        self.seqs = []  # type: List[str]
-        self.hits = defaultdict(lambda: 0)  # type: Dict[str, int]
+        self.seqs: List[str] = []
+        self.hits: Dict[str, int] = defaultdict(lambda: 0)
         if hits:
             for key, val in hits.items():
                 self.hits[str(key)] = int(val)
@@ -64,7 +64,7 @@ def generate_motifs(meme_dir: str, anchor_promoter: int, promoters: List[Promote
         os.makedirs(meme_dir)
 
     # prepare sets of promoter sequences (MEME input)
-    indices = set()  # type: Set[Tuple[int, int]] # to monitor unique start_index/end_index
+    indices: Set[Tuple[int, int]] = set()  # to monitor unique start_index/end_index
     for pm in PROMOTER_RANGE:
         start_index = anchor_promoter - pm.minus
         end_index = anchor_promoter + pm.plus

--- a/antismash/detection/cassis/motifs.py
+++ b/antismash/detection/cassis/motifs.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 import csv
 import logging
 import os
-from typing import Any, Dict, List, Optional, Set, Tuple  # pylint: disable=unused-import
+from typing import Any, Dict, List, Optional, Set, Tuple
 from xml.etree import cElementTree as ElementTree
 
 from Bio import SeqIO

--- a/antismash/detection/cassis/promoters.py
+++ b/antismash/detection/cassis/promoters.py
@@ -15,7 +15,7 @@ from antismash.common.secmet import Record, Gene
 
 class DuplicatePromoterError(Exception):
     '''Thrown when running into valid but duplicate promoter sequences during runtime'''
-    pass
+    pass  # pylint: disable=unnecessary-pass
 
 
 class Promoter:
@@ -245,8 +245,7 @@ def get_promoters(record: Record, genes: List[Gene],
             logging.error("Promoter %r occurs at least twice. This may be caused by overlapping gene annotations",
                           current_promoter.get_id())
             raise DuplicatePromoterError
-        else:
-            promoter_ids.add(current_promoter.get_id())
+        promoter_ids.add(current_promoter.get_id())
 
     if invalid:
         logging.debug("Ignoring %d promoters due to invalid promoter sequences", invalid)

--- a/antismash/detection/cassis/promoters.py
+++ b/antismash/detection/cassis/promoters.py
@@ -5,7 +5,7 @@
 
 import logging
 import os
-from typing import Any, Dict, List, Union, Set, Tuple  # pylint: disable=unused-import
+from typing import Any, Dict, List, Set
 
 from Bio import SeqIO
 from Bio.SeqRecord import SeqRecord

--- a/antismash/detection/cassis/promoters.py
+++ b/antismash/detection/cassis/promoters.py
@@ -108,7 +108,7 @@ def get_promoters(record: Record, genes: List[Gene],
 
     record_seq_length = len(record.seq)
     promoters = []
-    promoter_ids = set()  # type: Set[str]
+    promoter_ids: Set[str] = set()
     invalid = 0
 
     skip = False  # helper var for shared promoter of bidirectional genes

--- a/antismash/detection/cassis/test/test_cassis.py
+++ b/antismash/detection/cassis/test/test_cassis.py
@@ -45,7 +45,7 @@ def create_fake_record():
         cds.location = locations[i]
         seq_record.add_cds_feature(cds)
         seq_record.add_gene(secmet.Gene(locations[i], locus_tag="gene" + str(i+1)))
-        if i == 3 or i == 5:
+        if i in (3, 5):
             cds.gene_functions.add(secmet.qualifiers.GeneFunction.CORE, "testtool", "dummy", "product")
 
     return seq_record

--- a/antismash/detection/cluster_hmmer/__init__.py
+++ b/antismash/detection/cluster_hmmer/__init__.py
@@ -90,9 +90,8 @@ def run_on_record(record: Record, results: Optional[hmmer.HmmerResults],
         # same version requested, so reuse the results
         if database_version == previous_db:
             return results
-        else:
-            logging.debug("Replacing clusterhmmer results from %s with %s",
-                          previous_db, database_version)
+        logging.debug("Replacing clusterhmmer results from %s with %s",
+                      previous_db, database_version)
 
     logging.info('Running cluster PFAM search')
 

--- a/antismash/detection/cluster_hmmer/test/integration_cluster_hmmer.py
+++ b/antismash/detection/cluster_hmmer/test/integration_cluster_hmmer.py
@@ -62,33 +62,33 @@ class TestClusterHmmer(unittest.TestCase):
         self.set_max_evalue(self.original_max_evalue)
 
         # test regeneration when evalue threshold is more restrictive
-        new_evalue_threshold = sorted(hit["evalue"] for hit in results.hits)[6]
+        new_evalue_threshold = sorted(hit.evalue for hit in results.hits)[6]
         assert new_evalue_threshold < self.original_max_evalue
         new_hits = []
         for hit in results.hits:
-            if hit["evalue"] <= new_evalue_threshold:
+            if hit.evalue <= new_evalue_threshold:
                 new_hits.append(hit)
-        new_hits.sort(key=lambda x: x["evalue"])
+        new_hits.sort(key=lambda x: x.evalue)
         assert len(new_hits) < 13
 
         self.set_max_evalue(new_evalue_threshold)
         new_results = cluster_hmmer.regenerate_previous_results(json, record, self.options)
         self.set_max_evalue(self.original_max_evalue)
-        assert sorted(new_results.hits, key=lambda x: x["evalue"]) == new_hits
+        assert sorted(new_results.hits, key=lambda x: x.evalue) == new_hits
         self.check_add_to_record(nisin, results)
 
         # test regeneration when score threshold is more restrictive
-        new_score_threshold = sorted(hit["score"] for hit in results.hits)[6]
+        new_score_threshold = sorted(hit.score for hit in results.hits)[6]
         assert new_score_threshold > cluster_hmmer.MIN_SCORE
         new_hits = []
         for hit in results.hits:
-            if hit["score"] >= new_score_threshold:
+            if hit.score >= new_score_threshold:
                 new_hits.append(hit)
-        new_hits.sort(key=lambda x: x["score"])
+        new_hits.sort(key=lambda x: x.score)
         assert len(new_hits) < 13
 
         self.set_min_score(new_score_threshold)
         new_results = cluster_hmmer.regenerate_previous_results(json, record, self.options)
         self.set_min_score(self.original_min_score)
-        assert sorted(new_results.hits, key=lambda x: x["score"]) == new_hits
+        assert sorted(new_results.hits, key=lambda x: x.score) == new_hits
         self.check_add_to_record(nisin, results)

--- a/antismash/detection/clusterfinder_probabilistic/__init__.py
+++ b/antismash/detection/clusterfinder_probabilistic/__init__.py
@@ -129,7 +129,7 @@ def run_on_record(record: Record, results: Optional[ClusterFinderResults],
         logging.debug("No PFAM domains in record, probabilistic clusters cannot be found")
         return ClusterFinderResults(record.id, [])
 
-    pfam_ids = []  # type: List[str]
+    pfam_ids: List[str] = []
     for pfam in pfam_features:
         pfam_ids.append(pfam.identifier)
     if not pfam_ids:

--- a/antismash/detection/clusterfinder_probabilistic/probabilistic.py
+++ b/antismash/detection/clusterfinder_probabilistic/probabilistic.py
@@ -74,7 +74,7 @@ def find_probabilistic_clusters(record: Record, options: ConfigType) -> List[Clu
     cf_clusters = []
     state = "seed"
     cluster_position = (0, 0)
-    pfam_ids = []  # type: List[str]
+    pfam_ids: List[str] = []
     loop_index = 1
     probabilities = [0.]
     for feature in pfam_features:

--- a/antismash/detection/full_hmmer/__init__.py
+++ b/antismash/detection/full_hmmer/__init__.py
@@ -90,9 +90,8 @@ def run_on_record(record: Record, results: Optional[hmmer.HmmerResults],
         # same version requested, so reuse the results
         if database_version == previous_db:
             return results
-        else:
-            logging.debug("Replacing fullhmmer results from %s with %s",
-                          previous_db, database_version)
+        logging.debug("Replacing fullhmmer results from %s with %s",
+                      previous_db, database_version)
 
     logging.info('Running whole-genome PFAM search')
 

--- a/antismash/detection/full_hmmer/test/integration_full_hmmer.py
+++ b/antismash/detection/full_hmmer/test/integration_full_hmmer.py
@@ -62,33 +62,33 @@ class TestFullHmmer(unittest.TestCase):
         self.set_max_evalue(self.original_max_evalue)
 
         # test regeneration when evalue threshold is more restrictive
-        new_evalue_threshold = sorted(hit["evalue"] for hit in results.hits)[6]
+        new_evalue_threshold = sorted(hit.evalue for hit in results.hits)[6]
         assert new_evalue_threshold < self.original_max_evalue
         new_hits = []
         for hit in results.hits:
-            if hit["evalue"] <= new_evalue_threshold:
+            if hit.evalue <= new_evalue_threshold:
                 new_hits.append(hit)
-        new_hits.sort(key=lambda x: x["evalue"])
+        new_hits.sort(key=lambda x: x.evalue)
         assert len(new_hits) < 24
 
         self.set_max_evalue(new_evalue_threshold)
         new_results = full_hmmer.regenerate_previous_results(json, record, self.options)
         self.set_max_evalue(self.original_max_evalue)
-        assert sorted(new_results.hits, key=lambda x: x["evalue"]) == new_hits
+        assert sorted(new_results.hits, key=lambda x: x.evalue) == new_hits
         self.check_add_to_record(nisin, results)
 
         # test regeneration when score threshold is more restrictive
-        new_score_threshold = sorted(hit["score"] for hit in results.hits)[6]
+        new_score_threshold = sorted(hit.score for hit in results.hits)[6]
         assert new_score_threshold > full_hmmer.MIN_SCORE
         new_hits = []
         for hit in results.hits:
-            if hit["score"] >= new_score_threshold:
+            if hit.score >= new_score_threshold:
                 new_hits.append(hit)
-        new_hits.sort(key=lambda x: x["score"])
+        new_hits.sort(key=lambda x: x.score)
         assert len(new_hits) < 24
 
         self.set_min_score(new_score_threshold)
         new_results = full_hmmer.regenerate_previous_results(json, record, self.options)
         self.set_min_score(self.original_min_score)
-        assert sorted(new_results.hits, key=lambda x: x["score"]) == new_hits
+        assert sorted(new_results.hits, key=lambda x: x.score) == new_hits
         self.check_add_to_record(nisin, results)

--- a/antismash/detection/genefinding/__init__.py
+++ b/antismash/detection/genefinding/__init__.py
@@ -94,7 +94,8 @@ def run_on_record(record: Record, options: ConfigType) -> None:
         assert options.genefinding_tool == "glimmerhmm"
         logging.debug("Running glimmerhmm genefinding")
         return run_glimmerhmm(record)
-    elif options.genefinding_tool in ["prodigal", "prodigal-m"]:
+
+    if options.genefinding_tool in ["prodigal", "prodigal-m"]:
         logging.debug("Running prodigal based genefinding")
         return run_prodigal(record, options)
 

--- a/antismash/detection/genefinding/__init__.py
+++ b/antismash/detection/genefinding/__init__.py
@@ -45,10 +45,10 @@ def get_arguments() -> ModuleArgs:
 
 def check_prereqs(options: ConfigType) -> List[str]:
     """ Make sure the external tools to use are available """
-    failure_messages = []  # type: List[str]
+    failure_messages: List[str] = []
     if options.genefinding_tool in ['none']:
         return failure_messages
-    binaries = []  # type: List[str]
+    binaries: List[str] = []
     if options.check_prereqs_only:
         binaries = ["prodigal", "glimmerhmm"]
     elif options.genefinding_tool in ['prodigal', 'prodigal-m']:

--- a/antismash/detection/genefinding/test/test_genefinding.py
+++ b/antismash/detection/genefinding/test/test_genefinding.py
@@ -15,6 +15,16 @@ class TestCore(unittest.TestCase):
         options = Namespace()
         options.taxon = 'bacteria'
         options.genefinding_tool = "none"
+        assert not check_options(options)
+
+        options.genefinding_tool = "glimmerhmm"
+        assert check_options(options)
+
+        options.taxon = 'fungi'
+        assert not check_options(options)
+
+        options.genefinding_tool = "prodigal"
+        assert check_options(options)
 
     def test_is_enabled(self):
         options = Namespace()

--- a/antismash/detection/genefunctions/__init__.py
+++ b/antismash/detection/genefunctions/__init__.py
@@ -26,7 +26,7 @@ class AllFunctionResults(module_results.DetectionResults):
 
     def __init__(self, record_id: str) -> None:
         super().__init__(record_id)
-        self._tools = {}  # type: Dict[str, FunctionResults]
+        self._tools: Dict[str, FunctionResults] = {}
 
     def add_tool_results(self, results: FunctionResults) -> None:
         """ Add results for a tool, tool name must be unique and user-friendly """

--- a/antismash/detection/genefunctions/core.py
+++ b/antismash/detection/genefunctions/core.py
@@ -83,7 +83,7 @@ def scan_for_functions(cds_features: List[CDSFeature], database: str,
     hmm_lengths = utils.get_hmm_lengths(database)
     hmm_results = refine_hmmscan_results(results, hmm_lengths)
 
-    best_hits = {}  # type: Dict[str, HMMResult]
+    best_hits: Dict[str, HMMResult] = {}
 
     for cds in cds_features:
         cds_name = cds.get_name()

--- a/antismash/detection/hmm_detection/__init__.py
+++ b/antismash/detection/hmm_detection/__init__.py
@@ -78,7 +78,7 @@ def get_supported_cluster_types(strictness: str) -> List[str]:
     """ Returns a list of all cluster types for which there are rules
     """
     signature_names = {sig.name for sig in get_signature_profiles()}
-    rules = []  # type: List[rule_parser.DetectionRule]
+    rules: List[rule_parser.DetectionRule] = []
     for rule_file in _get_rule_files_for_strictness(strictness):
         with open(rule_file) as rulefile:
             rules = rule_parser.Parser("".join(rulefile.readlines()), signature_names, rules).rules

--- a/antismash/detection/nrps_pks_domains/domain_drawing.py
+++ b/antismash/detection/nrps_pks_domains/domain_drawing.py
@@ -148,7 +148,7 @@ def generate_js_domains(region: Region, record: Record) -> Dict[str, Union[str, 
     """ Creates a JSON-like structure for domains, used by javascript in
         drawing the domains
     """
-    orfs = []  # type: List[JSONOrf]
+    orfs: List[JSONOrf] = []
     for feature in region.cds_children:
         if not feature.nrps_pks:
             continue

--- a/antismash/detection/nrps_pks_domains/domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/domain_identification.py
@@ -28,7 +28,7 @@ class CDSResult:
         self.type = feature_type
         self.modules = modules
         self.ks_subtypes = ks_subtypes
-        self.domain_features = {}  # type: Dict[HMMResult, AntismashDomain]
+        self.domain_features: Dict[HMMResult, AntismashDomain] = {}
         ks_count = sum(dom.hit_id == "PKS_KS" for dom in self.domain_hmms)
         if len(ks_subtypes) != ks_count:
             raise ValueError("mismatching KS subtypes and PKS_KS counts: %d  %d" % (len(ks_subtypes), ks_count))
@@ -371,7 +371,7 @@ def generate_domain_features(gene: CDSFeature, domains: List[HMMResult]) -> Dict
             a dictionary mapping the HMMResult used to the matching AntismashDomain
     """
     new_features = {}
-    domain_counts = defaultdict(int)  # type: Dict[str, int]
+    domain_counts: Dict[str, int] = defaultdict(int)
     for domain in domains:
         loc = gene.get_sub_location_from_protein_coordinates(domain.query_start, domain.query_end)
         prot_loc = FeatureLocation(domain.query_start, domain.query_end)

--- a/antismash/detection/nrps_pks_domains/module_identification.py
+++ b/antismash/detection/nrps_pks_domains/module_identification.py
@@ -109,7 +109,7 @@ CLASSIFICATIONS = {
 
 class IncompatibleComponentError(ValueError):
     """ For better communication when evaluating the addition of a component """
-    pass
+    pass  # pylint: disable=unnecessary-pass
 
 
 class Component:

--- a/antismash/detection/nrps_pks_domains/module_identification.py
+++ b/antismash/detection/nrps_pks_domains/module_identification.py
@@ -194,9 +194,9 @@ class Component:
 
     def to_json(self) -> Dict[str, Any]:
         """ Generate a JSON representation of the component """
-        result = {
+        result: Dict[str, Any] = {
             "domain": self._domain.to_json(),
-        }  # type: Dict[str, Any]
+        }
         if self.subtype:
             result["subtype"] = self.subtype
         return result
@@ -214,13 +214,13 @@ class Module:
         added.
     """
     def __init__(self, first_in_cds: bool = False) -> None:
-        self._components = []  # type: List[Component]
-        self._starter = None  # type: Optional[Component]
-        self._loader = None  # type: Optional[Component]
-        self._modifications = []  # type: List[Component]
-        self._carrier_protein = None  # type: Optional[Component]
-        self._end = None  # type: Optional[Component]
-        self._others = []  # type: List[Component]
+        self._components: List[Component] = []
+        self._starter: Optional[Component] = None
+        self._loader: Optional[Component] = None
+        self._modifications: List[Component] = []
+        self._carrier_protein: Optional[Component] = None
+        self._end: Optional[Component] = None
+        self._others: List[Component] = []
         self._first_in_cds = first_in_cds
 
     def to_json(self) -> Dict[str, Any]:
@@ -385,7 +385,7 @@ class Module:
 
     def get_monomer(self, base: str = "", fallback: bool = False) -> str:  # pylint: disable=too-many-branches
         """ Builds a monomer including modifications from the given base. """
-        state = []  # type: List[str]
+        state: List[str] = []
         if self.is_trans_at() and not base:
             base = "mal"
 

--- a/antismash/detection/nrps_pks_domains/module_identification.py
+++ b/antismash/detection/nrps_pks_domains/module_identification.py
@@ -20,8 +20,7 @@ Non-carbon methylations are represented as either OMe or NMe, Norine mostly uses
 that form but occasionally has MeO.
 """
 
-from typing import Any, Dict, Iterator, List
-from typing import Optional  # comment hints, pylint: disable=unused-import
+from typing import Any, Dict, Iterator, List, Optional
 
 from antismash.common.hmmscan_refinement import HMMResult
 

--- a/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
@@ -169,14 +169,14 @@ class TestKSSubtypeMatching(unittest.TestCase):
     def test_empty(self):
         assert self.func([], []) == []
 
-    def test_non_PKS(self):
+    def test_non_pks(self):
         assert self.func([DummyHMMResult()], []) == []
 
-    def test_PKS_with_hit(self):
+    def test_pks_with_hit(self):
         assert self.func([DummyHMMResult("PKS_KS", start=1, end=40)],
                          [DummyHMMResult("trans-AT", start=1, end=38)]) == ["trans-AT"]
 
-    def test_PKS_with_no_hit(self):
+    def test_pks_with_no_hit(self):
         assert self.func([DummyHMMResult("PKS_KS", start=1, end=40)],
                          [DummyHMMResult("trans-AT", start=41, end=48)]) == [""]
 

--- a/antismash/detection/nrps_pks_domains/test/test_modules.py
+++ b/antismash/detection/nrps_pks_domains/test/test_modules.py
@@ -364,5 +364,6 @@ class TestBuildModules(unittest.TestCase):
             assert modules[0].is_complete()
             assert not modules[1]._first_in_cds
             print(modules[1], modules[1].is_complete())
-            print(modules[1]._starter, modules[1]._loader, modules[1]._carrier_protein, modules[1]._starter is modules[1]._loader)
+            print(modules[1]._starter, modules[1]._loader, modules[1]._carrier_protein,
+                  modules[1]._starter is modules[1]._loader)
             assert not modules[1].is_complete()

--- a/antismash/download_databases.py
+++ b/antismash/download_databases.py
@@ -46,7 +46,7 @@ CHUNK = 128 * 1024
 class DownloadError(RuntimeError):
     """Exception to throw when downloads fail."""
 
-    pass
+    pass  # pylint: disable=unnecessary-pass
 
 
 def get_remote_filesize(url: str) -> int:

--- a/antismash/download_databases.py
+++ b/antismash/download_databases.py
@@ -84,7 +84,7 @@ def download_file(url: str, filename: str) -> str:
         raise DownloadError("ERROR: File not found on server.\nPlease check your internet connection.")
 
     # use 1 because we want to divide by the expected size, can't use 0
-    expected_size = int(req.info().get("Content-Length", "1"))  # type: ignore
+    expected_size = int(req.info().get("Content-Length", "1"))
 
     basename = os.path.basename(filename)
     dirname = os.path.dirname(filename)

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -120,7 +120,7 @@ def verify_options(options: ConfigType, modules: List[AntismashModule]) -> bool:
         Returns:
             True if no problems detected, otherwise False
     """
-    errors = []  # type: List[str]
+    errors: List[str] = []
     for module in modules:
         try:
             logging.debug("Checking options for %s", module.__name__)
@@ -150,7 +150,7 @@ def run_detection(record: Record, options: ConfigType,
         Returns:
             the time taken by each detection module as a dictionary
     """
-    timings = {}  # type: Dict[str, float]
+    timings: Dict[str, float] = {}
 
     # run full genome detections
     for module in [full_hmmer]:
@@ -259,7 +259,7 @@ def analyse_record(record: Record, options: ConfigType, modules: List[AntismashM
         Returns:
             a dictionary mapping module name to time taken
     """
-    timings = {}  # type: Dict[str, float]
+    timings: Dict[str, float] = {}
     # try to run the given modules over the record
     for module in modules:
         run_module(record, module, options, previous_result, timings)
@@ -381,7 +381,7 @@ def add_antismash_comments(records: List[Tuple[Record, SeqRecord]], options: Con
             date=str(datetime.now().strftime("%Y-%m-%d %H:%M:%S")),
         )
     for record, bio_record in records:
-        extras = []  # type: List[str]
+        extras: List[str] = []
         if record.original_id:
             extras.append("Original ID  :: %s\n" % record.original_id)
 
@@ -594,7 +594,7 @@ def log_module_runtimes(timings: Dict[str, Dict[str, float]]) -> None:
         Returns:
             None
     """
-    total_times = defaultdict(lambda: 0.)  # type: Dict[str, float]
+    total_times:Dict[str, float] = defaultdict(lambda: 0.)
     for result in timings.values():
         for module, runtime in result.items():
             total_times[module] += runtime

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -292,10 +292,11 @@ def prepare_output_directory(name: str, input_file: str) -> None:
         if not input_file.endswith(".json") and \
                 list(filter(_ignore_patterns, glob.glob(os.path.join(name, "*")))):
             raise RuntimeError("Output directory contains other files, aborting for safety")
-        else:  # --reuse
-            logging.debug("Removing existing region genbank files")
-            for genbank in glob.glob(os.path.join(name, "*.region???.gbk")):
-                os.remove(genbank)
+
+        # --reuse
+        logging.debug("Removing existing region genbank files")
+        for genbank in glob.glob(os.path.join(name, "*.region???.gbk")):
+            os.remove(genbank)
         logging.debug("Reusing output directory: %s", name)
     else:
         logging.debug("Creating output directory: %s", name)
@@ -650,8 +651,8 @@ def _run_antismash(sequence_file: Optional[str], options: ConfigType) -> int:
             return 1
         print("All prerequisites satisfied")
         return 0
-    else:
-        check_prerequisites(options.all_enabled_modules, options)
+
+    check_prerequisites(options.all_enabled_modules, options)
 
     # start up profiling if relevant
     if options.profile:

--- a/antismash/modules/active_site_finder/analysis.py
+++ b/antismash/modules/active_site_finder/analysis.py
@@ -21,7 +21,7 @@ MultiplePairing = Tuple[secmet.features.Domain, List[str]]  # pylint: disable=in
 
 def run_all_analyses(record: secmet.Record) -> List[MultiplePairing]:
     """ Runs all AFS analyses at once and returns their aggregated results """
-    hits_by_feature = defaultdict(list)  # type: Dict[secmet.features.Domain, List[str]]
+    hits_by_feature: Dict[secmet.features.Domain, List[str]] = defaultdict(list)
     for analysis in [asp_ks, asp_ks_c, asp_at, acp_type, asp_acp, asp_pksi_dh, asp_pksi_kr,
                      asp_thioesterase, pksi_er_stereo, pksi_kr_stereo, pksi_at_spec, asp_p450_oxy]:
         for feature, hit in analysis(record):

--- a/antismash/modules/active_site_finder/analysis.py
+++ b/antismash/modules/active_site_finder/analysis.py
@@ -8,7 +8,7 @@
 """
 
 from collections import defaultdict
-from typing import Dict, List, Tuple  # used in comment hints # pylint: disable=unused-import
+from typing import Dict, List, Tuple
 
 from antismash.common import secmet
 

--- a/antismash/modules/active_site_finder/common.py
+++ b/antismash/modules/active_site_finder/common.py
@@ -51,7 +51,7 @@ class ActiveSiteAnalysis:
             if len(self.emissions) != len(positions):
                 raise ValueError("Number of emissions must match number of positions")
 
-        self.domains_of_interest = []  # type: List[secmet.features.Domain]
+        self.domains_of_interest: List[secmet.features.Domain] = []
         for candidate in candidates:
             if not isinstance(candidate, secmet.features.Domain):
                 raise TypeError("Candidates must be Domains, not %s" % type(candidate))

--- a/antismash/modules/clusterblast/core.py
+++ b/antismash/modules/clusterblast/core.py
@@ -704,8 +704,9 @@ def write_fastas_with_all_genes(regions: Iterable[secmet.Region], filename: str,
     """
     if not isinstance(partitions, int):
         raise TypeError("Partitions must be an int greater than 0")
-    elif partitions < 1:
+    if partitions < 1:
         raise ValueError("Partitions must be greater than 0")
+
     all_names, all_seqs = [], []
     for region in regions:
         names, seqs = create_blast_inputs(region)

--- a/antismash/modules/clusterblast/core.py
+++ b/antismash/modules/clusterblast/core.py
@@ -258,7 +258,7 @@ def remove_duplicate_hits(blast_lines: List[List[str]]) -> List[List[str]]:
         Returns:
             a subset of the input, keeping only the first hit for each pairing
     """
-    query_subject_combinations = set()  # type: Set[Tuple[str, str]]
+    query_subject_combinations: Set[Tuple[str, str]] = set()
     deduplicated = []
     for tabs in blast_lines:
         # if it doesn't even have both values, it's not a hit so skip it
@@ -335,12 +335,12 @@ def parse_all_clusters(blasttext: str, record: secmet.Record, min_seq_coverage: 
                         dictionary of query name to Query instance
     """
     seqlengths = get_cds_lengths(record)
-    queries = OrderedDict()  # type: Dict[str, Query]
-    clusters = OrderedDict()  # type: Dict[str, List[Query]]
+    queries: Dict[str, Query] = OrderedDict()
+    clusters: Dict[str, List[Query]] = OrderedDict()
     blastlines = remove_duplicate_hits([line.split("\t") for line in blasttext.rstrip().splitlines()])
     current_query = None
-    queries_by_cluster_number = {}  # type: Dict[int, Dict[str, Query]]
-    clusters_by_query_cluster_number = {}  # type: Dict[int, Dict[str, List[Query]]]
+    queries_by_cluster_number: Dict[int, Dict[str, Query]] = {}
+    clusters_by_query_cluster_number: Dict[int, Dict[str, List[Query]]] = {}
 
     for tabs in blastlines:
         query = tabs[0]
@@ -400,8 +400,8 @@ def blastparse(blasttext: str, record: secmet.Record, min_seq_coverage: float = 
                     a list of Query instances from that cluster
     """
     seqlengths = get_cds_lengths(record)
-    queries = OrderedDict()  # type: Dict[str, Query]
-    clusters = OrderedDict()  # type: Dict[str, List[Query]]
+    queries: Dict[str, Query] = OrderedDict()
+    clusters: Dict[str, List[Query]] = OrderedDict()
     blastlines = remove_duplicate_hits([line.split("\t") for line in blasttext.rstrip().split("\n")])
     current_query = None
 
@@ -555,7 +555,7 @@ def parse_clusterblast_dict(queries: List[Query], clusters: Dict[str, ReferenceC
                         a core gene
     """
     result = Score()
-    hitpositions = []  # type: List[Tuple[int, int]]
+    hitpositions: List[Tuple[int, int]] = []
     hitposcorelist = []
     cluster_locii = clusters[cluster_label].tags
     for query in queries:
@@ -591,7 +591,7 @@ def find_clusterblast_hitsgroups(hitpositions: List[Tuple[int, int]]) -> Dict[in
             a dictionary mapping each unique Query to
                 a list of Subjects that hit that Query
     """
-    groups = defaultdict(list)  # type: Dict
+    groups: Dict[int, List[int]] = defaultdict(list)
     for query, subject in hitpositions:
         groups[query].append(subject)
     return groups
@@ -616,8 +616,8 @@ def calculate_synteny_score(hitgroups: Dict[int, List[int]],
         Returns:
             a int representing the synteny score
     """
-    scored_queries = set()  # type: Set[int]
-    scored_hits = set()  # type: Set[int]
+    scored_queries: Set[int] = set()
+    scored_hits: Set[int] = set()
     synteny_score = 0
     for i, pos in enumerate(hitpositions[:-1]):
         query, subject = pos
@@ -799,7 +799,7 @@ def check_clusterblast_files(definition_file: str,
         Returns:
             A list of error strings the way `check_prereqs` does
     """
-    failure_messages = []  # type: List[str]
+    failure_messages: List[str] = []
 
     if path.locate_file(definition_file) is None:
         failure_messages.append("Failed to locate cluster definition file: {!r}".format(definition_file))

--- a/antismash/modules/clusterblast/core.py
+++ b/antismash/modules/clusterblast/core.py
@@ -8,7 +8,7 @@ import logging
 import os
 import struct
 from tempfile import NamedTemporaryFile
-from typing import Dict, Iterable, List, Set, Sequence, Tuple  # pylint: disable=unused-import
+from typing import Dict, Iterable, List, Set, Sequence, Tuple
 
 from helperlibs.wrappers.io import TemporaryDirectory
 

--- a/antismash/modules/clusterblast/data_structures.py
+++ b/antismash/modules/clusterblast/data_structures.py
@@ -4,7 +4,7 @@
 """ A collection of data structures shared by the clusterblast variants """
 
 from collections import OrderedDict
-from typing import Dict, List, Tuple, Union  # in comment hints: pylint: disable=unused-import
+from typing import Dict, List, Tuple, Union
 
 
 class ReferenceCluster:

--- a/antismash/modules/clusterblast/data_structures.py
+++ b/antismash/modules/clusterblast/data_structures.py
@@ -107,8 +107,8 @@ class Query:
         self.cluster_number = int(parts[1][1:])  # c1 -> 1
         self.id = parts[4]  # accession
         self.entry = entry
-        self.subjects = OrderedDict()  # type: Dict[str, Subject]
-        self.cluster_name_to_subjects = {}  # type: Dict[str, List[Subject]]
+        self.subjects: Dict[str, Subject] = OrderedDict()
+        self.cluster_name_to_subjects: Dict[str, List[Subject]] = {}
         self.index = index
 
     def add_subject(self, subject: Subject) -> None:
@@ -134,7 +134,7 @@ class Score:
         self.blast_score = 0.
         self.synteny_score = 0
         self.core_bonus = 0
-        self.scored_pairings = []  # type: List[Tuple[Query, Subject]]
+        self.scored_pairings: List[Tuple[Query, Subject]] = []
 
     @property
     def score(self) -> int:

--- a/antismash/modules/clusterblast/results.py
+++ b/antismash/modules/clusterblast/results.py
@@ -173,13 +173,13 @@ class GeneralResults(ModuleResults):
         assert record_id and isinstance(record_id, str)
         assert search_type and isinstance(search_type, str)
         super().__init__(record_id)
-        self.region_results = []  # type: List[RegionResult]
+        self.region_results: List[RegionResult] = []
         self.search_type = search_type
         # keep here instead of duplicating in clusters
         # and only keep those that are relevant instead of 7 million
-        self.proteins_of_interest = OrderedDict()  # type: Dict[str, Protein]
+        self.proteins_of_interest: Dict[str, Protein] = OrderedDict()
         # hold mappings of cluster number -> protein name -> mibig entries
-        self.mibig_entries = {}  # type: Dict[int, Dict[str, List[MibigEntry]]]
+        self.mibig_entries: Dict[int, Dict[str, List[MibigEntry]]] = {}
 
     def add_region_result(self, result: RegionResult, reference_clusters: Dict[str, ReferenceCluster],
                           reference_proteins: Dict[str, Protein]) -> None:
@@ -255,7 +255,7 @@ class GeneralResults(ModuleResults):
             result.region_results.append(RegionResult.from_json(region_result,
                                          record, result.proteins_of_interest))
         if "mibig_entries" in json:
-            entries = {}  # type: Dict[int, Dict[str, List[MibigEntry]]]
+            entries: Dict[int, Dict[str, List[MibigEntry]]] = {}
             for cluster_number, proteins in json["mibig_entries"].items():
                 entries[int(cluster_number)] = {}
                 for protein_name, protein_entries in proteins.items():
@@ -270,10 +270,10 @@ class ClusterBlastResults(ModuleResults):
 
     def __init__(self, record_id: str) -> None:
         super().__init__(record_id)
-        self.general = None  # type: Optional[GeneralResults]
-        self.subcluster = None  # type: Optional[GeneralResults]
-        self.knowncluster = None  # type: Optional[GeneralResults]
-        self.internal_homology_groups = {}  # type: Dict[int, List[List[str]]]
+        self.general: Optional[GeneralResults] = None
+        self.subcluster: Optional[GeneralResults] = None
+        self.knowncluster: Optional[GeneralResults] = None
+        self.internal_homology_groups: Dict[int, List[List[str]]] = {}
 
     def to_json(self) -> Dict[str, Any]:
         assert self.general or self.subcluster or self.knowncluster

--- a/antismash/modules/clusterblast/results.py
+++ b/antismash/modules/clusterblast/results.py
@@ -7,8 +7,7 @@
 from collections import OrderedDict
 import logging
 import os
-from typing import Any, Dict, List, Tuple
-from typing import Optional  # comment hints, pylint: disable=unused-import
+from typing import Any, Dict, List, Optional, Tuple
 
 from antismash.common.module_results import ModuleResults
 from antismash.common.path import changed_directory

--- a/antismash/modules/clusterblast/svg_builder.py
+++ b/antismash/modules/clusterblast/svg_builder.py
@@ -71,7 +71,7 @@ def sort_groups(query_ids: Iterable[T], groups: Set[Tuple[T, ...]]) -> List[Tupl
     """
 
     ordered_groups = []
-    found_groups = set()  # type: Set[int]
+    found_groups: Set[int] = set()
     for query_id in query_ids:
         for group in groups:
             if query_id in group:
@@ -131,7 +131,7 @@ def build_colour_groups(query_cds_features: List[secmet.CDSFeature],
     """
     # start with a set per query gene with only itself
     accessions = [cds.get_name() + " QUERY" for cds in query_cds_features]
-    groups = {accession: set() for accession in accessions}  # type: Dict[str, Set[str]]
+    groups: Dict[str, Set[str]] = {accession: set() for accession in accessions}
     # populate the sets with the id of any hits matching a query gene
     for _, score in ranking:
         for query, subject in score.scored_pairings:
@@ -179,7 +179,7 @@ class Gene:
         self.protein = protein
         self.product = product
         self.label = self._get_label().replace("_", " ")
-        self.pairings = []  # type: List[Tuple[Query, Subject]]
+        self.pairings: List[Tuple[Query, Subject]] = []
         self.reversed = False
 
     def _get_label(self) -> str:
@@ -307,7 +307,7 @@ class Cluster:
         else:
             raise TypeError("No conversion from type %s to Gene" % type(genes[0]))
         self.unique_hit_count = int(hits)
-        self.genes = sorted(genes, key=lambda gene: gene.start)  # type: List[Gene]
+        self.genes: List[Gene] = sorted(genes, key=lambda gene: gene.start)
         self.overall_strand = strand
         self.reversed = False
         self.start = int(self.genes[0].get_start())
@@ -487,7 +487,7 @@ def determine_strand_of_cluster(region: secmet.Region, pairings: List[Tuple[Quer
     for cds in region.cds_children:
         name_to_feature[cds.get_name()] = cds
 
-    counted = set()  # type: Set[str]
+    counted: Set[str] = set()
     strand = 0
     largest_size = 0
     strand_of_largest = 0
@@ -527,7 +527,7 @@ class ClusterSVGBuilder:
         region_number = region.get_region_number()
         cluster_limit = get_config().cb_nclusters
         self.colour_lookup = build_colour_groups(list(region.cds_children), ranking[:cluster_limit])
-        self.hits = []  # type: List[Cluster]
+        self.hits: List[Cluster] = []
         record_prefix = (region.parent_record.original_id or region.parent_record.id).split(".", 1)[0]
         assert record_prefix
         num_added = 0

--- a/antismash/modules/clusterblast/test/test_clusterblast.py
+++ b/antismash/modules/clusterblast/test/test_clusterblast.py
@@ -64,7 +64,7 @@ class TestBlastParsing(unittest.TestCase):
         queries, clusters = core.blastparse(self.sample_data, Record(), 0, 0)
 
         # check we process the right number of queries
-        self.assertEqual(len(queries), len(set([i[0] for i in self.sample_data_as_lists])))
+        self.assertEqual(len(queries), len(set(i[0] for i in self.sample_data_as_lists)))
 
         # check we have entries for every gene_cluster we found
         subjects = [self.parse_subject_wrapper(i) for i in self.sample_data_as_lists]
@@ -117,7 +117,7 @@ class TestBlastParsing(unittest.TestCase):
         queries, clusters = parse_all_wrapper(0, 0)
 
         # check we process the right number of queries
-        self.assertEqual(len(queries), len(set([i[0] for i in self.sample_data_as_lists])))
+        self.assertEqual(len(queries), len(set(i[0] for i in self.sample_data_as_lists)))
 
         # check we have entries for every gene_cluster we found
         subjects = [self.parse_subject_wrapper(i) for i in self.sample_data_as_lists]

--- a/antismash/modules/lanthipeptides/rodeo.py
+++ b/antismash/modules/lanthipeptides/rodeo.py
@@ -32,7 +32,7 @@ def run_rodeo(record: secmet.Record, query: secmet.CDSFeature, leader: str,
     heuristic_score, gathered_tabs_for_csv = acquire_rodeo_heuristics(record, query, leader, core, domains)
     rodeo_score += heuristic_score
 
-    fimo_scores = {}  # type: Dict[int, float]
+    fimo_scores: Dict[int, float] = {}
 
     if not get_global_config().without_fimo and get_lanthi_config().fimo_present:
         # Find motifs
@@ -76,7 +76,7 @@ def acquire_rodeo_heuristics(record: secmet.Record, query: secmet.CDSFeature,
                 the RODEO score, and
                 a list of floats for use in the RODEO SVM
     """
-    tabs = []  # type: List[float]
+    tabs: List[float] = []
     score = 0
     precursor = leader + core
     # Leader peptide contains FxLD motif
@@ -372,7 +372,7 @@ def generate_rodeo_svm_csv(leader: str, core: str, previously_gathered_tabs: Lis
                            fimo_scores: Dict[int, float]) -> List[float]:
     """Generates all the items for one candidate precursor peptide"""
     precursor = leader + core
-    columns = []  # type: List[float]
+    columns: List[float] = []
     # Precursor Index
     columns.append(1)
     # classification

--- a/antismash/modules/lanthipeptides/specific_analysis.py
+++ b/antismash/modules/lanthipeptides/specific_analysis.py
@@ -60,13 +60,13 @@ class LanthiResults(module_results.ModuleResults):
     def __init__(self, record_id: str) -> None:
         super().__init__(record_id)
         # keep new CDS features
-        self.new_cds_features = set()  # type: Set[CDSFeature]
+        self.new_cds_features: Set[CDSFeature] = set()
         # keep new CDSMotifs by the gene they match to
         # e.g. self.motifs_by_locus[gene_locus] = [motif1, motif2..]
-        self.motifs_by_locus = defaultdict(list)  # type: Dict[str, List[Prepeptide]]
+        self.motifs_by_locus: Dict[str, List[Prepeptide]] = defaultdict(list)
         # keep clusters and which genes in them had precursor hits
         # e.g. self.clusters[cluster_number] = {gene1_locus, gene2_locus}
-        self.clusters = defaultdict(set)  # type: Dict[int, Set[str]]
+        self.clusters: Dict[int, Set[str]] = defaultdict(set)
 
     def to_json(self) -> Dict[str, Any]:
         cds_features = [(str(feature.location), feature.get_name()) for feature in self.new_cds_features]
@@ -98,7 +98,7 @@ class LanthiResults(module_results.ModuleResults):
         for feature in self.new_cds_features:
             record.add_cds_feature(feature)
 
-        motifs_added = set()  # type: Set[str]
+        motifs_added: Set[str] = set()
         for motifs in self.motifs_by_locus.values():
             for motif in motifs:
                 if motif.get_name() not in motifs_added:
@@ -122,15 +122,15 @@ class PrepeptideBase:
         self.end = int(end)  # cleavage site position
         self.score = float(score)  # of cleavage site
         self.rodeo_score = int(rodeo_score)
-        self._leader = None  # type: Optional[str]
+        self._leader: Optional[str] = None
         self._core = ''
-        self._tail = None  # type: Optional[str]
+        self._tail: Optional[str] = None
         self._lan_bridges = -1
         self._weight = -1
         self._monoisotopic_weight = -1
-        self._alt_weights = []  # type: List[float]
-        self.core_analysis_monoisotopic = None  # type: Optional[utils.RobustProteinAnalysis]
-        self.core_analysis = None  # type: Optional[utils.RobustProteinAnalysis]
+        self._alt_weights: List[float] = []
+        self.core_analysis_monoisotopic: Optional[utils.RobustProteinAnalysis] = None
+        self.core_analysis: Optional[utils.RobustProteinAnalysis] = None
 
     @property
     def core(self) -> str:
@@ -360,7 +360,7 @@ def get_detected_domains(genes: Iterable[CDSFeature]) -> List[str]:
             a list of strings, each string being the name of a domain in the
             cluster
     """
-    found_domains = []  # type: List[str]
+    found_domains: List[str] = []
     if not genes:
         return found_domains
     # Gather biosynthetic domains
@@ -373,7 +373,7 @@ def get_detected_domains(genes: Iterable[CDSFeature]) -> List[str]:
     cluster_fasta = get_fasta_from_features(genes)
     assert cluster_fasta
     non_biosynthetic_hmms_by_id = run_non_biosynthetic_phmms(cluster_fasta)
-    non_biosynthetic_hmms_found = []  # type: List[str]
+    non_biosynthetic_hmms_found: List[str] = []
     for hsps_found in non_biosynthetic_hmms_by_id.values():
         for hsp in hsps_found:
             if hsp not in non_biosynthetic_hmms_found:
@@ -395,7 +395,7 @@ def run_non_biosynthetic_phmms(fasta: str) -> Dict[str, List[str]]:
     with open(path.get_full_path(__file__, "data", "non_biosyn_hmms", "hmmdetails.txt"), "r") as handle:
         hmmdetails = [line.strip().split("\t") for line in handle if line.count("\t") == 3]
     signature_profiles = [HmmSignature(details[0], details[1], int(details[2]), details[3]) for details in hmmdetails]
-    non_biosynthetic_hmms_by_id = defaultdict(list)  # type: Dict[str, List[str]]
+    non_biosynthetic_hmms_by_id: Dict[str, List[str]] = defaultdict(list)
     for sig in signature_profiles:
         sig.path = path.get_full_path(__file__, "data", "non_biosyn_hmms", sig.path.rpartition(os.sep)[2])
         runresults = subprocessing.run_hmmsearch(sig.path, fasta)

--- a/antismash/modules/lanthipeptides/test/test_specific_analysis.py
+++ b/antismash/modules/lanthipeptides/test/test_specific_analysis.py
@@ -9,9 +9,9 @@ from unittest.mock import patch
 
 from Bio.SeqUtils.ProtParam import ProteinAnalysis
 
-from antismash.common import subprocessing  # used in mocks # pylint: disable=unused-import
+from antismash.common import subprocessing
 from antismash.common.test.helpers import DummyCDS, FakeHit, DummyRecord
-from antismash.modules.lanthipeptides import specific_analysis as lanthi  # mocked # pylint: disable=unused-import
+from antismash.modules.lanthipeptides import specific_analysis as lanthi
 from antismash.modules.lanthipeptides.specific_analysis import (
     Lanthipeptide,
     predict_cleavage_site,

--- a/antismash/modules/lassopeptides/specific_analysis.py
+++ b/antismash/modules/lassopeptides/specific_analysis.py
@@ -197,7 +197,7 @@ class Lassopeptide:
         aas = utils.RobustProteinAnalysis(self.core, monoisotopic=True).count_amino_acids()
         if aas['C'] >= 4:
             return 2
-        elif aas['C'] >= 2:
+        if aas['C'] >= 2:
             return 1
         return 0
 

--- a/antismash/modules/lassopeptides/specific_analysis.py
+++ b/antismash/modules/lassopeptides/specific_analysis.py
@@ -34,13 +34,13 @@ class LassoResults(module_results.ModuleResults):
     def __init__(self, record_id: str) -> None:
         super().__init__(record_id)
         # keep new CDS features
-        self.new_cds_features = set()  # type: Set[CDSFeature]
+        self.new_cds_features: Set[CDSFeature] = set()
         # keep new CDSMotifs by the gene they match to
         # e.g. self.motifs_by_locus[gene_locus] = [motif1, motif2..]
-        self.motifs_by_locus = defaultdict(list)  # type: Dict[str, List[Prepeptide]]
+        self.motifs_by_locus: Dict[str, List[Prepeptide]] = defaultdict(list)
         # keep clusters and which genes in them had precursor hits
         # e.g. self.clusters[cluster_number] = {gene1_locus, gene2_locus}
-        self.clusters = defaultdict(set)  # type: Dict[int, Set[str]]
+        self.clusters: Dict[int, Set[str]] = defaultdict(set)
 
     def to_json(self) -> Dict[str, Any]:
         cds_features = [(str(feature.location),
@@ -285,7 +285,7 @@ def is_on_same_strand_as(cluster: Protocluster, query: CDSFeature, profile_name:
 def acquire_rodeo_heuristics(record: Record, cluster: Protocluster, query: CDSFeature,
                              leader: str, core: str) -> Tuple[int, List[Union[float, int]]]:
     """Calculate heuristic scores for RODEO"""
-    tabs = []  # type: List[Union[float, int]]
+    tabs: List[Union[float, int]] = []
     score = 0
     # Calcd. lasso peptide mass (Da) (with Xs average out)
     core_analysis = utils.RobustProteinAnalysis(core, monoisotopic=True, ignore_invalid=False)
@@ -442,7 +442,7 @@ def generate_rodeo_svm_csv(record: Record, query: CDSFeature, leader: str, core:
                            previously_gathered_tabs: List[Union[float, int]], fimo_motifs: List[int],
                            fimo_scores: Dict[int, float]) -> List[Union[float, int]]:
     """Generates all the items for a single precursor peptide candidate"""
-    columns = []  # type: List[Union[float, int]]
+    columns: List[Union[float, int]] = []
     # Precursor Index
     columns.append(1)
     # classification
@@ -587,8 +587,8 @@ def run_rodeo(record: Record, cluster: Protocluster, query: CDSFeature, leader: 
     heuristic_score, gathered_tabs_for_csv = acquire_rodeo_heuristics(record, cluster, query, leader, core)
     rodeo_score += heuristic_score
 
-    fimo_motifs = []  # type: List[int]
-    fimo_scores = {}  # type: Dict[int, float]
+    fimo_motifs: List[int] = []
+    fimo_scores: Dict[int, float] = {}
     motif_score = 0
 
     if not get_global_config().without_fimo and get_lasso_config().fimo_present:

--- a/antismash/modules/lassopeptides/specific_analysis.py
+++ b/antismash/modules/lassopeptides/specific_analysis.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 import logging
 import re
 import os
-from typing import Any, Dict, List, Optional, Set, Tuple, Union  # pylint: disable=unused-import
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from helperlibs.wrappers.io import TemporaryFile
 import joblib

--- a/antismash/modules/nrps_pks/at_analysis/at_analysis.py
+++ b/antismash/modules/nrps_pks/at_analysis/at_analysis.py
@@ -54,7 +54,7 @@ class ATPrediction(Prediction):
         self.predictions = sorted(predictions.items(), key=lambda x: (-x[1].score, x[1].name))
 
     def get_classification(self) -> List[str]:
-        results = []  # type: List[str]
+        results: List[str] = []
         if not self.predictions:
             return results
         best_score = self.predictions[0][1].score
@@ -114,10 +114,10 @@ def score_signatures(query_signatures: Dict[str, str],
         Returns:
             a dictionary mapping each query identifier to an ATPrediction
     """
-    results = {}  # type: Dict[str, Prediction]
+    results: Dict[str, Prediction] = {}
     for key, query_sig_seq in sorted(query_signatures.items()):
         # keep a single best prediction for each monomer type
-        scores = {}  # type: Dict[str, ATResult]
+        scores: Dict[str, ATResult] = {}
         for sig_name, sig_seq in reference_signatures.items():
             monomer = sig_name.rsplit('_', 1)[-1]
             score = 0.

--- a/antismash/modules/nrps_pks/at_analysis/test/test_at_analysis.py
+++ b/antismash/modules/nrps_pks/at_analysis/test/test_at_analysis.py
@@ -33,7 +33,7 @@ class TestScoring(unittest.TestCase):
         result = at_analysis.score_signatures(query_sigs, ref_sigs)
         assert len(result) == 1
         assert len(result["Q1"].predictions) == 11
-        assert set([res.name for _, res in result["Q1"].predictions]).issubset(set(ref_sigs))
+        assert set(res.name for _, res in result["Q1"].predictions).issubset(set(ref_sigs))
 
 
 class TestATPositions(unittest.TestCase):

--- a/antismash/modules/nrps_pks/html_output.py
+++ b/antismash/modules/nrps_pks/html_output.py
@@ -114,7 +114,7 @@ def get_norine_url_for_specificities(specificities: List[List[str]],
         if be_strict:
             wildcard = ""
         # always be strict to remove X and nrp
-        chunks = [monomer for monomer in filter_norine_as(domain_specificity_list, be_strict=True)]
+        chunks = filter_norine_as(domain_specificity_list, be_strict=True)
         query = (wildcard + separator).join(chunks) + wildcard
         if len(domain_specificity_list) > 1:
             query = "[" + query + "]"

--- a/antismash/modules/nrps_pks/html_output.py
+++ b/antismash/modules/nrps_pks/html_output.py
@@ -29,7 +29,7 @@ def generate_html(region_layer: RegionLayer, results: NRPS_PKS_Results,
 
     nrps_layer = NrpspksLayer(results, region_layer.region_feature, record_layer)
 
-    features_with_domain_predictions = {}  # type: Dict[str, List[str]]
+    features_with_domain_predictions: Dict[str, List[str]] = {}
     for domain_name, consensus in results.consensus.items():
         if not consensus:
             continue
@@ -183,15 +183,15 @@ class NrpspksLayer(RegionLayer):
         domains and structures.
     """
     def __init__(self, results: NRPS_PKS_Results, region_feature: Region, record: RecordLayer) -> None:
-        self.url_strict = {}  # type: Dict[str, str]  # gene name -> url
-        self.url_relaxed = {}  # type: Dict[str, str]  # gene name -> url
+        self.url_strict: Dict[str, str] = {}  # gene name -> url
+        self.url_relaxed: Dict[str, str] = {}  # gene name -> url
         self._build_urls(region_feature.cds_children)
         super().__init__(record, region_feature)
         assert isinstance(results, NRPS_PKS_Results), type(results)
         self.results = results
 
         region_number = region_feature.get_region_number()
-        self.candidate_clusters = []  # type: List[CandidateClusterLayer]
+        self.candidate_clusters: List[CandidateClusterLayer] = []
         for candidate_cluster_pred in results.region_predictions.get(region_number, []):
             candidate_cluster = record.get_candidate_cluster(candidate_cluster_pred.candidate_cluster_number)
             self.candidate_clusters.append(CandidateClusterLayer(candidate_cluster, candidate_cluster_pred))

--- a/antismash/modules/nrps_pks/html_output.py
+++ b/antismash/modules/nrps_pks/html_output.py
@@ -5,8 +5,7 @@
 
 import logging
 import re
-from typing import Any, Iterable, List, Optional
-from typing import Dict  # in comment type hints  # pylint: disable=unused-import
+from typing import Any, Dict, Iterable, List, Optional
 
 from antismash.common import path
 from antismash.common.html_renderer import HTMLSections, FileTemplate

--- a/antismash/modules/nrps_pks/kr_analysis/kr_analysis.py
+++ b/antismash/modules/nrps_pks/kr_analysis/kr_analysis.py
@@ -74,7 +74,7 @@ def run_kr_analysis(queries: Dict[str, str]) -> Tuple[Dict[str, Prediction], Dic
         stereochem_signatures.append(utils.extract_by_reference_positions(muscle_dict[name], refseq, positions_ste))
 
     # Check activity
-    activity = {}  # type: Dict[str, Prediction]
+    activity: Dict[str, Prediction] = {}
     for name, signature in zip(querysignames, activity_signatures):
         if is_active(signature):
             activity[name] = SimplePrediction("kr_activity", "active")
@@ -82,7 +82,7 @@ def run_kr_analysis(queries: Dict[str, str]) -> Tuple[Dict[str, Prediction], Dic
             activity[name] = SimplePrediction("kr_activity", "inactive")
 
     # Predict stereochemistry
-    stereochemistry = {}  # type: Dict[str, Prediction]
+    stereochemistry: Dict[str, Prediction] = {}
     for name, signature in zip(querysignames, stereochem_signatures):
         chem = predict_stereochemistry(signature)
         if chem:

--- a/antismash/modules/nrps_pks/minowa/base.py
+++ b/antismash/modules/nrps_pks/minowa/base.py
@@ -98,7 +98,7 @@ def run_minowa(sequence_info: Dict[str, str], startpos: int, muscle_ref: str, re
     """
     positions = get_positions(positions_file, startpos)
 
-    results_by_query = {}  # type: Dict[str, Prediction]
+    results_by_query: Dict[str, Prediction] = {}
 
     for query_id, query_seq in sequence_info.items():
         muscle = subprocessing.run_muscle_single(query_id, query_seq, muscle_ref)

--- a/antismash/modules/nrps_pks/nrps_predictor.py
+++ b/antismash/modules/nrps_pks/nrps_predictor.py
@@ -33,7 +33,7 @@ def _build_stach_codes() -> Dict[str, Set[str]]:
         data for use in checking how good a hit it really is
     """
     data_file = path.get_full_path(__file__, "external/NRPSPredictor2/data/labeled_sigs")
-    results = defaultdict(set)  # type: Dict[str, Set[str]]
+    results: Dict[str, Set[str]] = defaultdict(set)
     with open(data_file) as handle:
         for line in handle:
             # in the form: prediction angstrom_code stach_code
@@ -75,7 +75,7 @@ class PredictorSVMResult(Prediction):
         #     9      &            &              <
         #     8      ^            &              <
         #  <= 7      ^            ^              .
-        classification = []  # type: List[str]
+        classification: List[str] = []
 
         if self.uncertain:
             if self.stachelhaus_match_count >= 8:
@@ -311,7 +311,7 @@ def read_output(lines: List[str]) -> Dict[str, Prediction]:
         Returns:
             a dictionary mapping each domain name to a PredictorSVMResult
     """
-    results = {}  # type: Dict[str, Prediction]
+    results: Dict[str, Prediction] = {}
     for line in lines:
         results[line.split('\t')[0]] = PredictorSVMResult.from_line(line)
     return results

--- a/antismash/modules/nrps_pks/orderfinder.py
+++ b/antismash/modules/nrps_pks/orderfinder.py
@@ -138,7 +138,7 @@ def generate_substrates_order(geneorder: List[CDSFeature], consensus_predictions
             components.append((substrate, monomer, [domain.domain or "" for domain in module.domains]))
 
         if monomers:
-            monomers_by_cds.append("(%s)" % (" - ".join([monomer for monomer in monomers])))
+            monomers_by_cds.append("(%s)" % (" - ".join(monomers)))
 
     polymer = " + ".join(monomers_by_cds)
     smiles = gen_smiles_from_pksnrps(components)
@@ -267,7 +267,7 @@ def find_possible_orders(cds_features: List[CDSFeature], start_cds: Optional[CDS
         assert start_cds != end_cds, "Using same gene for start and end of ordering"
     cds_to_order = []
     for cds in cds_features:
-        if cds == start_cds or cds == end_cds:
+        if cds in (start_cds, end_cds):
             pass
         else:
             cds_to_order.append(cds)

--- a/antismash/modules/nrps_pks/orderfinder.py
+++ b/antismash/modules/nrps_pks/orderfinder.py
@@ -33,7 +33,7 @@ def analyse_biosynthetic_order(nrps_pks_features: List[CDSFeature],
                     prediction string
                     and whether docking domain analysis was used for the prediction
     """
-    compound_predictions = []  # type: List[CandidateClusterPrediction]
+    compound_predictions: List[CandidateClusterPrediction] = []
     # Find NRPS/PKS gene candidate_clusters
     candidate_clusters = [cluster for cluster in record.get_candidate_clusters()
                              if will_handle(cluster.products)]
@@ -231,7 +231,7 @@ def extract_cterminus(data_dir: str, cds_features: List[CDSFeature], end_cds: Op
             A dictionary mapping gene name to the pair of residues extracted
     """
     c_terminal_residues = {}
-    c_terminals = {}  # type: Dict[str, str]
+    c_terminals: Dict[str, str] = {}
     cterm_file = os.path.join(data_dir, 'cterm.fasta')
     for cds in cds_features:
         if cds is not end_cds:
@@ -272,10 +272,10 @@ def find_possible_orders(cds_features: List[CDSFeature], start_cds: Optional[CDS
         else:
             cds_to_order.append(cds)
     possible_orders = []
-    start = []  # type: List[CDSFeature]
+    start: List[CDSFeature] = []
     if start_cds:
         start = [start_cds]
-    end = []  # type: List[CDSFeature]
+    end: List[CDSFeature] = []
     if end_cds:
         end = [end_cds]
     for order in itertools.permutations(cds_to_order, len(cds_to_order)):

--- a/antismash/modules/nrps_pks/parsers.py
+++ b/antismash/modules/nrps_pks/parsers.py
@@ -64,7 +64,7 @@ def generate_nrps_consensus(results: Dict[str, Prediction]) -> str:
             the most frequent prediction
     """
     assert isinstance(results, dict), type(results)
-    hit_counts = defaultdict(int)  # type: Dict[str, int]
+    hit_counts: Dict[str, int] = defaultdict(int)
     for method, prediction in results.items():
         assert isinstance(method, str), method
         assert isinstance(prediction, Prediction), prediction
@@ -100,8 +100,8 @@ def calculate_consensus_prediction(cds_features: List[CDSFeature], results: Dict
                 the second for AT domains in trans-AT clusters
     """
     # Combine substrate specificity predictions into consensus prediction
-    cis_at = {}  # type: Dict[str, str]  # feature name -> prediction
-    trans_at = {}  # type: Dict[str, str]  # feature name -> prediction
+    cis_at: Dict[str, str] = {}  # feature name -> prediction
+    trans_at: Dict[str, str] = {}  # feature name -> prediction
 
     for cds in cds_features:
         assert cds.region, "Orphaned CDS found: %s" % cds
@@ -110,7 +110,7 @@ def calculate_consensus_prediction(cds_features: List[CDSFeature], results: Dict
             if 'OTHER' in domain.label:
                 continue
             if domain.name == "PKS_AT":
-                preds = []  # type: List[str]
+                preds: List[str] = []
                 preds.extend(map(get_short_form, predictions["minowa_at"].get_classification()))
                 preds.extend(map(get_short_form, predictions["signature"].get_classification()))
                 consensus = calculate_individual_consensus(preds)

--- a/antismash/modules/nrps_pks/results.py
+++ b/antismash/modules/nrps_pks/results.py
@@ -69,7 +69,7 @@ def modify_substrate(module: Module, base: str = "") -> str:  # pylint: disable=
             conversions = {"ccmal": "redmal", "ccmmal": "redmmal", "ccmxmal": "redmxmal", "ccemal": "redemal"}
             base = conversions.get(base, base)
 
-    state = []  # type: List[str]
+    state: List[str] = []
     for domain in module.domains:
         if domain.domain != "MT":
             continue
@@ -127,10 +127,10 @@ class NRPS_PKS_Results(ModuleResults):
     def __init__(self, record_id: str) -> None:
         super().__init__(record_id)
         # keep a mapping of domain name -> method -> Prediction
-        self.domain_predictions = defaultdict(dict)  # type: Dict[str, Dict[str, Prediction]]
-        self.consensus = {}  # type: Dict[str, str]  # domain name -> consensus
-        self.region_predictions = defaultdict(list)  # type: Dict[int, List[CandidateClusterPrediction]]
-        self.consensus_transat = {}  # type: Dict[str, str]
+        self.domain_predictions: Dict[str, Dict[str, Prediction]] = defaultdict(dict)
+        self.consensus: Dict[str, str] = {}  # domain name -> consensus
+        self.region_predictions: Dict[int, List[CandidateClusterPrediction]] = defaultdict(list)
+        self.consensus_transat: Dict[str, str] = {}
 
     def add_method_results(self, method: str, results: Dict[str, Prediction]) -> None:
         """ Add per-domain results for a single prediction method
@@ -146,7 +146,7 @@ class NRPS_PKS_Results(ModuleResults):
             self.domain_predictions[domain_name][method] = prediction
 
     def to_json(self) -> Dict[str, Any]:
-        domain_predictions = defaultdict(dict)  # type: Dict[str, Dict[str, Any]]
+        domain_predictions: Dict[str, Dict[str, Any]] = defaultdict(dict)
         for domain, predictions in self.domain_predictions.items():
             domain_predictions[domain] = {method: val.to_json() for method, val in predictions.items()}
         region_json = {}
@@ -172,7 +172,7 @@ class NRPS_PKS_Results(ModuleResults):
         for domain_name, method_predictions in predictions.items():
             for method, prediction in method_predictions.items():
                 if method == "NRPSPredictor2":
-                    rebuilt = PredictorSVMResult.from_json(prediction)  # type: Prediction
+                    rebuilt: Prediction = PredictorSVMResult.from_json(prediction)
                 elif method.startswith("minowa"):
                     rebuilt = MinowaPrediction.from_json(prediction)
                 elif method == "signature":

--- a/antismash/modules/nrps_pks/results.py
+++ b/antismash/modules/nrps_pks/results.py
@@ -5,8 +5,7 @@
 
 from collections import defaultdict
 import logging
-from typing import Any, Dict, Optional
-from typing import List  # comment hint, pylint: disable=unused-import
+from typing import Any, Dict, List, Optional
 
 from antismash.common.module_results import ModuleResults
 from antismash.common.secmet import AntismashDomain, Module, Record

--- a/antismash/modules/nrps_pks/smiles_generator.py
+++ b/antismash/modules/nrps_pks/smiles_generator.py
@@ -20,7 +20,7 @@ _STARTING_BONDS = {
 
 def load_smiles() -> Dict[str, str]:
     """Load smiles from a dictionary mapping residues to SMILES string"""
-    aa_smiles = {}  # type: Dict[str, str]
+    aa_smiles: Dict[str, str] = {}
 
     smiles_monomer = open(path.get_full_path(__file__, 'data', 'aaSMILES.txt'), 'r')
 
@@ -55,9 +55,9 @@ class Atom:
         self.bonds_to_left = bonds_to_left
         self.bonds_to_right = 0
         self.identifier = identifier
-        self.branches = []  # type: List[List[Atom]]
-        self.references_out = []  # type: List[str]
-        self.references_in = []  # type: List[Atom]
+        self.branches: List[List[Atom]] = []
+        self.references_out: List[str] = []
+        self.references_in: List[Atom] = []
 
     @property
     def available_bonds(self) -> int:
@@ -111,15 +111,15 @@ class Bonds:
             smiles: the smiles string to build from
     """
     def __init__(self, smiles: str) -> None:
-        self._atoms_by_identifier = {}  # type: Dict[str, Atom]
-        self._top_level_atoms = self._parse_smiles(smiles)  # type: List[Atom]
+        self._atoms_by_identifier: Dict[str, Atom] = {}
+        self._top_level_atoms: List[Atom] = self._parse_smiles(smiles)
 
     def _parse_smiles(self, smiles: str) -> List[Atom]:
         """ Parse a SMILES string into a list of Atom instances """
 
         def chain(smiles: str) -> Tuple[List[Atom], str]:
             """ Recursively parse branches in SMILES and return found Atoms and leftover SMILES """
-            atoms = []  # type: List[Atom]
+            atoms: List[Atom] = []
             while smiles:
                 symbol = smiles[0]
                 smiles = smiles[1:]

--- a/antismash/modules/nrps_pks/specific_analysis.py
+++ b/antismash/modules/nrps_pks/specific_analysis.py
@@ -56,7 +56,8 @@ def specific_analysis(record: Record, results: NRPS_PKS_Results, options: Config
     pks_results = run_pks_substr_spec_predictions(nrps_pks_genes)
     for method, method_results in pks_results.items():
         results.add_method_results(method, method_results)
-    results.consensus, results.consensus_transat = calculate_consensus_prediction(nrps_pks_genes, results.domain_predictions)
+    consensus_pair = calculate_consensus_prediction(nrps_pks_genes, results.domain_predictions)
+    results.consensus, results.consensus_transat = consensus_pair
 
     candidate_cluster_predictions = analyse_biosynthetic_order(nrps_pks_genes, results.consensus, record)
     for prediction in candidate_cluster_predictions:

--- a/antismash/modules/nrps_pks/substrates.py
+++ b/antismash/modules/nrps_pks/substrates.py
@@ -31,7 +31,7 @@ def run_pks_substr_spec_predictions(cds_features: List[CDSFeature]) -> Dict[str,
                     AntismashDomain name to Prediction
     """
     at_domains = extract_at_domains(cds_features)
-    method_results = {}  # type: Dict[str, Dict[str, Prediction]]
+    method_results: Dict[str, Dict[str, Prediction]] = {}
     if at_domains:
         signature_results, minowa_at_results = run_minowa_predictor_pks_at(at_domains)
         method_results["signature"] = signature_results

--- a/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
+++ b/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
@@ -60,7 +60,7 @@ class IntegrationNRPSPKS(unittest.TestCase):
                 continue
             nrpspred2_results[domain] = methods["NRPSPredictor2"].get_classification()
         expected_preds = [["leu"], ["bht"], ["asn"], ["hpg"], ["hpg"], ["bht"], ["dhpg"], ["tyr"], ["pk"]]
-        expected_nrps2 = {name: pred for name, pred in zip(nrps_names, expected_preds)}
+        expected_nrps2 = dict(zip(nrps_names, expected_preds))
         assert nrpspred2_results == expected_nrps2
 
         cal = results.domain_predictions["nrpspksdomains_pks_CAL_domain.1"]["minowa_cal"]

--- a/antismash/modules/pfam2go/pfam2go.py
+++ b/antismash/modules/pfam2go/pfam2go.py
@@ -79,7 +79,7 @@ class Pfam2GoResults(ModuleResults):
 
     def to_json(self) -> Dict[str, Any]:
         """ Construct a JSON representation of this instance """
-        pfam_ontologies = {}  # type: Dict[str, Dict[str, str]]
+        pfam_ontologies: Dict[str, Dict[str, str]] = {}
         json_out = {"pfams": pfam_ontologies,
                     "record_id": self.record_id,
                     "schema_version": Pfam2GoResults.schema_version}
@@ -103,7 +103,7 @@ class Pfam2GoResults(ModuleResults):
         if json["schema_version"] != Pfam2GoResults.schema_version:
             logging.warning("Schema version mismatch, discarding Pfam2GO results")
             return None
-        all_pfam_ids_to_ontologies = defaultdict(list)  # type: Dict[PFAMDomain, List[GeneOntologies]]
+        all_pfam_ids_to_ontologies: Dict[PFAMDomain, List[GeneOntologies]] = defaultdict(list)
         for domain in record.get_pfam_domains():
             id_without_version = domain.identifier
             if id_without_version in json["pfams"]:
@@ -128,7 +128,7 @@ def construct_mapping(mapfile: str) -> Dict[str, GeneOntologies]:
         terms matched to this ID.
     """
     results = {}
-    gene_ontology_per_pfam = defaultdict(list)  # type: Dict[str, List[GeneOntology]]
+    gene_ontology_per_pfam: Dict[str, List[GeneOntology]] = defaultdict(list)
     with open(path.get_full_path(__file__, mapfile), 'r') as pfam_map:
         for line in pfam_map:
             if line.startswith('!'):
@@ -156,7 +156,7 @@ def get_gos_for_pfams(record: Record) -> Dict[PFAMDomain, List[GeneOntologies]]:
     Returns:
         A dictionary mapping a specific PFAMDomain instance to a list of GeneOntologies within the PFAMDomain.
     """
-    pfam_domains_with_gos = defaultdict(list)  # type: Dict[PFAMDomain, List[GeneOntologies]]
+    pfam_domains_with_gos: Dict[PFAMDomain, List[GeneOntologies]] = defaultdict(list)
     pfams = record.get_pfam_domains()
     full_gomap_as_ontologies = construct_mapping(DATA_FILE)
     if not pfams:

--- a/antismash/modules/pfam2go/test/test_pfam2go.py
+++ b/antismash/modules/pfam2go/test/test_pfam2go.py
@@ -4,7 +4,6 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=no-self-use,protected-access,missing-docstring
 
-import os
 import unittest
 
 from typing import Dict
@@ -13,7 +12,6 @@ from Bio.Alphabet import generic_dna
 from Bio.Seq import Seq
 from Bio.SeqFeature import FeatureLocation
 
-from antismash.common import path
 from antismash.common.secmet.record import Record
 from antismash.common.test.helpers import DummyRecord, DummyPFAMDomain
 from antismash.modules.pfam2go import pfam2go

--- a/antismash/modules/sactipeptides/html_output.py
+++ b/antismash/modules/sactipeptides/html_output.py
@@ -4,13 +4,11 @@
 """ Handles HTML output for sactipeptides """
 
 from collections import defaultdict
-from typing import List
-from typing import Dict  # comment hint, pylint: disable=unused-import
+from typing import Dict, List
 
 from antismash.common import path
 from antismash.common.html_renderer import HTMLSections, FileTemplate
-from antismash.common.secmet import Prepeptide, Region
-from antismash.common.secmet import CDSMotif # comment hint, pylint: disable=unused-import
+from antismash.common.secmet import CDSMotif, Prepeptide, Region
 from antismash.common.layers import RegionLayer, RecordLayer, OptionsLayer
 
 from .specific_analysis import SactiResults

--- a/antismash/modules/sactipeptides/html_output.py
+++ b/antismash/modules/sactipeptides/html_output.py
@@ -24,7 +24,7 @@ def generate_html(region_layer: RegionLayer, results: SactiResults,
     """ Generates HTML for the module """
     html = HTMLSections("sactipeptides")
 
-    motifs_in_region = defaultdict(list)  # type: Dict[str, List[CDSMotif]]
+    motifs_in_region: Dict[str, List[CDSMotif]] = defaultdict(list)
     for locus, motifs in results.motifs_by_locus.items():
         for motif in motifs:
             if motif.is_contained_by(region_layer.region_feature):
@@ -59,7 +59,7 @@ class SactipeptideLayer(RegionLayer):
     """ An extended RegionLayer for holding a list of LanthipeptideMotifs """
     def __init__(self, record: RecordLayer, region_feature: Region) -> None:
         RegionLayer.__init__(self, record, region_feature)
-        self.motifs = []  # type: List[Prepeptide]
+        self.motifs: List[Prepeptide] = []
         for motif in self.record.seq_record.get_cds_motifs():
             if not isinstance(motif, Prepeptide):
                 continue

--- a/antismash/modules/sactipeptides/specific_analysis.py
+++ b/antismash/modules/sactipeptides/specific_analysis.py
@@ -35,13 +35,13 @@ class SactiResults(module_results.ModuleResults):
     def __init__(self, record_id: str) -> None:
         super().__init__(record_id)
         # keep new CDS features
-        self.new_cds_features = set()  # type: Set[secmet.CDSFeature]
+        self.new_cds_features: Set[secmet.CDSFeature] = set()
         # keep new CDSMotifs by the gene they match to
         # e.g. self.motifs_by_locus[gene_locus] = [motif1, motif2..]
-        self.motifs_by_locus = defaultdict(list)  # type: Dict[str, List[secmet.Prepeptide]]
+        self.motifs_by_locus: Dict[str, List[secmet.Prepeptide]] = defaultdict(list)
         # keep clusters and which genes in them had precursor hits
         # e.g. self.clusters[cluster_number] = {gene1_locus, gene2_locus}
-        self.clusters = defaultdict(set)  # type: Dict[int, Set[str]]
+        self.clusters: Dict[int, Set[str]] = defaultdict(set)
 
     def to_json(self) -> Dict[str, Any]:
         cds_features = [(str(feature.location),
@@ -90,7 +90,7 @@ def get_detected_domains(cluster: secmet.Protocluster) -> Dict[str, int]:
         Returns:
             a dictionary mapping domain ids to number of times that domain was found
     """
-    found_domains = {}  # type: Dict[str, int]
+    found_domains: Dict[str, int] = {}
     # Gather biosynthetic domains
     for feature in cluster.cds_children:
         if not feature.sec_met:
@@ -115,7 +115,7 @@ def run_non_biosynthetic_phmms(cluster_fasta: str) -> Dict[str, List[HSP]]:
         hmmdetails = [line.split("\t") for line in handle.read().splitlines() if line.count("\t") == 3]
     signature_profiles = [HmmSignature(details[0], details[1], int(details[2]), details[3]) for details in hmmdetails]
 
-    non_biosynthetic_hmms_by_id = defaultdict(list)  # type: Dict[str, Any]
+    non_biosynthetic_hmms_by_id: Dict[str, Any] = defaultdict(list)
     for sig in signature_profiles:
         sig.path = path.get_full_path(__file__, "data", "non_biosyn_hmms", sig.path)
         runresults = subprocessing.run_hmmsearch(sig.path, cluster_fasta)
@@ -408,7 +408,7 @@ def structure_analysis(seq: str) -> Tuple[int, float, float, List[int]]:
 def generate_rodeo_svm_csv(leader: str, core: str, previously_gathered_tabs: List[Union[float, int]],
                            hitends: List[int], domain_counts: Dict[str, int]) -> List[float]:
     """Generates all the items for one candidate precursor peptide"""
-    columns = []  # type: List[float]
+    columns: List[float] = []
     precursor = leader + core
     # Precursor Index
     columns.append(1)
@@ -555,7 +555,7 @@ def annotate_orfs(cds_features: List[secmet.CDSFeature], hmm_results: Dict[str, 
         the cluster detection stage of antiSMASH.
     """
 
-    domains_by_feature = defaultdict(list)  # type: Dict[str, List[SecMetQualifier.Domain]]
+    domains_by_feature: Dict[str, List[SecMetQualifier.Domain]] = defaultdict(list)
     for hit_id, results in hmm_results.items():
         for result in results:
             domain = SecMetQualifier.Domain(result.query_id, result.evalue, result.bitscore, 0, "sactipeptides")

--- a/antismash/modules/smcog_trees/trees.py
+++ b/antismash/modules/smcog_trees/trees.py
@@ -28,7 +28,7 @@ logging.getLogger('matplotlib').setLevel(logging.WARNING)
 def generate_trees(smcogs_dir: str, genes_within_clusters: List[CDSFeature],
                    nrpspks_genes: List[CDSFeature]) -> Dict[str, str]:
     """ smCOG phylogenetic tree construction """
-    pks_nrps_cds_names = set([feature.get_name() for feature in nrpspks_genes])
+    pks_nrps_cds_names = set(feature.get_name() for feature in nrpspks_genes)
     logging.info("Calculating and drawing phylogenetic trees of cluster genes "
                  "with smCOG members")
     cds_features = []

--- a/antismash/modules/smcog_trees/trees.py
+++ b/antismash/modules/smcog_trees/trees.py
@@ -11,7 +11,7 @@ from io import StringIO
 import glob
 import logging
 import os
-from typing import Dict, List  # List used in comment type hints, pylint: disable=unused-import
+from typing import Dict, List
 
 from Bio import Phylo
 from Bio.Phylo.NewickIO import NewickError

--- a/antismash/modules/smcog_trees/trees.py
+++ b/antismash/modules/smcog_trees/trees.py
@@ -110,7 +110,7 @@ def trim_alignment(input_number: int, alignment_file: str) -> None:
     seqs = list(contents.values())
 
     # store conservation of residues
-    conservations = [defaultdict(lambda: 0) for i in range(sequence_length)]  # type: List[Dict[str, int]]
+    conservations: List[Dict[str, int]] = [defaultdict(lambda: 0) for i in range(sequence_length)]
     for seq in seqs:
         for position, base in enumerate(seq):
             conservations[position][base] += 1

--- a/antismash/modules/t2pks/results.py
+++ b/antismash/modules/t2pks/results.py
@@ -5,7 +5,7 @@
 
 import logging
 from typing import Any, Dict, List, Optional, Union
-from typing import Set, Tuple  # used in comment type hints, pylint: disable=unused-import
+from typing import Set, Tuple
 
 from antismash.common.module_results import ModuleResults
 from antismash.common.secmet import Record, GeneFunction

--- a/antismash/modules/t2pks/results.py
+++ b/antismash/modules/t2pks/results.py
@@ -147,7 +147,7 @@ class T2PKSResults(ModuleResults):
 
     def __init__(self, record_id: str) -> None:
         super().__init__(record_id)
-        self.cluster_predictions = {}  # type: Dict[int, ProtoclusterPrediction]
+        self.cluster_predictions: Dict[int, ProtoclusterPrediction] = {}
 
     def __repr__(self) -> str:
         return "T2PKSResults(clusters=%s)" % list(self.cluster_predictions)

--- a/antismash/modules/t2pks/t2pks_analysis.py
+++ b/antismash/modules/t2pks/t2pks_analysis.py
@@ -140,7 +140,7 @@ def sum_predictions(predictions: List[CDSPrediction]) -> List[Prediction]:
     """
     if not predictions:
         return []
-    summed_preds = {}  # type: Dict[str, Prediction]
+    summed_preds: Dict[str, Prediction] = {}
     for pred in predictions:
         if pred.pfunc is None:
             continue
@@ -257,8 +257,8 @@ def make_cds_predictions(cds_hmm_hits: Dict[str, List[HMMResult]],
                     that protein type
     """
 
-    preds_by_cds = defaultdict(list)  # type: Dict[str, List[CDSPrediction]]
-    preds_by_protein = defaultdict(list)  # type: Dict[str, List[CDSPrediction]]
+    preds_by_cds: Dict[str, List[CDSPrediction]] = defaultdict(list)
+    preds_by_protein: Dict[str, List[CDSPrediction]] = defaultdict(list)
 
     for cds_name, hmm_hits in cds_hmm_hits.items():
         # combine blast and hmmscan results

--- a/antismash/modules/t2pks/test/integration_t2pks.py
+++ b/antismash/modules/t2pks/test/integration_t2pks.py
@@ -39,7 +39,8 @@ class T2PKSTest(unittest.TestCase):
         pred = results.cluster_predictions[1]
         assert pred.starter_units == [t2pks.results.Prediction('malonamyl-CoA', 2319., 0.)]
         assert pred.malonyl_elongations == [t2pks.results.Prediction('8|9', 661.0, 1.3e-201)]
-        assert pred.product_classes == {'angucycline', 'tetracycline', 'aureolic acid', 'anthracycline', 'tetracenomycin'}
+        assert pred.product_classes == {'angucycline', 'tetracycline', 'aureolic acid',
+                                        'anthracycline', 'tetracenomycin'}
         assert set(pred.molecular_weights) == {'malonamyl-CoA_8', 'malonamyl-CoA_9'}
         self.assertAlmostEqual(pred.molecular_weights['malonamyl-CoA_8'], 654.63434)
         self.assertAlmostEqual(pred.molecular_weights['malonamyl-CoA_9'], 696.67102)

--- a/antismash/modules/thiopeptides/html_output.py
+++ b/antismash/modules/thiopeptides/html_output.py
@@ -22,7 +22,7 @@ class ThiopeptideLayer(RegionLayer):
     """ A wrapper of RegionLayer to allow for tracking the ThiopeptideMotifs """
     def __init__(self, record: RecordLayer, results: ThioResults, region_feature: Region) -> None:
         RegionLayer.__init__(self, record, region_feature)
-        self.motifs = []  # type: List[Prepeptide]
+        self.motifs: List[Prepeptide] = []
         for motif in results.motifs:
             if motif.is_contained_by(self.region_feature) and isinstance(motif, Prepeptide):
                 self.motifs.append(motif)

--- a/antismash/modules/thiopeptides/rodeo.py
+++ b/antismash/modules/thiopeptides/rodeo.py
@@ -5,7 +5,7 @@
 
 import os
 import re
-from typing import List, Set, Tuple, Optional  # pylint: disable=unused-import
+from typing import List, Set, Tuple, Optional
 
 import joblib
 

--- a/antismash/modules/thiopeptides/rodeo.py
+++ b/antismash/modules/thiopeptides/rodeo.py
@@ -15,7 +15,7 @@ from antismash.common import path, utils
 def acquire_rodeo_heuristics(leader: str, core: str,  # pylint: disable=too-many-branches,too-many-statements
                              domains: Set[str]) -> Tuple[int, List[float]]:
     """ Calculate heuristic scores for RODEO """
-    tabs = []  # type: List[float]
+    tabs: List[float] = []
     score = 0
     # Contains TOMM YcaO (PF02624)
     if "YcaO" in domains:
@@ -143,7 +143,7 @@ def acquire_rodeo_heuristics(leader: str, core: str,  # pylint: disable=too-many
 def generate_rodeo_svm_csv(leader: str, core: str, previously_gathered_tabs: List[float]) -> List[float]:
     """Generates all the items for one candidate precursor peptide"""
     precursor = leader + core
-    columns = []  # type: List[float]
+    columns: List[float] = []
     # Precursor Index
     columns.append(1)
     # classification
@@ -257,12 +257,12 @@ class ThioStatistics:
         using lazy evaluation to only calculate when required."""
     def __init__(self, core: str) -> None:
         self._core = core
-        self._c_repeats = None  # type: Optional[int]
-        self._s_repeats = None  # type: Optional[int]
-        self._t_repeats = None  # type: Optional[int]
-        self._block_repeats = None  # type: Optional[int]
-        self._heteroblocks = None  # type: Optional[int]
-        self._average_heteroblock_length = None  # type: Optional[float]
+        self._c_repeats: Optional[int] = None
+        self._s_repeats: Optional[int] = None
+        self._t_repeats: Optional[int] = None
+        self._block_repeats: Optional[int] = None
+        self._heteroblocks: Optional[int] = None
+        self._average_heteroblock_length: Optional[float] = None
 
     @property
     def c_repeats(self) -> int:

--- a/antismash/modules/thiopeptides/specific_analysis.py
+++ b/antismash/modules/thiopeptides/specific_analysis.py
@@ -26,11 +26,11 @@ class ThioResults(module_results.ModuleResults):
 
     def __init__(self, record_id: str) -> None:
         super().__init__(record_id)
-        self.clusters_with_motifs = set()  # type: Set[secmet.Protocluster]
+        self.clusters_with_motifs: Set[secmet.Protocluster] = set()
         # to track CDSs found with find_all_orfs and within which clusters they were found
-        self.cds_features = defaultdict(list)  # type: Dict[int, List[secmet.CDSFeature]]
+        self.cds_features: Dict[int, List[secmet.CDSFeature]] = defaultdict(list)
         # to track the motifs created
-        self.motifs = []  # type: List[secmet.Prepeptide]
+        self.motifs: List[secmet.Prepeptide] = []
 
     def to_json(self) -> Dict[str, Any]:
         """ Converts the results to JSON format """
@@ -81,14 +81,14 @@ class Thiopeptide:
         self._core = ''
         self._weight = -1.
         self._monoisotopic_weight = -1.
-        self._alt_weights = []  # type: List[float]
+        self._alt_weights: List[float] = []
         self._macrocycle = ''
         self.amidation = False
-        self._mature_alt_weights = []  # type: List[float]
+        self._mature_alt_weights: List[float] = []
         self._mature_features = ''
         self._c_cut = ''
-        self.core_analysis_monoisotopic = None  # type: Optional[utils.RobustProteinAnalysis]
-        self.core_analysis = None  # type: Optional[utils.RobustProteinAnalysis]
+        self.core_analysis_monoisotopic: Optional[utils.RobustProteinAnalysis] = None
+        self.core_analysis: Optional[utils.RobustProteinAnalysis] = None
 
     @property
     def core(self) -> str:
@@ -361,7 +361,7 @@ def get_detected_domains(cluster: secmet.Protocluster) -> Set[str]:
         Return:
             a set of domain ids
     """
-    found_domains = []  # type: List[str]
+    found_domains: List[str] = []
     # Gather biosynthetic domains
     for feature in cluster.cds_children:
         if not feature.sec_met:
@@ -371,7 +371,7 @@ def get_detected_domains(cluster: secmet.Protocluster) -> Set[str]:
     # Gather non-biosynthetic domains
     cluster_fasta = fasta.get_fasta_from_features(cluster.cds_children)
     non_biosynthetic_hmms_by_id = run_non_biosynthetic_phmms(cluster_fasta)
-    non_biosynthetic_hmms_found = []  # type: List[str]
+    non_biosynthetic_hmms_found: List[str] = []
     for hsps_found_for_this_id in non_biosynthetic_hmms_by_id.values():
         for hsp in hsps_found_for_this_id:
             if hsp.query_id not in non_biosynthetic_hmms_found:
@@ -386,7 +386,7 @@ def run_non_biosynthetic_phmms(cluster_fasta: str) -> Dict[str, Any]:
     with open(path.get_full_path(__file__, "data", "non_biosyn_hmms", "hmmdetails.txt"), "r") as handle:
         hmmdetails = [line.split("\t") for line in handle.read().splitlines() if line.count("\t") == 3]
     signature_profiles = [HmmSignature(details[0], details[1], int(details[2]), details[3]) for details in hmmdetails]
-    non_biosynthetic_hmms_by_id = defaultdict(list)  # type: Dict[str, Any]
+    non_biosynthetic_hmms_by_id: Dict[str, Any] = defaultdict(list)
     for sig in signature_profiles:
         sig.path = path.get_full_path(__file__, "data", "non_biosyn_hmms", sig.path.rpartition(os.sep)[2])
         runresults = subprocessing.run_hmmsearch(sig.path, cluster_fasta)
@@ -568,7 +568,7 @@ def result_vec_to_feature(orig_feature: secmet.CDSFeature, res_vec: Thiopeptide)
     if res_vec.c_cut:
         res_vec.core = res_vec.core[:-len(res_vec.c_cut)]
 
-    mature_weights = []  # type: List[float]
+    mature_weights: List[float] = []
     if res_vec.thio_type != "Type III":
         mature_weights = res_vec.mature_alt_weights
     feature = secmet.Prepeptide(orig_feature.location, "thiopeptide", res_vec.core, orig_feature.get_name(),

--- a/antismash/modules/thiopeptides/specific_analysis.py
+++ b/antismash/modules/thiopeptides/specific_analysis.py
@@ -36,9 +36,10 @@ class ThioResults(module_results.ModuleResults):
         """ Converts the results to JSON format """
         cds_features_by_cluster = {key: [(str(feature.location), feature.get_name()) for feature in features]
                                    for key, features in self.cds_features.items()}
+        protoclusters = [cluster.get_protocluster_number() for cluster in self.clusters_with_motifs]
         return {"record_id": self.record_id,
                 "schema_version": ThioResults.schema_version,
-                "protoclusters with motifs": [cluster.get_protocluster_number() for cluster in self.clusters_with_motifs],
+                "protoclusters with motifs": protoclusters,
                 "motifs": [motif.to_json() for motif in self.motifs],
                 "cds_features": cds_features_by_cluster}
 

--- a/antismash/modules/thiopeptides/test/test_thio_specific_analysis.py
+++ b/antismash/modules/thiopeptides/test/test_thio_specific_analysis.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=no-self-use,protected-access,missing-docstring,unbalanced-tuple-unpacking
 
 import unittest
 from unittest.mock import patch

--- a/antismash/modules/tta/tta.py
+++ b/antismash/modules/tta/tta.py
@@ -25,8 +25,8 @@ class TTAResults(ModuleResults):
 
     def __init__(self, record_id: str, gc_content: float, threshold: float) -> None:
         super().__init__(record_id)
-        self.codon_starts = []  # type: List[Codon] # tuples of start and strand for each marker
-        self.features = []  # type: List[Feature] # features created for markers
+        self.codon_starts: List[Codon] = []  # tuples of start and strand for each marker
+        self.features: List[Feature] = []  # features created for markers
         self.gc_content = float(gc_content)
         self.threshold = float(threshold)
 

--- a/antismash/modules/tta/tta.py
+++ b/antismash/modules/tta/tta.py
@@ -9,8 +9,7 @@
 """
 
 import logging
-from typing import Any, Dict, Tuple, Optional
-from typing import List  # used in comment hints, pylint: disable=unused-import
+from typing import Any, Dict, List, Tuple, Optional
 
 from antismash.common.secmet import Record
 from antismash.common.secmet.features import Feature, FeatureLocation

--- a/antismash/outputs/html/generator.py
+++ b/antismash/outputs/html/generator.py
@@ -62,7 +62,7 @@ def write_regions_js(records: List[Dict[str, Any]], output_dir: str,
         of code"""
     with open(os.path.join(output_dir, 'regions.js'), 'w') as handle:
         handle.write("var recordData = %s;\n" % json.dumps(records, indent=4))
-        regions = {"order": []}  # type: Dict[str, Any]
+        regions: Dict[str, Any] = {"order": []}
         for record in records:
             for region in record['regions']:
                 regions[region['anchor']] = region
@@ -121,7 +121,7 @@ def generate_webpage(records: List[Record], results: List[Dict[str, module_resul
         options_layer = OptionsLayer(options)
         record_layers_with_regions = []
         record_layers_without_regions = []
-        results_by_record_id = {}  # type: Dict[str, Dict[str, module_results.ModuleResults]]
+        results_by_record_id: Dict[str, Dict[str, module_results.ModuleResults]] = {}
         for record, record_results in zip(records, results):
             if record.get_regions():
                 record_layers_with_regions.append(RecordLayer(record, None, options_layer))

--- a/antismash/outputs/html/js.py
+++ b/antismash/outputs/html/js.py
@@ -6,14 +6,13 @@
 """
 
 import os
-from typing import Any, Dict, Iterable, List, Optional, Tuple
-from typing import Set  # comment hints, # pylint: disable=unused-import
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from antismash.common import html_renderer, path
 from antismash.common.module_results import ModuleResults
 from antismash.common.secmet import CDSFeature, Feature, Record, Region, CandidateCluster, SubRegion
 from antismash.common.secmet.qualifiers.gene_functions import GeneFunction
-from antismash.common.secmet import Protocluster  # comment hints, # pylint: disable=unused-import
+from antismash.common.secmet import Protocluster
 from antismash.common.secmet.features.cdscollection import CDSCollection
 from antismash.config import ConfigType
 from antismash.modules import clusterblast, tta

--- a/antismash/outputs/html/js.py
+++ b/antismash/outputs/html/js.py
@@ -18,7 +18,7 @@ from antismash.config import ConfigType
 from antismash.modules import clusterblast, tta
 from antismash.outputs.html.generate_html_table import generate_html_table
 
-searchgtr_links = {}  # type: Dict[str, str]  # TODO: refactor away from global
+searchgtr_links: Dict[str, str] = {}  # TODO: refactor away from global
 
 
 def convert_records(records: List[Record], results: List[Dict[str, ModuleResults]],
@@ -44,7 +44,7 @@ def convert_record(record: Record, options: ConfigType, result: Optional[Dict[st
 
 def fetch_tta_features(region: Region, result: Dict[str, ModuleResults]) -> List[Feature]:
     """ Returns a list of all TTA features that overlap with the region """
-    hits = []  # type: List[Feature]
+    hits: List[Feature] = []
     tta_results = result.get(tta.__name__)
     if not tta_results:
         return hits
@@ -60,7 +60,7 @@ def fetch_tta_features(region: Region, result: Dict[str, ModuleResults]) -> List
 def convert_regions(record: Record, options: ConfigType, result: Dict[str, ModuleResults]) -> List[Dict[str, Any]]:
     """Convert Region features to JSON"""
     js_regions = []
-    mibig_results = {}  # type: Dict[int, Dict[str, List[clusterblast.results.MibigEntry]]]
+    mibig_results: Dict[int, Dict[str, List[clusterblast.results.MibigEntry]]] = {}
 
     clusterblast_results = result.get(clusterblast.__name__)
     if clusterblast_results is not None:
@@ -72,7 +72,7 @@ def convert_regions(record: Record, options: ConfigType, result: Dict[str, Modul
     for region in record.get_regions():
         tta_codons = fetch_tta_features(region, result)
 
-        js_region = {}  # type: Dict[str, Any]
+        js_region: Dict[str, Any] = {}
         js_region['start'] = int(region.location.start) + 1
         js_region['end'] = int(region.location.end)
         js_region['idx'] = region.get_region_number()
@@ -99,7 +99,7 @@ def convert_cds_features(record: Record, features: Iterable[CDSFeature], options
         # resistance genes have special markers, not just a colouring, so revert to OTHER
         if gene_function == GeneFunction.RESISTANCE:
             gene_function = GeneFunction.OTHER
-        mibig_hits = []  # type: List[clusterblast.results.MibigEntry]
+        mibig_hits: List[clusterblast.results.MibigEntry] = []
         mibig_hits = mibig_entries.get(feature.get_name(), [])
         description = get_description(record, feature, str(gene_function), options, mibig_hits)
         js_orfs.append({
@@ -135,7 +135,7 @@ def _find_non_overlapping_cluster_groups(collections: Iterable[CDSCollection],
         raise ValueError("padding cannot be negative")
     if not collections:
         return {}
-    groups = []  # type: List[List[CDSCollection]]
+    groups: List[List[CDSCollection]] = []
     for collection in collections:
         found_group = False
         for group in groups:
@@ -156,7 +156,7 @@ def _find_non_overlapping_cluster_groups(collections: Iterable[CDSCollection],
 def get_clusters_from_region_parts(candidate_clusters: Iterable[CandidateCluster],
                                    subregions: Iterable[SubRegion]) -> List[Dict[str, Any]]:
     """ Converts all Protoclusters in a collection of CandidateCluster features to JSON """
-    unique_clusters = set()  # type: Set[Protocluster]
+    unique_clusters: Set[Protocluster] = set()
     for candidate_cluster in candidate_clusters:
         unique_clusters.update(candidate_cluster.protoclusters)
     js_clusters = []

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ tests_require = [
     'pytest >= 3.4.0, < 5', # pytest 5 breaks compatibility with coverage
     'coverage',
     'pylint == 1.8.4', # until pylint handles ignore lines the same way
+    'mypy == 0.630',  # for consistent type checking
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
 tests_require = [
     'pytest >= 3.4.0, < 5', # pytest 5 breaks compatibility with coverage
     'coverage',
-    'pylint == 1.8.4', # until pylint handles ignore lines the same way
+    'pylint == 2.6.0',
     'mypy == 0.630',  # for consistent type checking
 ]
 


### PR DESCRIPTION
Updating to 3.8 isn't possible with the `pyscss` dependency, but updating to 3.7 allows for the new dataclasses feature in python, along with variable type hinting and a few background improvements.

Upgrading will also allow for newer versions of biopython.

- Uses of comment type hints have been converted (where possible)
- `antismash.common.hmmer` converted to use a dataclass instead of a dict
- `pylint` is updated, with some matching style changes and config changes
- `mypy` version added with a pinned version to the dev dependencies, so that devs will have consistent error reporting