### PR TITLE
Misc fixes

### DIFF
--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -660,8 +660,7 @@ class SingleCondition(Conditions):
             other_possibilities = [res.query_id for res in other_hits]
             if self.name in other_possibilities:
                 # a positive match, so we can exit early
-                if not self.negated:
-                    return ConditionMet(True)
+                return ConditionMet(not self.negated)
 
         # if negated and we failed to find anything, that's a good thing
         return ConditionMet(self.negated)

--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -343,7 +343,7 @@ class Details:
         parsing
     """
     def __init__(self, cds_name: str, feats: Dict[str, CDSFeature],
-                 results: Dict[str, HSP], cutoff: int) -> None:
+                 results: Dict[str, List[HSP]], cutoff: int) -> None:
         self.cds = cds_name  # str, name of cds that is being classified
         self.features_by_id = feats  # { id : feature }
         self.results_by_id = results  # { id : HSP list }

--- a/antismash/common/hmm_rule_parser/test/test_rule_parser.py
+++ b/antismash/common/hmm_rule_parser/test/test_rule_parser.py
@@ -112,8 +112,12 @@ class DetectionTest(unittest.TestCase):
         self.expect(results, ["GENE_1", "GENE_2"])
 
     def test_chained_and_a(self):
-        results = self.run_test("A", 10, 20, "a and b and not c")
-        self.expect(results, ["GENE_1"])  # 2 reaches c
+        # remove the c hit from GENE_2
+        self.results_by_id["GENE_2"] = [FakeHSPHit("a", "GENE_1", 0, 10, 50, 0)]
+        results = self.run_test("A", 25, 20, "a and b and not c")
+        # GENE_1 contains both
+        # GENE_2 contains a b, but reaches the c in GENE_3
+        self.expect(results, ["GENE_1"])
 
     def test_chained_and_b(self):
         results = self.run_test("A", 10, 20, "a and b and not cds(a and b)")

--- a/antismash/common/hmmer.py
+++ b/antismash/common/hmmer.py
@@ -133,7 +133,7 @@ class HmmerResults(module_results.ModuleResults):
 
 def build_hits(record: Record, hmmscan_results: List, min_score: float,
                max_evalue: float, database: str) -> List[HmmerHit]:
-    """ Builds PFAMDomains from the given hmmscan results
+    """ Builds HmmerHits from the given hmmscan results
 
         Arguments:
             record: the Record being scanned
@@ -143,7 +143,7 @@ def build_hits(record: Record, hmmscan_results: List, min_score: float,
             database: the name of the database used to find the hits
 
         Returns:
-            a list of JSON representations of hmmer hits
+            a list of HmmerHit instances
     """
     hits = []
     feature_by_id = record.get_cds_name_mapping()

--- a/antismash/detection/sideloader/__init__.py
+++ b/antismash/detection/sideloader/__init__.py
@@ -74,7 +74,8 @@ def get_arguments() -> ModuleArgs:
                     action=SideloadAction,
                     default="",
                     help=("Sideload a single subregion in record ACCESSION from START "
-                          "to END. Positions are "))
+                          "to END. Positions are expected to be 0-indexed, "
+                          "with START inclusive and END exclusive."))
     return args
 
 

--- a/antismash/modules/rrefinder/rrefinder.py
+++ b/antismash/modules/rrefinder/rrefinder.py
@@ -49,8 +49,8 @@ class RREFinderResults(ModuleResults):
 
     def convert_hits_to_features(self) -> None:
         """Convert all the hits found to features"""
-        domain_counts: Dict[str, int] = defaultdict(int)
         for locus_tag, hits in self.hits_by_cds.items():
+            domain_counts: Dict[str, int] = defaultdict(int)
             for hit in hits:
                 location = location_from_string(hit.location)
                 protein_location = FeatureLocation(hit.protein_start, hit.protein_end)
@@ -67,8 +67,7 @@ class RREFinderResults(ModuleResults):
                 rre_feature.detection = self.detection
 
                 domain_counts[hit.domain] += 1  # 1-indexed, so increment before use
-                rre_feature.domain_id = "{}_{}_{:04d}".format(self.tool, rre_feature.locus_tag,
-                                                              domain_counts[hit.domain])
+                rre_feature.domain_id = f"{self.tool}_{locus_tag}_{hit.domain}.{domain_counts[hit.domain]}"
 
                 self.features.append(rre_feature)
 

--- a/antismash/modules/rrefinder/rrefinder.py
+++ b/antismash/modules/rrefinder/rrefinder.py
@@ -189,16 +189,18 @@ def filter_hits(hits_by_cds: Dict[str, List[HmmerHit]], candidates_by_protoclust
                 min_length: int, bitscore_cutoff: float
                 ) -> Tuple[Dict[str, List[HmmerHit]], Dict[int, List[str]]]:
     '''Filter the hits based on the bitscore and length criteria'''
-    filtered_tags_by_protocluster: Dict[int, List[str]] = defaultdict(list)
-    filtered_hits_by_cds: Dict[str, List[HmmerHit]] = defaultdict(list)
+    filtered_hits_by_cds: Dict[str, List[HmmerHit]] = {}
+    for cds_name, hits in hits_by_cds.items():
+        trimmed_hits = [hit for hit in hits if check_hmm_hit(hit, min_length, bitscore_cutoff)]
+        if trimmed_hits:
+            filtered_hits_by_cds[cds_name] = trimmed_hits
+
+    filtered_tags_by_protocluster: Dict[int, List[str]] = {}
     for protocluster, locus_tags in candidates_by_protocluster.items():
-        for locus_tag in locus_tags:
-            for hit in hits_by_cds.get(locus_tag, []):
-                if check_hmm_hit(hit, min_length, bitscore_cutoff):
-                    filtered_hits_by_cds[locus_tag].append(hit)
-            if filtered_hits_by_cds.get(locus_tag):
-                filtered_tags_by_protocluster[protocluster].append(locus_tag)
-    return dict(filtered_hits_by_cds), dict(filtered_tags_by_protocluster)
+        trimmed = [locus for locus in locus_tags if locus in filtered_hits_by_cds]
+        if trimmed:
+            filtered_tags_by_protocluster[protocluster] = trimmed
+    return filtered_hits_by_cds, filtered_tags_by_protocluster
 
 
 def check_hmm_hit(hit: HmmerHit, min_length: int, bitscore_cutoff: float) -> bool:

--- a/antismash/modules/rrefinder/test/test_rrefinder.py
+++ b/antismash/modules/rrefinder/test/test_rrefinder.py
@@ -103,7 +103,7 @@ class TestRREResults(unittest.TestCase):
         assert feature.description == hit.description
         assert feature.domain == hit.domain
         assert feature.locus_tag == hit.locus_tag
-        assert feature.domain_id == '{}_{}_0001'.format(self.tool, hit.locus_tag)
+        assert feature.domain_id == '{}_{}_{}.1'.format(self.tool, hit.locus_tag, hit.domain)
         assert feature.database == self.database
         assert feature.detection == self.detection
         assert feature.score == hit.score


### PR DESCRIPTION
Major fixes:
 - a crash that could occur in `rrefinder` when multiple profiles hit the same CDS
 - detection rules with a `not` component could ignore that component under certain circumstances
 
Minor fixes:
- a typing issue in `hmm_rule_parser` that mypy doesn't detect
- `--sideloader-simple` help was incomplete
- `rrefinder` duplicated hits against CDS features when two or more relevant protoclusters included that CDS
- incorrect docstrings in `common.hmmer`