### PR TITLE
common.hmm_rule_parser: remove inferiors on overlap, not just contains

### DIFF
--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -12,7 +12,7 @@ from Bio.SearchIO._model.hsp import HSP
 
 from antismash.common import fasta, path, serialiser
 from antismash.common.secmet import Record, Protocluster, CDSFeature, FeatureLocation
-from antismash.common.secmet.locations import location_contains_other
+from antismash.common.secmet.locations import locations_overlap
 from antismash.common.secmet.qualifiers import GeneFunction, SecMetQualifier
 from antismash.common.subprocessing import run_hmmsearch
 from antismash.common.hmm_rule_parser import rule_parser
@@ -150,7 +150,7 @@ def remove_redundant_protoclusters(clusters: List[Protocluster],
         is_redundant = False
         for superior in rules_by_name[rule_name].superiors:
             for other_cluster in clusters_by_rule.get(superior, []):
-                if location_contains_other(other_cluster.core_location, cluster.core_location):
+                if locations_overlap(other_cluster.core_location, cluster.core_location):
                     is_redundant = True
                     break
             if is_redundant:

--- a/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
@@ -76,8 +76,7 @@ class TestRedundancy(unittest.TestCase):
     def test_larger(self):
         clusters = [self.create_cluster("inferior", 101, 110),
                     self.create_cluster("superior", 102, 109)]
-        print("testing clusters:", clusters)
-        assert self.remove(clusters) == clusters
+        assert self.remove(clusters) == [clusters[1]]
 
     def test_neighbourhoods_dont_matter(self):
         neighbourhood = self.rules_by_name["superior"].neighbourhood


### PR DESCRIPTION
Previously, nearly all rules with `SUPERIORS` specified were single CDS features and wouldn't create overlapping protoclusters. With the addition of the new RiPP rules, especially the `RRE-containing` rule, the previous method of filtering out 'inferior' types where the inferior was completely contained by the superior was insufficient and has been changed to be overlapping with any superior type.