### PR TITLE
Change AntismashDomain to be more generic and subclassable by modules for specifics

### DIFF
--- a/antismash/common/secmet/features/antismash_domain.py
+++ b/antismash/common/secmet/features/antismash_domain.py
@@ -18,9 +18,10 @@ class AntismashDomain(Domain):
     __slots__ = ["domain_subtype", "specificity"]
     FEATURE_TYPE = "aSDomain"
 
-    def __init__(self, location: Location, tool: str, protein_location: FeatureLocation, locus_tag: str) -> None:
+    def __init__(self, location: Location, tool: str, protein_location: FeatureLocation,
+                 locus_tag: str, domain: str = None) -> None:
         super().__init__(location, self.FEATURE_TYPE, protein_location, locus_tag,
-                         tool=tool, created_by_antismash=True)
+                         tool=tool, created_by_antismash=True, domain=domain)
 
     @classmethod
     def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,

--- a/antismash/common/secmet/features/antismash_domain.py
+++ b/antismash/common/secmet/features/antismash_domain.py
@@ -3,8 +3,7 @@
 
 """ A more detailed Domain feature """
 
-from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Type, TypeVar
+from typing import Any, Dict, List, Type, TypeVar
 
 from Bio.SeqFeature import SeqFeature
 
@@ -22,36 +21,46 @@ class AntismashDomain(Domain):
     def __init__(self, location: Location, tool: str, protein_location: FeatureLocation, locus_tag: str) -> None:
         super().__init__(location, self.FEATURE_TYPE, protein_location, locus_tag,
                          tool=tool, created_by_antismash=True)
-        self.domain_subtype: Optional[str] = None
-        self.specificity: List[str] = []
-
-    def to_biopython(self, qualifiers: Dict[str, List[str]] = None) -> List[SeqFeature]:
-        mine: Dict[str, List[str]] = OrderedDict()
-        if self.domain_subtype:
-            mine["domain_subtype"] = [self.domain_subtype]
-        if self.specificity:
-            mine["specificity"] = self.specificity
-        if qualifiers:
-            mine.update(qualifiers)
-        return super().to_biopython(mine)
 
     @classmethod
     def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,
                        leftovers: Dict[str, List[str]] = None, record: Any = None) -> T:
         if leftovers is None:
             leftovers = Feature.make_qualifiers_copy(bio_feature)
-        # grab mandatory qualifiers and create the class
-        tool = leftovers.pop("aSTool")[0]
-        protein_location = generate_protein_location_from_qualifiers(leftovers, record)
-        # locus tag is special, antismash versions <= 5.0 didn't require it, but > 5.0 do
-        locus_tag = leftovers.pop("locus_tag", ["(unknown)"])[0]
-        feature = cls(bio_feature.location, tool, protein_location, locus_tag)
+        if not feature:
+            # if there is an appropriate subtype and it's not yet called, call it
+            tool = leftovers["aSTool"][0]
+            if tool in _SUBTYPE_MAPPING:
+                subtype = _SUBTYPE_MAPPING[tool]
+                # this to_biopython() will call this same function again
+                # so this path *must* return
+                variant: AntismashDomain = subtype.from_biopython(bio_feature, feature=None,
+                                                                  leftovers=leftovers, record=record)
+                assert isinstance(variant, AntismashDomain)
+                assert variant.type == AntismashDomain.FEATURE_TYPE
+                assert isinstance(variant, cls)
+                return variant
 
-        # grab optional qualifiers
-        feature.domain_subtype = leftovers.pop("domain_subtype", [""])[0] or None
-        feature.specificity = leftovers.pop("specificity", [])
+            # no tool, so process the minimum for a default domain
+            # grab mandatory qualifiers and create the class
+            tool = leftovers.pop("aSTool")[0]
+            protein_location = generate_protein_location_from_qualifiers(leftovers, record)
+            # locus tag is special, antismash versions <= 5.0 didn't require it, but > 5.0 do
+            locus_tag = leftovers.pop("locus_tag", ["(unknown)"])[0]
+            feature = cls(bio_feature.location, tool, protein_location, locus_tag)
 
-        # grab parent optional qualifiers
+        # for any instance, populate with the superclass info
         super().from_biopython(bio_feature, feature=feature, leftovers=leftovers, record=record)
-
+        assert feature.domain_id
         return feature
+
+
+_SUBTYPE_MAPPING: Dict[str, Type[AntismashDomain]] = {}
+
+
+def register_asdomain_variant(tool: str, subtype: Type[AntismashDomain]) -> None:
+    if not issubclass(subtype, AntismashDomain):
+        raise TypeError(f"{subtype} is not a subclass of AntismashDomain")
+    if tool in _SUBTYPE_MAPPING:
+        raise ValueError(f"{tool!r} is already present as a subtype ({_SUBTYPE_MAPPING[tool]})")
+    _SUBTYPE_MAPPING[tool] = subtype

--- a/antismash/common/secmet/features/test/test_antismash_domain.py
+++ b/antismash/common/secmet/features/test/test_antismash_domain.py
@@ -67,3 +67,12 @@ class TestSubtyping(unittest.TestCase):
         self.register("test", AntismashDomain)
         with self.assertRaisesRegex(ValueError, "already present as a subtype"):
             self.register("test", AntismashDomain)
+
+
+class TestValues(unittest.TestCase):
+    def test_domain_passthrough(self):
+        for value in ["test", "DomainName"]:
+            domain = AntismashDomain(FeatureLocation(1, 3, 1), locus_tag="locus",
+                                     tool="test", protein_location=FeatureLocation(0, 1),
+                                     domain=value)
+            assert domain.domain == value

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -125,10 +125,12 @@ class TestStripping(unittest.TestCase):
 
     def test_antismash_domains(self):
         assert not self.rec.get_antismash_domains()
-        self.rec.add_antismash_domain(DummyAntismashDomain())
+        self.rec.add_antismash_domain(DummyAntismashDomain(tool="test"))
         assert self.rec.get_antismash_domains()
+        assert self.rec.get_antismash_domains_by_tool("test")
         self.rec.strip_antismash_annotations()
         assert not self.rec.get_antismash_domains()
+        assert not self.rec.get_antismash_domains_by_tool("test")
 
     def test_pfams(self):
         assert not self.rec.get_pfam_domains()
@@ -179,6 +181,19 @@ class TestStripping(unittest.TestCase):
         assert self.cds.gene_functions
         self.rec.strip_antismash_annotations()
         assert not self.cds.gene_functions
+
+    def test_antismash_domains_by_tool(self):
+        assert not self.rec.get_antismash_domains()
+        assert self.rec.get_antismash_domains_by_tool("a") == tuple()
+        assert self.rec.get_antismash_domains_by_tool("b") == tuple()
+        a = DummyAntismashDomain(tool="a")
+        b = DummyAntismashDomain(tool="b")
+        z = DummyAntismashDomain(tool="a")
+        for i in [a, b, z]:
+            self.rec.add_antismash_domain(i)
+        assert self.rec.get_antismash_domains() == (a, b, z)
+        assert self.rec.get_antismash_domains_by_tool("a") == (a, z)
+        assert self.rec.get_antismash_domains_by_tool("b") == (b,)
 
 
 class TestRecordFeatureNumbering(unittest.TestCase):

--- a/antismash/detection/nrps_pks_domains/__init__.py
+++ b/antismash/detection/nrps_pks_domains/__init__.py
@@ -14,6 +14,7 @@ from antismash.config.args import ModuleArgs
 
 from .domain_drawing import generate_html, generate_js_domains, will_handle
 from .domain_identification import generate_domains, NRPSPKSDomains
+from .modular_domain import ModularDomain
 
 NAME = "nrps_pks_domains"
 SHORT_DESCRIPTION = "NRPS/PKS domain identification"

--- a/antismash/detection/nrps_pks_domains/modular_domain.py
+++ b/antismash/detection/nrps_pks_domains/modular_domain.py
@@ -1,0 +1,71 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+""" An AntismashDomain subclass with specificity """
+
+from collections import OrderedDict
+from typing import Any, Dict, List, Optional, Type, TypeVar
+
+from Bio.SeqFeature import SeqFeature
+
+from antismash.common.secmet.features.antismash_domain import (
+    AntismashDomain,
+    Feature,
+    FeatureLocation,
+    Location,
+    register_asdomain_variant,
+    generate_protein_location_from_qualifiers
+)
+
+T = TypeVar("T", bound="ModularDomain")
+
+TOOL = "nrps_pks_domains"
+
+
+class ModularDomain(AntismashDomain):
+    """ A class to represent a Domain with extra specificities and type information """
+    __slots__ = ["specificity"]
+    FEATURE_TYPE = "aSDomain"
+
+    def __init__(self, location: Location, protein_location: FeatureLocation, locus_tag: str) -> None:
+        super().__init__(location, protein_location=protein_location, locus_tag=locus_tag,
+                         tool=TOOL)
+        self.domain_subtype: Optional[str] = None
+        self.specificity: List[str] = []
+
+    def to_biopython(self, qualifiers: Dict[str, List[str]] = None) -> List[SeqFeature]:
+        mine: Dict[str, List[str]] = OrderedDict()
+        if self.domain_subtype:
+            mine["domain_subtype"] = [self.domain_subtype]
+        if self.specificity:
+            mine["specificity"] = list(self.specificity)
+        if qualifiers:
+            mine.update(qualifiers)
+        assert self.domain_id
+        return super().to_biopython(mine)
+
+    @classmethod
+    def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,
+                       leftovers: Dict[str, List[str]] = None, record: Any = None) -> T:
+        if leftovers is None:
+            leftovers = Feature.make_qualifiers_copy(bio_feature)
+        # grab mandatory qualifiers and create the class
+        tool = leftovers.pop("aSTool")[0]
+        if tool != TOOL:
+            raise ValueError(f"incompatible tool type for {cls}: {tool}")
+        protein_location = generate_protein_location_from_qualifiers(leftovers, record)
+        # locus tag is special, antismash versions <= 5.0 didn't require it, but > 5.0 do
+        locus_tag = leftovers.pop("locus_tag", ["(unknown)"])[0]
+        feature = cls(bio_feature.location, protein_location, locus_tag)
+
+        # grab optional qualifiers
+        feature.domain_subtype = leftovers.pop("domain_subtype", [""])[0] or None
+        feature.specificity = leftovers.pop("specificity", [])
+
+        # grab parent optional qualifiers
+        super().from_biopython(bio_feature, feature=feature, leftovers=leftovers, record=record)
+
+        return feature
+
+
+register_asdomain_variant(TOOL, ModularDomain)

--- a/antismash/detection/nrps_pks_domains/test/integration_domains.py
+++ b/antismash/detection/nrps_pks_domains/test/integration_domains.py
@@ -81,6 +81,7 @@ class TestAnalyses(unittest.TestCase):
         assert len(results.cds_results) == 2
         assert len(record.get_cds_motifs()) == 2
         assert len(record.get_antismash_domains()) == 3
+        assert len(record.get_antismash_domains_by_tool("nrps_pks_domains")) == 3
 
         two_domains = record.get_cds_by_name("two_domains")
         assert two_domains.nrps_pks.type == "NRPS"

--- a/antismash/modules/active_site_finder/__init__.py
+++ b/antismash/modules/active_site_finder/__init__.py
@@ -22,7 +22,7 @@ class ASFResults(module_results.ModuleResults):
     schema_version = 1
 
     def __init__(self, record_id: str, pairings: List[Tuple[secmet.features.Domain, List[str]]]) -> None:
-        # pairing features will be either AntismashDomain or PFAMDomain
+        # pairing features will be either ModularDomain or PFAMDomain
         super().__init__(record_id)
         self.pairings = pairings
 

--- a/antismash/modules/active_site_finder/analysis.py
+++ b/antismash/modules/active_site_finder/analysis.py
@@ -43,7 +43,7 @@ def pksi_kr_stereo(record: secmet.Record) -> List[SinglePairing]:
     positions = [149, 162, 166]
     expected = ["S", "Y", "N"]
     target_domain = "PKS_KR"
-    candidates = record.get_antismash_domains()
+    candidates = record.get_antismash_domains_by_tool("nrps_pks_domains")
 
     analyser = ActiveSiteAnalysis(target_domain, candidates, "PKSI-KR.hmm2", positions, expected)
 
@@ -74,7 +74,7 @@ def asp_ks(record: secmet.Record) -> List[SinglePairing]:
     expected = ['G', 'S', 'S', 'S']
     emissions = [0.99, 0.9, 0.81, 0.81]
     target_domain = "PKS_KS"
-    candidates = record.get_antismash_domains()
+    candidates = record.get_antismash_domains_by_tool("nrps_pks_domains")
 
     results = []
 
@@ -104,7 +104,7 @@ def asp_ks_c(record: secmet.Record) -> List[SinglePairing]:
     expected = ['E', 'G', 'T', 'G', 'T', 'G', 'D', 'E', 'K', 'G', 'G', 'K']
     emissions = [0.96, 0.92, 0.95, 0.94, 0.95, 0.96, 0.99, 0.99, 1., 0.99, 0.96, 0.93]
     target_domain = "PKS_KS"
-    candidates = record.get_antismash_domains()
+    candidates = record.get_antismash_domains_by_tool("nrps_pks_domains")
 
     results = []
 
@@ -129,7 +129,7 @@ def asp_at(record: secmet.Record) -> List[SinglePairing]:
     expected = ['G', 'H', 'G', 'E']
     emissions = [1., 1., 1., 0.94]
     target_domain = "PKS_AT"
-    candidates = record.get_antismash_domains()
+    candidates = record.get_antismash_domains_by_tool("nrps_pks_domains")
     analyser = ActiveSiteAnalysis(target_domain, candidates, "PKSI-AT.hmm2",
                                   positions, expected, emissions=emissions)
 
@@ -157,7 +157,7 @@ def acp_type(record: secmet.Record) -> List[SinglePairing]:
     expected = ['G', 'D', 'S']
     emissions = [0.97, 0.9, 0.98]
     target_domain = "ACP"
-    candidates = record.get_antismash_domains()
+    candidates = record.get_antismash_domains_by_tool("nrps_pks_domains")
     analyser = ActiveSiteAnalysis(target_domain, candidates, "PKSI-ACP.hmm2",
                                   positions, expected, emissions=emissions)
     results = []
@@ -187,7 +187,7 @@ def asp_acp(record: secmet.Record) -> List[SinglePairing]:
     expected = ['G', 'D']
     emissions = [0.97, 0.9]
     target_domain = "ACP"
-    candidates = record.get_antismash_domains()
+    candidates = record.get_antismash_domains_by_tool("nrps_pks_domains")
     analyser = ActiveSiteAnalysis(target_domain, candidates, "PKSI-ACP.hmm2",
                                   positions, expected, emissions=emissions)
 
@@ -211,7 +211,7 @@ def asp_pksi_dh(record: secmet.Record) -> List[SinglePairing]:
     expected = ['L', 'L', 'G', 'P', 'L', 'D']
     emissions = [0.9, 0.78, 0.86, 0.7, 0.85, 0.78]
     target_domain = "PKS_DH"
-    candidates = record.get_antismash_domains()
+    candidates = record.get_antismash_domains_by_tool("nrps_pks_domains")
     analyser = ActiveSiteAnalysis(target_domain, candidates, "PKSI-DH.hmm2",
                                   positions, expected, emissions=emissions)
 
@@ -243,7 +243,7 @@ def asp_pksi_kr(record: secmet.Record) -> List[SinglePairing]:
     expected = ['R', 'D', 'G', 'A', 'K', 'S']
     emissions = [0.93, 0.88, 0.93, 0.9, 0.99, 0.87]
     target_domain = "PKS_KR"
-    candidates = record.get_antismash_domains()
+    candidates = record.get_antismash_domains_by_tool("nrps_pks_domains")
     analyser = ActiveSiteAnalysis(target_domain, candidates, "PKSI-KR.hmm2",
                                   positions, expected, emissions=emissions)
 
@@ -270,7 +270,7 @@ def asp_thioesterase(record: secmet.Record) -> List[SinglePairing]:
     expected = ['G', 'G', 'G', 'A', 'D']
     emissions = [0.93, 1., 0.99, 0.9, 0.9]
     target_domain = "Thioesterase"
-    candidates = record.get_antismash_domains()
+    candidates = record.get_antismash_domains_by_tool("nrps_pks_domains")
     analyser = ActiveSiteAnalysis(target_domain, candidates, "Thioesterase.hmm2",
                                   positions, expected, emissions=emissions)
 
@@ -301,7 +301,7 @@ def pksi_er_stereo(record: secmet.Record) -> List[SinglePairing]:
     positions = [31, 135, 137, 144, 146, 227]
     expected = ['D', 'L', 'H', 'G', 'A', 'G']
     target_domain = "PKS_ER"
-    candidates = record.get_antismash_domains()
+    candidates = record.get_antismash_domains_by_tool("nrps_pks_domains")
     analyser = ActiveSiteAnalysis(target_domain, candidates, "PKSI-ER.hmm2", positions, expected)
 
     results = []
@@ -334,7 +334,7 @@ def pksi_at_spec(record: secmet.Record) -> List[SinglePairing]:
     positions = [93, 94, 95, 120, 196, 198, 199, 227, 244, 245]
     expected = ['G', 'H', 'S', 'R', 'A', 'H', 'S', 'S', 'Y', 'W']
     target_domain = "PKS_AT"
-    candidates = record.get_antismash_domains()
+    candidates = record.get_antismash_domains_by_tool("nrps_pks_domains")
     analyser = ActiveSiteAnalysis(target_domain, candidates, "PKSI-AT.hmm2", positions, expected)
 
     results = []

--- a/antismash/modules/active_site_finder/test/test_analysis.py
+++ b/antismash/modules/active_site_finder/test/test_analysis.py
@@ -13,6 +13,7 @@ from Bio import SearchIO
 from antismash.common import subprocessing
 from antismash.common import fasta, path, secmet
 from antismash.common.test.helpers import DummyAntismashDomain, DummyRecord, DummyPFAMDomain
+from antismash.detection.nrps_pks_domains.modular_domain import TOOL
 from antismash.modules import active_site_finder
 from antismash.modules.active_site_finder import analysis
 
@@ -27,7 +28,8 @@ def rebuild_domains(filename, domain_type):
     domain_fasta = fasta.read_fasta(full_path)
     domains = []
     for name, translation in domain_fasta.items():
-        domain = DummyAntismashDomain(start=1, end=100, domain_id=domain_type + name)
+        domain = DummyAntismashDomain(start=1, end=100, domain_id=domain_type + name,
+                                      tool=TOOL)
         domain.domain = domain_type
         domain.translation = translation
         domains.append(domain)

--- a/antismash/modules/nrps_pks/nrps_predictor.py
+++ b/antismash/modules/nrps_pks/nrps_predictor.py
@@ -14,8 +14,8 @@ from helperlibs.wrappers.io import TemporaryDirectory
 from jinja2 import Markup
 
 from antismash.common import path, subprocessing
-from antismash.common.secmet import AntismashDomain
 from antismash.config import ConfigType
+from antismash.detection.nrps_pks_domains import ModularDomain
 
 from .data_structures import Prediction
 
@@ -276,7 +276,7 @@ def extract(sequence: str, positions: List[int]) -> str:
     return "".join(seq)
 
 
-def get_34_aa_signature(domain: AntismashDomain) -> str:
+def get_34_aa_signature(domain: ModularDomain) -> str:
     """ Extract 10 / 34 AA NRPS signatures from A domains """
     assert " " not in domain.get_name()
     assert verify_good_sequence(domain.translation)
@@ -317,11 +317,11 @@ def read_output(lines: List[str]) -> Dict[str, Prediction]:
     return results
 
 
-def run_nrpspredictor(a_domains: List[AntismashDomain], options: ConfigType) -> Dict[str, Prediction]:
+def run_nrpspredictor(a_domains: List[ModularDomain], options: ConfigType) -> Dict[str, Prediction]:
     """ Runs NRPSPredictor2 over the provided A domains.
 
         Arguments:
-            a_domains: a list of AntismashDomains, one for each A domain
+            a_domains: a list of ModularDomains, one for each A domain
             options: antismash options
 
         Returns:

--- a/antismash/modules/nrps_pks/parsers.py
+++ b/antismash/modules/nrps_pks/parsers.py
@@ -91,7 +91,7 @@ def calculate_consensus_prediction(cds_features: List[CDSFeature], results: Dict
 
         Arguments:
             cds_features: a list of CDSFeature to calculate consensus for
-            results: a dictionary mapping AntismashDomain name to
+            results: a dictionary mapping domain name to
                         a dictionary mapping analysis method to a Prediction
 
         Returns:

--- a/antismash/modules/nrps_pks/results.py
+++ b/antismash/modules/nrps_pks/results.py
@@ -8,8 +8,9 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from antismash.common.module_results import ModuleResults
-from antismash.common.secmet import AntismashDomain, Module, Record
+from antismash.common.secmet import Module, Record
 from antismash.common.secmet.qualifiers import NRPSPKSQualifier
+from antismash.detection.nrps_pks_domains import ModularDomain
 
 from .parsers import generate_nrps_consensus
 from .data_structures import Prediction, SimplePrediction
@@ -71,6 +72,7 @@ def modify_substrate(module: Module, base: str = "") -> str:  # pylint: disable=
 
     state: List[str] = []
     for domain in module.domains:
+        assert isinstance(domain, ModularDomain)
         if domain.domain != "MT":
             continue
         if domain.domain_subtype == "nMT":
@@ -245,7 +247,7 @@ class NRPS_PKS_Results(ModuleResults):
             nrps_qualifier = cds_feature.nrps_pks
             for domain in nrps_qualifier.domains:
                 feature = record.get_domain_by_name(domain.feature_name)
-                assert isinstance(feature, AntismashDomain)
+                assert isinstance(feature, ModularDomain)
 
                 domain.predictions.clear()
                 if domain.name in ["AMP-binding", "A-OX"]:

--- a/antismash/modules/nrps_pks/specific_analysis.py
+++ b/antismash/modules/nrps_pks/specific_analysis.py
@@ -8,8 +8,9 @@ In-depth analysis and annotation of NRPS/PKS regions.
 import logging
 from typing import List
 
-from antismash.common.secmet import Record, CDSFeature, AntismashDomain, Region
+from antismash.common.secmet import Record, CDSFeature, Region
 from antismash.config import ConfigType
+from antismash.detection.nrps_pks_domains import ModularDomain
 
 from .orderfinder import analyse_biosynthetic_order
 from .parsers import calculate_consensus_prediction
@@ -19,23 +20,23 @@ from .substrates import run_pks_substr_spec_predictions
 from .nrps_predictor import run_nrpspredictor
 
 
-def get_a_domains_from_cds_features(record: Record, cds_features: List[CDSFeature]) -> List[AntismashDomain]:
-    """ Fetches all AMP-binding AntismashDomains which are contained within the given
+def get_a_domains_from_cds_features(record: Record, cds_features: List[CDSFeature]) -> List[ModularDomain]:
+    """ Fetches all AMP-binding ModularDomains which are contained within the given
         CDS features.
 
         Arguments:
-            record: the Record containing both AntismashDomains and CDSFeatures
+            record: the Record containing both ModularDomains and CDSFeatures
             cds_features: the specific CDSFeatures from which to get the A-domains
 
         Returns:
-            a list of AntismashDomains, one for each A domain found
+            a list of ModularDomains, one for each A domain found
     """
     a_domains = []
     for cds in cds_features:
         for domain in cds.nrps_pks.domains:
             if domain.name in ["AMP-binding"]:
                 as_domain = record.get_domain_by_name(domain.feature_name)
-                assert isinstance(as_domain, AntismashDomain), type(as_domain)
+                assert isinstance(as_domain, ModularDomain), type(as_domain)
                 a_domains.append(as_domain)
     return a_domains
 

--- a/antismash/modules/nrps_pks/substrates.py
+++ b/antismash/modules/nrps_pks/substrates.py
@@ -28,7 +28,7 @@ def run_pks_substr_spec_predictions(cds_features: List[CDSFeature]) -> Dict[str,
         Returns:
             a dictionary mapping
                 analysis method name to a dictionary mapping
-                    AntismashDomain name to Prediction
+                    domain name to Prediction
     """
     at_domains = extract_at_domains(cds_features)
     method_results: Dict[str, Dict[str, Prediction]] = {}


### PR DESCRIPTION
As discussed in #288, there needed to be a more generic way of handling `aSDomain` features annotated in GenBank files.

Subclasses of `AntismashDomain` can now be registered by modules creating them and registered as a variant for specific regeneration (via `antismash.common.secmet.features.antismash_domain.register_asdomain_variant()`).
After registration, `AntismashDomain.from_biopython()` will use the relevant type based on the `aSTool` qualifier matching the registered type. If no tool matches, the generic `AntismashDomain` will be used.

Previous NRPS/PKS-specific attributes are now handled by the `antismash.detection.nrps_pks_domains.ModularDomain` class.