### PR TITLE
Misc small additions and fixes

### DIFF
--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -292,7 +292,11 @@ class Feature:
         if leftovers:
             feature.created_by_antismash = leftovers.get("tool") == ["antismash"]
             if "codon_start" in leftovers:
-                codon_start = int(leftovers.pop("codon_start")[0]) - 1
+                try:
+                    raw_start = leftovers.pop("codon_start")
+                    codon_start = int(raw_start[0]) - 1
+                except ValueError as err:
+                    raise SecmetInvalidInputError(f"invalid codon_start qualifier: {raw_start}")
                 if not 0 <= codon_start <= 2:
                     raise SecmetInvalidInputError("invalid codon_start qualifier: %d" % (codon_start + 1))
                 feature._original_codon_start = codon_start  # very much private, so pylint: disable=protected-access

--- a/antismash/common/secmet/features/test/test_feature.py
+++ b/antismash/common/secmet/features/test/test_feature.py
@@ -137,7 +137,7 @@ class TestFeature(unittest.TestCase):
     def test_invalid_codon_start(self):
         seqf = SeqFeature(FeatureLocation(5, AfterPosition(12), -1))
         seqf.type = "test"
-        for codon_start in ["-1", "4"]:
+        for codon_start in ["-1", "4", "NA"]:
             seqf.qualifiers["codon_start"] = [codon_start]
             with self.assertRaisesRegex(ValueError, "invalid codon_start"):
                 Feature.from_biopython(seqf)

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -684,7 +684,7 @@ class Record:
 
         assert isinstance(seq_record, SeqRecord), type(seq_record)
         molecule_type = seq_record.annotations.get("molecule_type", "DNA")
-        if not molecule_type.endswith("DNA"):
+        if not molecule_type.upper().endswith("DNA"):
             raise SecmetInvalidInputError(f"{molecule_type} records are not supported")
         if seq_record.seq and not Record.is_nucleotide_sequence(seq_record.seq):
             raise SecmetInvalidInputError("protein records are not supported")

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -81,6 +81,16 @@ class TestConversion(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "protein records are not supported"):
             Record.from_biopython(before, taxon="bacteria")
 
+    def test_dna_casing(self):
+        before = list(Bio.SeqIO.parse(get_path_to_nisin_genbank(), "genbank"))[0]
+        for molecule in ["DNA", "dna", "Dna"]:
+            before.annotations["molecule_type"] = molecule
+            Record.from_biopython(before, taxon="bacteria")
+
+            before.annotations["molecule_type"] = molecule + "x"
+            with self.assertRaisesRegex(ValueError, "records are not supported"):
+                Record.from_biopython(before, taxon="bacteria")
+
     def test_missing_locations_caught(self):
         rec = list(Bio.SeqIO.parse(get_path_to_nisin_genbank(), "genbank"))[0]
         Record.from_biopython(rec, taxon="bacteria")

--- a/antismash/common/test/test_serialiser.py
+++ b/antismash/common/test/test_serialiser.py
@@ -14,7 +14,8 @@ from helperlibs.wrappers.io import TemporaryDirectory
 
 from antismash.common import serialiser
 from antismash.common.secmet import Record
-from antismash.common.test.helpers import get_path_to_nisin_genbank
+from antismash.common.secmet.test import helpers
+from antismash.common.test.helpers import DummyRecord, get_path_to_nisin_genbank
 
 
 class TestResultsJSON(unittest.TestCase):
@@ -94,3 +95,54 @@ class TestFeatureSerialiser(unittest.TestCase):
         assert new_feature.id == feature.id
         assert new_feature.type == feature.type
         assert str(new_feature.location) == str(new_feature.location)
+
+
+class TestAreas(unittest.TestCase):
+    def test_empty(self):
+        record = DummyRecord()
+        result = serialiser.gather_record_areas(record)
+        assert result == []
+
+    def test_complex(self):
+        protos = [
+            helpers.DummyProtocluster(core_start=3, core_end=22, neighbourhood_range=1, product='a'),
+            helpers.DummyProtocluster(core_start=33, core_end=48, neighbourhood_range=2, product='b'),
+        ]
+        candidates = [
+            helpers.DummyCandidateCluster(clusters=protos[:1]),
+            helpers.DummyCandidateCluster(clusters=protos, kind=helpers.DummyCandidateCluster.kinds.INTERLEAVED)
+        ]
+        subregion = helpers.DummySubRegion(start=55, end=90)
+        regions = [
+            helpers.DummyRegion(candidate_clusters=candidates, subregions=[]),
+            helpers.DummyRegion(candidate_clusters=[], subregions=[subregion]),
+        ]
+
+        record = DummyRecord(record_id="test", seq="A"*90,
+                             features=regions + [subregion] + candidates + protos)
+        results = serialiser.gather_record_areas(record)
+        assert results
+        assert len(results) == 2
+        res = results[0]
+        assert res["end"] == protos[1].location.end
+        assert res["products"] == [p.product for p in protos]
+        assert res["subregions"] == []
+        assert len(res["protoclusters"]) == 2
+        assert list(res["protoclusters"]) == [0, 1]
+        assert res["protoclusters"][1]["product"] == protos[1].product
+        assert len(res["candidates"]) == 2
+        assert res["candidates"][0]["protoclusters"] == [0]
+        assert res["candidates"][1]["protoclusters"] == [0, 1]
+
+        res = results[1]
+        assert res["start"] == subregion.location.start
+        assert res["subregions"]
+        assert res["subregions"][0]["start"] == subregion.location.start
+        assert res["subregions"][0]["tool"] == subregion.tool
+        assert res["subregions"][0]["label"] == subregion.label
+        assert not res["protoclusters"]
+
+        # lastly, check all this is properly embedded in the final JSON
+        bio = record.to_biopython()
+        full = serialiser.dump_records([bio], [{}], [record])
+        assert full[0]["areas"] == results

--- a/antismash/detection/genefinding/__init__.py
+++ b/antismash/detection/genefinding/__init__.py
@@ -6,6 +6,7 @@
 import logging
 from typing import List
 
+from antismash.common.errors import AntismashInputError
 from antismash.common.secmet import Record
 from antismash.config import ConfigType
 from antismash.config.args import ModuleArgs, ReadableFullPathAction
@@ -86,7 +87,7 @@ def run_on_record(record: Record, options: ConfigType) -> None:
         Genes will be added to the record as they are found.
     """
     if options.genefinding_tool == 'error':
-        raise ValueError("Called find_genes, but genefinding disabled")
+        raise AntismashInputError(f"Record {record.id} contains no genes and no genefinding tool specified")
 
     if options.taxon == 'fungi':
         if options.genefinding_tool == ["none"]:

--- a/antismash/outputs/html/__init__.py
+++ b/antismash/outputs/html/__init__.py
@@ -10,8 +10,12 @@ import logging
 import os
 import shutil
 from typing import Dict, List, Optional
+import warnings
 
-import scss
+# silence warnings about nested sets (relevant for pyScss <= 1.3.7 and python >= 3.5)
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    import scss
 
 from antismash.common import path
 from antismash.common.module_results import ModuleResults


### PR DESCRIPTION
The JSON output now includes a list of areas for each record, where previously they were derived from the other contents of the JSON. This should simplify things for people wanting something similar to the old spreadsheet style result and having to script it. 
This change is write-only so while the schema version is bumped (to 2), previous schema versions can still be reused with `--reuse-results`.

Other fixes:
- improves handling of some odd ways of specifying codon starts
- hides the pyScss Deprecation/FutureWarnings about nested sets, as users were thinking that was an error (can be removed when/if pyScss updates)
- changes the `ValueError` raised when `--genedfinding-tool` is set to `error` (the default), to a `AntismashInputError` so that the error message is displayed and the program exits cleanly (though still non-zero)