### PR TITLE
Handle bug in macOS py3.8+ changes to parallel functions and config

### DIFF
--- a/antismash/common/test/integration_mac_bug.py
+++ b/antismash/common/test/integration_mac_bug.py
@@ -1,0 +1,49 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+# for test files, silence irrelevant and noisy pylint warnings
+# pylint: disable=no-self-use,protected-access,missing-docstring
+
+from unittest import mock, TestCase
+
+from antismash import config
+from antismash.common import record_processing
+from antismash.common.test.helpers import get_path_to_nisin_fasta
+from antismash.detection import genefinding
+
+
+class TestMacBug(TestCase):
+    """ For python 3.8+ on mac, parallel behaviour of Pool() changed
+        from using fork() to spawn(), which meant that config objects
+        failed to serialise in the same way.
+
+        Since the parallel section involved is in record_processing, the
+        entry point is tested there.
+    """
+
+    def tearDown(self):
+        config.destroy_config()
+
+    def test_mac_bad_parallel(self):
+        # single cpu is important, the mock itself fails to pickle under py3.7
+        options = config.build_config(["--cpus", "1", "--genefinding-tool", "prodigal"],
+                                      isolated=True, modules=[genefinding])
+        config.update_config({
+            "genefinding_gff": "",
+            "genefinding_tool": "prodigal",
+            "taxon": "bacteria",
+        })
+
+        original = record_processing.ensure_cds_info
+
+        def wrapper(*args, **kwargs):
+            config.destroy_config()  # fake the bug's effect
+            return original(*args, **kwargs)
+
+        records = record_processing.parse_input_sequence(get_path_to_nisin_fasta())
+        assert len(records) == 1
+        assert not records[0].get_cds_features()
+
+        with mock.patch.object(record_processing, "ensure_cds_info", wraps=wrapper):
+            record_processing.pre_process_sequences(records, options, genefinding)
+        assert records[0].get_cds_features()

--- a/antismash/custom_typing.pyi
+++ b/antismash/custom_typing.pyi
@@ -7,7 +7,7 @@
 # pylint: disable=pointless-statement,unused-argument,missing-docstring,multiple-statements
 
 from types import ModuleType
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from .config.args import ModuleArgs
 
@@ -21,6 +21,8 @@ from .common.secmet import Region, Record
 class ConfigType:
     """ A type for the Config._Config object to ensure the right object types are
         being passed without all the warnings about non-existant members """
+
+    def __iter__(self) -> Iterator[Tuple[str, Any]]: ...
 
     def __getattr__(self, attr: str) -> Any: ...
 


### PR DESCRIPTION
Beginning in python 3.8 on macOS `multiprocessing.Pool` started using `spawn()` instead of `fork()`, which broke the singleton behaviour with `get_config()`. This only affected `record_processing` calling the gene finding detection module.

This fixes this specific issue by reconstructing the relevant options within the function needing them in the case that that the config object is empty.

Fixes #360 