### PR TITLE
Handle removal of biopython\s Alphabet in newer versions

### DIFF
--- a/antismash/common/secmet/features/region.py
+++ b/antismash/common/secmet/features/region.py
@@ -162,6 +162,9 @@ class Region(CDSCollection):
         cluster_record.annotations["taxonomy"] = record.annotations.get("taxonomy", [])
         cluster_record.annotations["data_file_division"] = record.annotations.get("data_file_division", 'UNK')
         cluster_record.annotations["comment"] = record.annotations.get("comment", '')
+        # biopython does not persist the molecule_type annotation in slices,
+        # despite it being required for output to the genbank format
+        cluster_record.annotations["molecule_type"] = record.annotations["molecule_type"]
 
         # update the antiSMASH annotation to include some cluster details
         comment_end_marker = "##antiSMASH-Data-END"

--- a/antismash/common/secmet/features/test/test_region.py
+++ b/antismash/common/secmet/features/test/test_region.py
@@ -7,7 +7,6 @@
 from tempfile import NamedTemporaryFile
 import unittest
 
-from Bio.Alphabet import generic_dna
 from Bio.Seq import Seq
 from helperlibs.bio import seqio
 
@@ -138,7 +137,7 @@ class TestRegion(unittest.TestCase):
         assert Region(candidate_clusters=candidates, subregions=subs).probabilities == [0.1, 0.7]
 
     def test_genbank(self):
-        dummy_record = Record(Seq("A"*100, generic_dna))
+        dummy_record = Record(Seq("A"*100))
         clusters = [create_protocluster(3, 20, "prodA"),
                     create_protocluster(25, 41, "prodB")]
         for cluster in clusters:
@@ -164,7 +163,7 @@ class TestRegion(unittest.TestCase):
         assert new.probabilities == region.probabilities
 
     def test_prepeptide_adjustment(self):
-        dummy_record = Record(Seq("A"*400, generic_dna))
+        dummy_record = Record(Seq("A"*400))
         subregion = DummySubRegion(start=100, end=300)
         dummy_record.add_subregion(subregion)
         region = Region(subregions=[subregion])

--- a/antismash/common/secmet/test/test_circular_conversion.py
+++ b/antismash/common/secmet/test/test_circular_conversion.py
@@ -6,7 +6,7 @@
 
 import unittest
 
-from Bio.Seq import UnknownSeq
+from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature
 from Bio.SeqRecord import SeqRecord
 
@@ -16,7 +16,7 @@ from antismash.common.secmet.record import Record, SecmetInvalidInputError
 
 class TestBridgeConversion(unittest.TestCase):
     def setUp(self):
-        self.seqrec = SeqRecord(UnknownSeq(21))
+        self.seqrec = SeqRecord(Seq("A"*21))
         loc = CompoundLocation([FeatureLocation(12, 15, strand=1),
                                 FeatureLocation(18, 21, strand=1),
                                 FeatureLocation(0, 3, strand=1),
@@ -25,6 +25,7 @@ class TestBridgeConversion(unittest.TestCase):
         self.seqcds = SeqFeature(loc, type="CDS")
         self.seqgene = SeqFeature(loc, type="gene")
         self.seqrec.annotations["topology"] = "circular"
+        self.seqrec.annotations["molecule_type"] = "DNA"
 
     def test_bridge_in_linear_record(self):
         self.seqrec.annotations["topology"] = "linear"
@@ -110,7 +111,7 @@ class TestBridgeConversion(unittest.TestCase):
 
 class TestSingleLower(TestBridgeConversion):
     def setUp(self):
-        self.seqrec = SeqRecord(UnknownSeq(21))
+        self.seqrec = SeqRecord(Seq("A"*21))
         loc = CompoundLocation([FeatureLocation(12, 15, strand=1),
                                 FeatureLocation(18, 21, strand=1),
                                 FeatureLocation(0, 9, strand=1)],
@@ -122,7 +123,7 @@ class TestSingleLower(TestBridgeConversion):
 
 class TestSingleUpper(TestBridgeConversion):
     def setUp(self):
-        self.seqrec = SeqRecord(UnknownSeq(21))
+        self.seqrec = SeqRecord(Seq("A"*21))
         loc = CompoundLocation([FeatureLocation(12, 21, strand=1),
                                 FeatureLocation(0, 3, strand=1),
                                 FeatureLocation(6, 9, strand=1)],
@@ -133,7 +134,7 @@ class TestSingleUpper(TestBridgeConversion):
 
 class TestSingleBoth(TestBridgeConversion):
     def setUp(self):
-        self.seqrec = SeqRecord(UnknownSeq(21))
+        self.seqrec = SeqRecord(Seq("A"*21))
         loc = CompoundLocation([FeatureLocation(12, 21, strand=1),
                                 FeatureLocation(0, 9, strand=1)],
                                 operator="join")

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 import unittest
 
 import Bio.SeqIO
-from Bio.Alphabet.IUPAC import IUPACProtein
 from Bio.Seq import Seq
 from Bio.SeqFeature import FeatureLocation, SeqFeature
 
@@ -78,7 +77,7 @@ class TestConversion(unittest.TestCase):
         assert isinstance(before.seq, Seq)
         Record.from_biopython(before, taxon="bacteria")
 
-        before.seq = Seq("AAAA", IUPACProtein())
+        before.annotations["molecule_type"] = "protein"
         with self.assertRaisesRegex(ValueError, "protein records are not supported"):
             Record.from_biopython(before, taxon="bacteria")
 
@@ -789,3 +788,20 @@ class TestCDSUniqueness(unittest.TestCase):
         cds = CDSFeature(FeatureLocation(12, 18, 1), locus_tag="test", protein_id="prot", translation="MA")
         with self.assertRaisesRegex(ValueError, "same name for mapping"):
             record.add_cds_feature(cds)
+
+
+class TestIsNuclSeq(unittest.TestCase):
+    def test_seq(self):
+        # > 20%
+        for seq in ["AGTC", "AGCTFC", "agtcfc", "AGTCFCT"]:
+            assert Record.is_nucleotide_sequence(Seq(seq))
+        # edge case == 20% should be failure
+        assert not Record.is_nucleotide_sequence(Seq("AGFTC"))
+        # and less than 20%
+        assert not Record.is_nucleotide_sequence(Seq("AGFTCF"))
+
+    def test_str(self):
+        for seq in ["AGTC", "AGCTFC", "agtcfc", "AGTCFCT"]:
+            assert Record.is_nucleotide_sequence(seq)
+        assert not Record.is_nucleotide_sequence("AGFTC")
+        assert not Record.is_nucleotide_sequence("AGFTCF")

--- a/antismash/common/serialiser.py
+++ b/antismash/common/serialiser.py
@@ -10,8 +10,6 @@ import json
 import logging
 from typing import Any, Dict, IO, List, Union
 
-import Bio.Alphabet
-import Bio.Alphabet.IUPAC
 from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, Reference
 from Bio.SeqRecord import SeqRecord
@@ -179,8 +177,10 @@ def record_from_json(data: Union[str, Dict]) -> SeqRecord:
 
 def sequence_to_json(sequence: Seq) -> Dict[str, str]:
     """ Constructs a JSON object that represents a Seq sequence """
-    return {"data": str(sequence),
-            "alphabet": str(sequence.alphabet).rsplit('()')[0]}  # DNA() -> DNA
+    return {
+        "data": str(sequence),
+        "alphabet": "DNA",  # for compatibility, removable on schema version change
+    }
 
 
 def sequence_from_json(data: Union[str, Dict]) -> Seq:
@@ -188,12 +188,7 @@ def sequence_from_json(data: Union[str, Dict]) -> Seq:
     if isinstance(data, str):
         data = json.loads(data)
     assert isinstance(data, dict)
-    alphabet = data["alphabet"]
-    if "IUPAC" in alphabet:
-        alphabet_class = getattr(Bio.Alphabet.IUPAC, alphabet)
-    else:
-        alphabet_class = getattr(Bio.Alphabet, alphabet)
-    return Seq(data["data"], alphabet=alphabet_class())
+    return Seq(data["data"])
 
 
 def feature_to_json(feature: SeqFeature) -> Dict[str, Any]:

--- a/antismash/common/test/helpers.py
+++ b/antismash/common/test/helpers.py
@@ -13,7 +13,6 @@
 
 import os
 
-from Bio.Seq import Seq
 from helperlibs.wrappers.io import TemporaryDirectory
 
 import antismash
@@ -46,8 +45,9 @@ def get_simple_options(module, args):
 
 class DummyRecord(Record):
     "class for generating a Record like data structure"
-    def __init__(self, features=None, seq='FAKESEQ', taxon='bacteria'):
+    def __init__(self, features=None, seq='AGCTACGT', taxon='bacteria'):
         super().__init__(seq, transl_table=11 if taxon == 'bacteria' else 1)
+#        self.annotations["molecule_type"] = "DNA"
         if features:
             for feature in features:
                 self.add_feature(feature)

--- a/antismash/common/test/test_record_processing.py
+++ b/antismash/common/test/test_record_processing.py
@@ -154,23 +154,6 @@ class TestTrimSequence(unittest.TestCase):
         assert new.seq == self.record.seq
 
 
-class TestIsNuclSeq(unittest.TestCase):
-    def test_seq(self):
-        # > 20%
-        for seq in ["AGTC", "AGCTFC", "agtcfc", "AGTCFCT"]:
-            assert record_processing.is_nucl_seq(Seq(seq))
-        # edge case == 20% should be failure
-        assert not record_processing.is_nucl_seq(Seq("AGFTC"))
-        # and less than 20%
-        assert not record_processing.is_nucl_seq(Seq("AGFTCF"))
-
-    def test_str(self):
-        for seq in ["AGTC", "AGCTFC", "agtcfc", "AGTCFCT"]:
-            assert record_processing.is_nucl_seq(seq)
-        assert not record_processing.is_nucl_seq("AGFTC")
-        assert not record_processing.is_nucl_seq("AGFTCF")
-
-
 class TestPreprocessRecords(unittest.TestCase):
     def setUp(self):
         class DummyModule:

--- a/antismash/modules/pfam2go/test/test_pfam2go.py
+++ b/antismash/modules/pfam2go/test/test_pfam2go.py
@@ -8,7 +8,6 @@ import unittest
 
 from typing import Dict
 
-from Bio.Alphabet import generic_dna
 from Bio.Seq import Seq
 from Bio.SeqFeature import FeatureLocation
 
@@ -97,7 +96,7 @@ class PfamToGoTest(unittest.TestCase):
 
     def test_blank_records(self):
         blank_no_pfams = DummyRecord()
-        blank_no_ids = Record(Seq("ATGTTATGAGGGTCATAACAT", generic_dna))
+        blank_no_ids = Record(Seq("ATGTTATGAGGGTCATAACAT"))
         fake_pfam = DummyPFAMDomain(identifier="PF00000")
         blank_no_ids.add_pfam_domain(fake_pfam)
 

--- a/antismash/modules/tta/test/test_tta.py
+++ b/antismash/modules/tta/test/test_tta.py
@@ -7,7 +7,6 @@
 from argparse import Namespace
 import unittest
 
-from Bio.Alphabet import generic_dna
 from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, FeatureLocation
 
@@ -19,7 +18,7 @@ from antismash.modules import tta
 class TtaTest(unittest.TestCase):
     def setUp(self):
         # locations:            VVV         VVV
-        record = Record(Seq("ATGTTATGAGGGTCATAACAT", generic_dna))
+        record = Record(Seq("ATGTTATGAGGGTCATAACAT"))
 
         record.add_cds_feature(DummyCDS(0, 9, strand=1))
         record.add_cds_feature(DummyCDS(12, 21, strand=-1))

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ class PyTest(TestCommand):
 
 setup(
     name="antismash",
-    python_requires='>=3.5',
+    python_requires='>=3.7',
     version=read_version(),
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ long_description = read('README.md')
 
 install_requires = [
     'numpy',
-    'biopython >=1.71,<1.77',
+    'biopython >=1.78',
     'helperlibs',
     'jinja2',
     'joblib',


### PR DESCRIPTION
Handle latest biopython versions without Alphabet, makes the minimum biopython 1.78.

Also bumps minimum python to 3.7 to match language features used elsewhere.