### PR TITLE
Add secmet rule categories

### DIFF
--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -1107,9 +1107,9 @@ class Parser:  # pylint: disable=too-few-public-methods
 
 def is_legal_identifier(identifier: str) -> bool:
     """ Returns true if the identifier matches the form:
-        [a-zA-Z]{[a-zA-Z0-9_-]}*
+        {[a-zA-Z0-9_-]}*[a-zA-Z]{[a-zA-Z0-9_-]}*
     """
-    if not identifier[0].isalpha():
+    if not any(i.isalpha() for i in identifier):
         return False
     for char in identifier:
         if not (char.isalpha() or char.isdigit() or char in ['_', '-']):

--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -813,8 +813,10 @@ class Parser:  # pylint: disable=too-few-public-methods
         text are stored in the .rules member.
     """
     def __init__(self, text: str, signature_names: Set[str],
+                 valid_categories: Set[str],
                  existing_rules: List[DetectionRule] = None) -> None:
         self.lines = text.splitlines()
+        self.valid_categories = valid_categories
         if not existing_rules:
             existing_rules = []
         self.rules = list(existing_rules)
@@ -883,6 +885,9 @@ class Parser:  # pylint: disable=too-few-public-methods
         comments = ""
         self._consume(TokenTypes.CATEGORY)
         category = self._consume_identifier()
+        if category not in self.valid_categories:
+            valid_categories = ", ".join(self.valid_categories)
+            raise RuleSyntaxError(f"Invalid category {category}, use one of {valid_categories}")
         if not self.current_token:
             raise RuleSyntaxError("expected %s, %s, or %s sections after %s"
                                   % (TokenTypes.COMMENT, TokenTypes.SUPERIORS,

--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -224,7 +224,7 @@ class TokenTypes(IntEnum):
         """ Returns True if the token is a rule structure keyword such as
             RULE, COMMENT, CONDITIONS, etc
         """
-        return 15 <= self.value <= 21  # pylint: disable=comparison-with-callable
+        return 15 <= self.value and self.value != self.TEXT # pylint: disable=comparison-with-callable
 
 
 class Tokeniser:  # pylint: disable=too-few-public-methods

--- a/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
@@ -23,9 +23,9 @@ class DummyConditions(rule_parser.Conditions):
 
 class TestRedundancy(unittest.TestCase):
     def setUp(self):
-        superior = rule_parser.DetectionRule("superior", 10, 10, DummyConditions())
-        inferior = rule_parser.DetectionRule("inferior", 10, 10, DummyConditions(), superiors=["superior"])
-        irrelevant = rule_parser.DetectionRule("irrelevant", 10, 10, DummyConditions())
+        superior = rule_parser.DetectionRule("superior", "category", 10, 10, DummyConditions())
+        inferior = rule_parser.DetectionRule("inferior", "category", 10, 10, DummyConditions(), superiors=["superior"])
+        irrelevant = rule_parser.DetectionRule("irrelevant", "category", 10, 10, DummyConditions())
         self.rules_by_name = {rule.name: rule for rule in [superior, inferior, irrelevant]}
 
     def remove(self, clusters):

--- a/antismash/common/hmm_rule_parser/test/test_rule_parser.py
+++ b/antismash/common/hmm_rule_parser/test/test_rule_parser.py
@@ -441,12 +441,12 @@ class RuleParserTest(unittest.TestCase):
         with self.assertRaises(rule_parser.RuleSyntaxError):
             self.parse(format_as_rule("A", 10, 10, "a.b or c"))
 
-        assert not rule_parser.is_legal_identifier("0sdf")
+        assert not rule_parser.is_legal_identifier("0123")
         with self.assertRaises(rule_parser.RuleSyntaxError):
-            self.parse(format_as_rule("A", 10, 10, "a or 0sdf"))
+            self.parse(format_as_rule("A", 10, 10, "a or 0123"))
 
         with self.assertRaises(rule_parser.RuleSyntaxError):
-            self.parse(format_as_rule("A", 10, 10, "0sdf or a"))
+            self.parse(format_as_rule("A", 10, 10, "0123 or a"))
 
         assert not rule_parser.is_legal_identifier("a!b")
         with self.assertRaises(rule_parser.RuleSyntaxError):

--- a/antismash/detection/hmm_detection/categories.py
+++ b/antismash/detection/hmm_detection/categories.py
@@ -1,0 +1,59 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+""" Handle valid rule categories plus associated metadata
+"""
+
+from dataclasses import dataclass
+import json
+from typing import Dict, List, Type, TypeVar, Union
+
+from antismash.common import path
+
+TRuleCategory = TypeVar("TRuleCategory", bound="RuleCategory")
+
+
+@dataclass
+class RuleCategory:
+    name: str
+    description: str
+    version: int = 1
+
+    @classmethod
+    def from_json(cls: Type[TRuleCategory], name: str,
+                  entry: Dict[str, Union[str, int]]) -> TRuleCategory:
+
+        try:
+            description: str = str(entry["description"])  # cast to make mypy happy
+            version: int = int(entry["version"])  # cast to make mypy happy
+        except KeyError as err:
+            raise ValueError(f"missing required rule metadata key '{err}'")
+
+        if version != 1:
+            raise ValueError(f"Unknown rule category version {version}")
+
+        return cls(name, description, version)
+
+
+def get_rule_categories() -> List[RuleCategory]:
+    """Generate a list of rule categories from categories.json
+    Only processes the file once per Python invocation, future calls access the cached data.
+    """
+    # if called before, just return the cached data
+    existing = getattr(get_rule_categories, 'existing', None)
+    if existing is not None:
+        assert isinstance(existing, list)
+        return existing
+
+    # not cached, generate
+    categories : List[RuleCategory] = []
+
+    with open(path.get_full_path(__file__, "data", "categories.json"), 'r') as handle:
+        category_json = json.load(handle)
+        for name, metadata in category_json.items():
+            categories.append(RuleCategory.from_json(name, metadata))
+
+    # and cache for future calls, and silence mypy warning as mypy can't handle this
+    get_rule_categories.existing = categories  # type: ignore
+
+    return categories

--- a/antismash/detection/hmm_detection/cluster_rules/loose.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/loose.txt
@@ -4,6 +4,7 @@
 # Cutoffs and neighbourhoods are given in kilobases
 
 RULE saccharide
+    CATEGORY saccharide
     COMMENT from clusterfinder
     CUTOFF 20
     NEIGHBOURHOOD 10
@@ -16,12 +17,14 @@ RULE saccharide
                           Polysacc_synt_2, RmlD_sub_bind, Wzy_C])
 
 RULE fatty_acid
+    CATEGORY other
     COMMENT from clusterfinder
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS  bt1fas or ft1fas or t2fas or fabH
 
 RULE halogenated
+    CATEGORY other
     COMMENT Halogenases are frequently involved in secondary metabolite biosynthesis
     CUTOFF 5
     NEIGHBOURHOOD 10

--- a/antismash/detection/hmm_detection/cluster_rules/relaxed.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/relaxed.txt
@@ -3,6 +3,7 @@
 # Cutoffs and neighbourhoods are given in kilobases
 
 RULE NRPS-like
+    CATEGORY NRPS
     COMMENT Catches NRPS-like fragments that are not detected by the NRPS rule
     SUPERIORS NRPS
     CUTOFF 0  # since we're really looking at single CDS fragments
@@ -10,6 +11,7 @@ RULE NRPS-like
     CONDITIONS cds((PP-binding or NAD_binding_4) and (AMP-binding or A-OX))
 
 RULE PKS-like
+    CATEGORY PKS
     COMMENT Catches PKS-like fragments that are not detected by another PKS rule
     SUPERIORS T2PKS
     CUTOFF 10
@@ -17,6 +19,7 @@ RULE PKS-like
     CONDITIONS t2pks2 or ksIII
 
 RULE transAT-PKS-like
+    CATEGORY PKS
     COMMENT Marks partial transAT-PKS clusters, specifically those with an AT-docking domain,
             but no AT domain.
     SUPERIORS transAT-PKS

--- a/antismash/detection/hmm_detection/cluster_rules/strict.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/strict.txt
@@ -3,12 +3,14 @@
 # Cutoffs and neighbourhoods are given in kilobases
 
 RULE T1PKS
+    CATEGORY PKS
     COMMENT Type-I PKS
     CUTOFF 20
     NEIGHBOURHOOD 20
     CONDITIONS cds(PKS_AT and (PKS_KS or ene_KS or mod_KS or hyb_KS or itr_KS or tra_KS))
 
 RULE T2PKS
+    CATEGORY PKS
     COMMENT Type-II PKS
     RELATED t2pks2, ksIII
     CUTOFF 20
@@ -16,12 +18,14 @@ RULE T2PKS
     CONDITIONS t2ks and t2clf
 
 RULE T3PKS
+    CATEGORY PKS
     COMMENT Type-III PKS
     CUTOFF 20
     NEIGHBOURHOOD 20
     CONDITIONS Chal_sti_synt_C or Chal_sti_synt_N
 
 RULE transAT-PKS
+    CATEGORY PKS
     CUTOFF 45  # kirromycin (CP006259) has a range of ~42kb
     NEIGHBOURHOOD 20
     CONDITIONS cds(PKS_AT and not (PKS_KS or ene_KS or mod_KS or hyb_KS or itr_KS or tra_KS))
@@ -32,33 +36,39 @@ RULE transAT-PKS
                )
 
 RULE hglE-KS
+    CATEGORY PKS
     COMMENT heterocyst glycolipid synthase like PKS such as KC489223
     CUTOFF 20
     NEIGHBOURHOOD 20
     CONDITIONS hglE or hglD
 
 RULE arylpolyene
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 20
     CONDITIONS APE_KS1 or APE_KS2
 
 RULE resorcinol
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 20
     CONDITIONS DarB
 
 RULE ladderane
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 20
     CONDITIONS ladderane
 
 RULE PUFA
+    CATEGORY other
     COMMENT PolyUnsaturated Fatty Acid
     CUTOFF 20
     NEIGHBOURHOOD 20
     CONDITIONS PUFA_KS
 
 RULE NRPS
+    CATEGORY NRPS
     COMMENT non-ribosomal peptide synthase
     CUTOFF 20
     NEIGHBOURHOOD 20
@@ -66,6 +76,7 @@ RULE NRPS
                or (Condensation and AMP-binding)  #TODO: dubious
 
 RULE CDPS
+    CATEGORY NRPS
     COMMENT tRNA-dependent cyclodipeptide synthases like BGC0001468 aka
             bicyclomycin
     RELATED Flavoprotein, 2OG-FeII_Oxy, p450
@@ -74,6 +85,7 @@ RULE CDPS
     CONDITIONS CDPS or cycdipepsynth
 
 RULE thioamide-NRP
+    CATEGORY NRPS
     COMMENT thioamide-containing non-ribosomal peptides (https://doi.org/10.1002/anie.201807970)
     RELATED Chor_lyase
     CUTOFF 20
@@ -82,6 +94,7 @@ RULE thioamide-NRP
                 (DUF98 or Orn_Arg_deC_N or Orn_DAP_Arg_deC)
 
 RULE terpene
+    CATEGORY terpene
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS Terpene_synth or Terpene_synth_C or phytoene_synt or Lycopene_cycl
@@ -89,6 +102,7 @@ RULE terpene
                or trichodiene_synth or TRI5
 
 RULE lanthipeptide
+    CATEGORY RiPP
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS (LANC_like and (Lant_dehydr_N or Lant_dehydr_C)  # Class I
@@ -96,6 +110,7 @@ RULE lanthipeptide
                and not (YcaO or TIGR03882) # because then it'd be a thiopeptide
 
 RULE lipolanthine
+    CATEGORY RiPP
     COMMENT Lanthipeptide class containing N-terminal fatty acids such as MG673929
             See https://doi.org/10.1038/s41589-018-0068-6
     RELATED PKS_KS, AMP-binding, PP-binding
@@ -104,6 +119,7 @@ RULE lipolanthine
     CONDITIONS micKC and Flavoprotein
 
 RULE lanthidin
+    CATEGORY RiPP
     COMMENT Glycosylated lanthipeptide/linaridin hybrids like MT210103
     RELATED Flavoprotein, Glycos_transf_1, Glycos_transf_2
     CUTOFF 20
@@ -111,6 +127,7 @@ RULE lanthidin
     CONDITIONS APH and HopA1
 
 RULE bacteriocin
+    CATEGORY RiPP
     CUTOFF 20
     NEIGHBOURHOOD 5
     CONDITIONS strepbact or Antimicrobial14 or Bacteriocin_IId or BacteriocIIc_cy
@@ -122,6 +139,7 @@ RULE bacteriocin
                or TIGR03975 or DUF692 or TIGR01193
 
 RULE thiopeptide
+    CATEGORY RiPP
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS (YcaO or TIGR03882)
@@ -131,6 +149,7 @@ RULE thiopeptide
                or thiostrepton
 
 RULE TfuA-related
+    CATEGORY RiPP
     COMMENT TfuA-related RiPPs as described in https://doi.org/10.1093/nar/gkz192
             and found on JOBF01000011
     CUTOFF 20
@@ -139,21 +158,25 @@ RULE TfuA-related
                and TfuA
 
 RULE linaridin
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS cypemycin or cypI
 
 RULE cyanobactin
+    CATEGORY RiPP
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS cyanobactin_synth
 
 RULE glycocin
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS glycocin or sublancin
 
 RULE LAP
+    CATEGORY RiPP
     COMMENT Linear azol(in)e-containing peptides like goadsporin (AB205012) or
             microcin B17 (FM877811)
     RELATED TIGR04424
@@ -163,63 +186,75 @@ RULE LAP
                and (YcaO or TIGR03882)
 
 RULE lassopeptide
+    CATEGORY RiPP
     CUTOFF 10
     NEIGHBOURHOOD 10
     CONDITIONS PF13471 and Asn_synthase or micJ25 or mcjC
 
 RULE sactipeptide
+    CATEGORY RiPP
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS subtilosin or thuricin or TIGR04404 or TIGR03973
 
 RULE bottromycin
+    CATEGORY RiPP
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS botH
 
 RULE head_to_tail
+    CATEGORY RiPP
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS Subtilosin_A or skfc
 
 RULE microviridin
+    CATEGORY RiPP
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS mvd or mvnA
 
 RULE proteusin
+    CATEGORY RiPP
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS PoyD
 
 RULE blactam
+    CATEGORY other
     COMMENT beta-lactam
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS BLS or CAS or tabtoxin
 
 RULE amglyccycl
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS strH or strK1 or strK2 or NeoL or DOIS or ValA or SpcFG
                or SpcDK_glyc or salQ
 
 RULE aminocoumarin
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS novK or novJ or novI or novH or SpcDK_cou
 
 RULE siderophore
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 5
     CONDITIONS IucA_IucC
 
 RULE ectoine
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 5
     CONDITIONS ectoine_synt
 
 RULE NAGGN
+    CATEGORY other
     COMMENT N-acetylglutaminylglutamine amide cluster (Psyr_3747-Psyr_3749 in NC_007005.1)
             see https://doi.org/10.1128/AEM.00686-10
     CUTOFF 10
@@ -229,85 +264,101 @@ RULE NAGGN
                and (TIGR03106 or Peptidase_M42)               # aminopeptidase ggnC
 
 RULE butyrolactone
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 5
     CONDITIONS AfsA
 
 RULE indole
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS indsynth or dmat or indole_PTase
 
 RULE nucleoside
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS LipM or LipV or LipU or ToyB or TunD or pur6 or pur10 or nikJ or nikO or truD
 
 RULE phosphoglycolipid
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS MoeO5 or moeGT
 
 RULE melanin
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 5
     CONDITIONS melC
 
 RULE oligosaccharide
+    CATEGORY saccharide
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS minimum(3,[Glycos_transf_1,Glycos_transf_2,Glyco_transf_28,MGT,DUF1205])
                and minscore(MGT, 150)
 
 RULE furan
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS mmyO or AvrD
 
 RULE hserlactone
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS Autoind_synth
 
 RULE phenazine
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS phzB
 
 RULE phosphonate
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 20
     CONDITIONS phosphonates
 
 RULE fused
+    CATEGORY RiPP
     CUTOFF 20
     NEIGHBOURHOOD 10
     CONDITIONS pgm1 and pgm_amidino
 
 RULE other
+    CATEGORY other
     CUTOFF 20
     NEIGHBOURHOOD 20
     CONDITIONS LmbU or Neocarzinostat or fom1 or bcpB
                or frbD or mitE or vlmB or prnB or CaiA or bacilysin or orf2_PTase
 
 RULE acyl_amino_acids
+    CATEGORY other
     CUTOFF 30
     NEIGHBOURHOOD 30
     CONDITIONS NasY
 
 RULE PBDE
+    CATEGORY other
     COMMENT polybrominated diphenyl ethers (PBDEs) such as KX588877
     CUTOFF 10
     NEIGHBOURHOOD 10
     CONDITIONS FMO-like and p450 and DUF98
 
 RULE PpyS-KS
+    CATEGORY PKS
     COMMENT PPY-like specific ketosynthases (PPYSKS) such as KT373879
     CUTOFF 10
     NEIGHBOURHOOD 10
     CONDITIONS PpyS
 
 RULE betalactone
+    CATEGORY other
     COMMENT beta-lactone containing protease inhibitor such as KY249118
     RELATED RimK, Abhydrolase_6
     CUTOFF 10
@@ -315,6 +366,7 @@ RULE betalactone
     CONDITIONS HMGL-like and AMP-binding
 
 RULE RaS-RiPP
+    CATEGORY RiPP
     COMMENT streptide-like thioether-bond RiPPs such as FR875178
             See https://pubs.acs.org/doi/10.1021/jacs.8b11060 and
             https://pubs.acs.org/doi/full/10.1021/jacs.8b10266
@@ -323,6 +375,7 @@ RULE RaS-RiPP
     CONDITIONS PF04055 and TIGR01716
 
 RULE fungal-RiPP
+    CATEGORY RiPP
     COMMENT fungal RiPP with POP or UstH peptidase types and a modification
     CUTOFF 15
     NEIGHBOURHOOD 15
@@ -332,6 +385,7 @@ RULE fungal-RiPP
                DUF3328 and (Peptidase_S41 or Peptidase_S28 or pop or ustH)
 
 RULE tropodithietic-acid
+    CATEGORY other
     COMMENT tropodithietic acid like cluster as described in DOI: 10.1039/C4CC01924E
     CUTOFF 20
     NEIGHBOURHOOD 10

--- a/antismash/detection/hmm_detection/data/categories.json
+++ b/antismash/detection/hmm_detection/data/categories.json
@@ -1,0 +1,30 @@
+{
+    "PKS": {
+        "description": "Polyketide",
+        "version": 1
+    },
+    "NRPS": {
+        "description": "Nonribosomal peptide",
+        "version": 1
+    },
+    "RiPP": {
+        "description": "Ribosomally synthesized and post-translationally modified peptide",
+        "version": 1
+    },
+    "terpene": {
+        "description": "Terpene",
+        "version": 1
+    },
+    "saccharide": {
+        "description": "Saccharide",
+        "version": 1
+    },
+    "alkaloid": {
+        "description": "Alkaloid",
+        "version": 1
+    },
+    "other": {
+        "description": "Other",
+        "version": 1
+    }
+}

--- a/antismash/detection/hmm_detection/test/test_hmm_detection.py
+++ b/antismash/detection/hmm_detection/test/test_hmm_detection.py
@@ -62,12 +62,12 @@ class HmmDetectionTest(unittest.TestCase):
                            "a", "b", "c", "d"}
 
         self.rules = rule_parser.Parser("\n".join([
-                "RULE MetaboliteA CUTOFF 10 NEIGHBOURHOOD 5 CONDITIONS modelA",
-                "RULE MetaboliteB CUTOFF 10 NEIGHBOURHOOD 5 CONDITIONS cds(modelA and modelB)",
-                "RULE MetaboliteC CUTOFF 10 NEIGHBOURHOOD 5 CONDITIONS (modelA and modelB)",
-                "RULE MetaboliteD CUTOFF 20 NEIGHBOURHOOD 5 CONDITIONS minimum(2,[modelC,modelB]) and modelA",
-                "RULE Metabolite0 CUTOFF 1 NEIGHBOURHOOD 3 CONDITIONS modelF",
-                "RULE Metabolite1 CUTOFF 1 NEIGHBOURHOOD 3 CONDITIONS modelG"]), self.test_names).rules
+                "RULE MetaboliteA CATEGORY Cat CUTOFF 10 NEIGHBOURHOOD 5 CONDITIONS modelA",
+                "RULE MetaboliteB CATEGORY Cat CUTOFF 10 NEIGHBOURHOOD 5 CONDITIONS cds(modelA and modelB)",
+                "RULE MetaboliteC CATEGORY Cat CUTOFF 10 NEIGHBOURHOOD 5 CONDITIONS (modelA and modelB)",
+                "RULE MetaboliteD CATEGORY Cat CUTOFF 20 NEIGHBOURHOOD 5 CONDITIONS minimum(2,[modelC,modelB]) and modelA",
+                "RULE Metabolite0 CATEGORY Cat CUTOFF 1 NEIGHBOURHOOD 3 CONDITIONS modelF",
+                "RULE Metabolite1 CATEGORY Cat CUTOFF 1 NEIGHBOURHOOD 3 CONDITIONS modelG"]), self.test_names).rules
         self.features = []
         for gene_id in self.feature_by_id:
             self.features.append(self.feature_by_id[gene_id])
@@ -84,8 +84,8 @@ class HmmDetectionTest(unittest.TestCase):
     def test_overlaps_but_not_contains(self):
         # should get gene2 and gene3
         rules = rule_parser.Parser("\n".join([
-                "RULE Overlap CUTOFF 25 NEIGHBOURHOOD 5 CONDITIONS modelB and modelF "
-                "RULE OverlapImpossible CUTOFF 25 NEIGHBOURHOOD 5 CONDITIONS modelA and modelF"]),
+                "RULE Overlap CATEGORY Cat CUTOFF 25 NEIGHBOURHOOD 5 CONDITIONS modelB and modelF "
+                "RULE OverlapImpossible CATEGORY Cat CUTOFF 25 NEIGHBOURHOOD 5 CONDITIONS modelA and modelF"]),
                 self.test_names).rules
         detected_types, cluster_type_hits = hmm_detection.apply_cluster_rules(self.record, self.results_by_id, rules)
         assert detected_types == {"GENE_2": {"Overlap": {"modelB"}},


### PR DESCRIPTION
The idea here is that we can use the actual cluster rules to build the database's `bgc_types.sql` at some point in future.