### PR TITLE
Misc fixes

### DIFF
--- a/antismash/download_databases.py
+++ b/antismash/download_databases.py
@@ -394,6 +394,7 @@ def _main() -> None:
     )
 
     args = parser.parse_args()
+    antismash.config.update_config({"database_dir": args.database_dir})
     download(args)
     try:
         print("Pre-building all databases...")

--- a/antismash/modules/clusterblast/core.py
+++ b/antismash/modules/clusterblast/core.py
@@ -497,9 +497,12 @@ def internal_homology_blast(record: secmet.Record) -> Dict[int, List[List[str]]]
     """
     with TemporaryDirectory(change=True):
         logging.info("Finding internal homologs in each gene cluster...")
-        internalhomologygroups = {}
+        internalhomologygroups: Dict[int, List[List[str]]] = {}
         for region in record.get_regions():
             region_number = region.get_region_number()
+            if not region.cds_children:
+                internalhomologygroups[region_number] = []
+                continue
             iquerycluster_names, iqueryclusterseqs = create_blast_inputs(region)
             query_filename = "internal_input.fasta"
             fasta.write_fasta(iquerycluster_names, iqueryclusterseqs, query_filename)

--- a/antismash/modules/lanthipeptides/specific_analysis.py
+++ b/antismash/modules/lanthipeptides/specific_analysis.py
@@ -622,8 +622,10 @@ def result_vec_to_feature(orig_feature: CDSFeature, res_vec: Lanthipeptide) -> P
             a Prepeptide instance
     """
     assert res_vec.leader is not None
-    feature = Prepeptide(orig_feature.location, "lanthipeptide", res_vec.core,
-                         orig_feature.get_name(), "lanthipeptides", res_vec.lantype, res_vec.score,
+    product = "lanthipeptide"
+    name = f"{orig_feature.get_name()}_{product}"
+    feature = Prepeptide(orig_feature.location, product, res_vec.core,
+                         name, "lanthipeptides", res_vec.lantype, res_vec.score,
                          res_vec.monoisotopic_mass, res_vec.molecular_weight,
                          res_vec.alternative_weights, res_vec.leader)
     qual = LanthiQualifier(res_vec.number_of_lan_bridges,

--- a/antismash/modules/lanthipeptides/templates/details.html
+++ b/antismash/modules/lanthipeptides/templates/details.html
@@ -14,7 +14,7 @@
       <dl class="details-text">
         {% for motif in results[locus] %}
           <dt>
-            <span class="serif">{{motif.get_name()}}</span> leader / core peptide
+            <span class="serif">{{motif.get_name().rsplit("_", 1)[0]}}</span> leader / core peptide
           </dt>
           <dd>
             {{ motif.leader }}

--- a/antismash/modules/lanthipeptides/templates/sidepanel.html
+++ b/antismash/modules/lanthipeptides/templates/sidepanel.html
@@ -7,7 +7,7 @@
     <dl class ="prediction-text">
     {% for motifs in results.values() %}
     {%- for motif in motifs -%}
-      <dt><span class="serif">{{motif.get_name()}}</span> - {{motif.peptide_subclass}}</dt>
+      <dt><span class="serif">{{motif.get_name().rsplit("_", 1)[0]}}</span> - {{motif.peptide_subclass}}</dt>
         <dd>Cleavage pHMM score: {{'%0.2f' | format(motif.score)}}</dd>
         <dd>RODEO score: {{motif.detailed_information.rodeo_score}}</dd>
         <dd>Monoisotopic mass: {{'%0.1f' | format(motif.monoisotopic_mass)}} Da</dd>

--- a/antismash/modules/lanthipeptides/test/integration_lanthipeptides.py
+++ b/antismash/modules/lanthipeptides/test/integration_lanthipeptides.py
@@ -130,11 +130,11 @@ class IntegrationLanthipeptides(unittest.TestCase):
         rec, _ = self.run_lanthi(filename, expected_snippet, expected_motifs=2)
         motifs = sorted(rec.get_cds_motifs(), key=lambda x: x.locus_tag)
 
-        assert motifs[0].locus_tag == "labA1"
+        assert motifs[0].locus_tag == "labA1_lanthipeptide"
         assert motifs[0].detailed_information.lan_bridges == 4
         self.assertAlmostEqual(motifs[0].molecular_weight, 2059.3, delta=0.5)
 
-        assert motifs[1].locus_tag == "labA2"
+        assert motifs[1].locus_tag == "labA2_lanthipeptide"
         assert motifs[1].detailed_information.lan_bridges == 4
         self.assertAlmostEqual(motifs[1].molecular_weight, 1908.1, delta=0.5)
 
@@ -161,7 +161,7 @@ class IntegrationLanthipeptides(unittest.TestCase):
         assert len(motifs) == 1
 
         assert motifs[0].peptide_subclass == "Class II"
-        assert motifs[0].locus_tag == "lasA"
+        assert motifs[0].locus_tag == "lasA_lanthipeptide"
 
     def test_multiple_biosynthetic_enzymes(self):
         # TODO: find/create an input with both class II and class III lanthipeptides

--- a/antismash/modules/lanthipeptides/test/test_specific_analysis.py
+++ b/antismash/modules/lanthipeptides/test/test_specific_analysis.py
@@ -114,7 +114,7 @@ class TestSpecificAnalysis(unittest.TestCase):
         assert motif.location.start == 0
         assert motif.location.end == 165
         assert motif.location.strand == 1
-        assert motif.locus_tag == orig_feature.locus_tag
+        assert motif.locus_tag == f"{orig_feature.locus_tag}_{motif.peptide_class}"
         assert motif.score == 42
         assert motif.detailed_information.rodeo_score == 23
         assert motif.peptide_class == "lanthipeptide"

--- a/antismash/modules/lassopeptides/specific_analysis.py
+++ b/antismash/modules/lassopeptides/specific_analysis.py
@@ -681,7 +681,9 @@ def result_vec_to_motif(query: CDSFeature, result: Lassopeptide) -> Prepeptide:
     cut_mass = result.cut_mass
     cut_weight = result.cut_weight
 
-    feature = Prepeptide(query.location, "lassopeptide", core, query.get_name(), "lassopeptides",
+    product = "lassopeptide"
+    name = f"{query.get_name()}_{product}"
+    feature = Prepeptide(query.location, product, core, name, "lassopeptides",
                          peptide_subclass=result.lasso_class,
                          score=result.score, monoisotopic_mass=result.monoisotopic_mass,
                          molecular_weight=weight,

--- a/antismash/modules/lassopeptides/templates/details.html
+++ b/antismash/modules/lassopeptides/templates/details.html
@@ -13,7 +13,7 @@
     <hr>
       <dl class="details-text">
         {% for motif in results[locus] %}
-          <dt><span class="serif">{{motif.get_name()}}</span> leader / core peptide / cleaved tail</dt>
+          <dt><span class="serif">{{motif.get_name().rsplit("_", 1)[0]}}</span> leader / core peptide / cleaved tail</dt>
           <dd>
             {{ motif.leader }}
             -

--- a/antismash/modules/lassopeptides/templates/sidepanel.html
+++ b/antismash/modules/lassopeptides/templates/sidepanel.html
@@ -7,7 +7,7 @@
   <dl class ="prediction-text">
     {% for motifs in results.values() %}
     {%- for motif in motifs -%}
-    <dt><span class="serif">{{motif.get_name()}}</span> - {{motif.peptide_subclass}}</dt>
+    <dt><span class="serif">{{motif.get_name().rsplit("_", 1)[0]}}</span> - {{motif.peptide_subclass}}</dt>
       <dd>Cleavage pHMM score: {{'%0.2f' | format(motif.score)}}</dd>
       <dd>RODEO score: {{motif.detailed_information.rodeo_score}}</dd>
       <dd>Monoisotopic mass: {{'%0.1f' | format(motif.detailed_information.cut_mass)}} Da</dd>

--- a/antismash/modules/lassopeptides/test/test_specific_analysis.py
+++ b/antismash/modules/lassopeptides/test/test_specific_analysis.py
@@ -117,7 +117,7 @@ class TestSpecificAnalysis(unittest.TestCase):
         vec = Lassopeptide(23, 42, 51, "HEADHEADHEAD", seq)
         vec.c_cut = "TIP"
         motif = result_vec_to_motif(orig_feature, vec)
-        assert motif.locus_tag == "FAKE0001"
+        assert motif.locus_tag == f"{orig_feature.locus_tag}_{motif.peptide_class}"
         assert motif.location == orig_feature.location
         assert motif.leader == "HEADHEADHEAD"
         assert motif.tail == "TIP"

--- a/antismash/modules/sactipeptides/specific_analysis.py
+++ b/antismash/modules/sactipeptides/specific_analysis.py
@@ -530,7 +530,9 @@ def determine_precursor_peptide_candidate(cluster: secmet.Protocluster, query: s
     valid, score = run_rodeo(cluster, query, leader, core, domains)
     if not valid:
         return None
-    return secmet.Prepeptide(query.location, "sactipeptide", core, query.get_name(),
+    product = "sactipeptide"
+    name = f"{query.get_name()}_{product}"
+    return secmet.Prepeptide(query.location, product, core, name,
                              tool="sactipeptides", leader=leader, score=score)
 
 

--- a/antismash/modules/sactipeptides/templates/details.html
+++ b/antismash/modules/sactipeptides/templates/details.html
@@ -13,7 +13,7 @@
     <hr>
       <dl class="details-text">
         {% for motif in results[locus] %}
-        <dt><span class="serif">{{motif.get_name()}}</span> leader / core peptide</dt>
+        <dt><span class="serif">{{motif.get_name().rsplit("_", 1)[0]}}</span> leader / core peptide</dt>
         <dd>
           {{ motif.leader }} - {{motif.core}}
         </dd>

--- a/antismash/modules/sactipeptides/templates/sidepanel.html
+++ b/antismash/modules/sactipeptides/templates/sidepanel.html
@@ -7,7 +7,7 @@
   <dl class ="prediction-text">
   {% for motifs in results.values() %}
     {%- for motif in motifs -%}
-    <dt><span class="serif">{{motif.get_name()}}</span></dt>
+    <dt><span class="serif">{{motif.get_name().rsplit("_", 1)[0]}}</span></dt>
       <dd>Putative sactipeptide</dd>
       <dd>RODEO score: {{motif.score}}</dd>
       <dd>Core sequence, approximate: {{motif.core}}</dd>

--- a/antismash/modules/sactipeptides/test/integration_sactipeptides.py
+++ b/antismash/modules/sactipeptides/test/integration_sactipeptides.py
@@ -33,7 +33,7 @@ class IntegrationSactipeptides(unittest.TestCase):
         prepeptide = result.motifs_by_locus["BEST7613_6887"][0]
         assert prepeptide.location.start == 9735
         assert prepeptide.location.end == 9867
-        assert prepeptide.get_name() == "BEST7613_6887"
+        assert prepeptide.get_name() == "BEST7613_6887_sactipeptide"
         assert prepeptide.leader == "MKKAVIVENK"
         assert prepeptide.core == "GCATCSIGAACLVDGPIPDFEIAGATGLFGLWG"
         self.assertAlmostEqual(prepeptide.score, 33.)
@@ -46,7 +46,7 @@ class IntegrationSactipeptides(unittest.TestCase):
         prepeptide = result.motifs_by_locus["allorf_09736_09867"][0]
         assert prepeptide.location.start == 9735
         assert prepeptide.location.end == 9867
-        assert prepeptide.get_name() == "allorf_09736_09867"
+        assert prepeptide.get_name() == "allorf_09736_09867_sactipeptide"
         assert prepeptide.leader == "MKKAVIVENK"
         assert prepeptide.core == "GCATCSIGAACLVDGPIPDFEIAGATGLFGLWG"
         self.assertAlmostEqual(prepeptide.score, 33.)

--- a/antismash/modules/thiopeptides/specific_analysis.py
+++ b/antismash/modules/thiopeptides/specific_analysis.py
@@ -572,7 +572,9 @@ def result_vec_to_feature(orig_feature: secmet.CDSFeature, res_vec: Thiopeptide)
     mature_weights: List[float] = []
     if res_vec.thio_type != "Type III":
         mature_weights = res_vec.mature_alt_weights
-    feature = secmet.Prepeptide(orig_feature.location, "thiopeptide", res_vec.core, orig_feature.get_name(),
+    product = "thiopeptide"
+    name = f"{orig_feature.get_name()}_{product}"
+    feature = secmet.Prepeptide(orig_feature.location, product, res_vec.core, name,
                                 "thiopeptides", res_vec.thio_type, res_vec.score, res_vec.monoisotopic_mass,
                                 res_vec.molecular_weight, res_vec.alternative_weights,
                                 leader=res_vec.leader, tail=res_vec.c_cut)

--- a/antismash/modules/thiopeptides/templates/details.html
+++ b/antismash/modules/thiopeptides/templates/details.html
@@ -12,7 +12,7 @@
     <hr>
     <dl class="details-text">
       {% for motif in cluster.motifs if motif.peptide_class == "thiopeptide" %}
-        <dt> {{motif.locus_tag}} leader / core peptide, putative {{motif.peptide_subclass}} </dt>
+        <dt> {{motif.locus_tag.rsplit("_", 1)[0]}} leader / core peptide, putative {{motif.peptide_subclass}} </dt>
         <dd>
           {{ motif.leader }}
           -

--- a/antismash/modules/thiopeptides/templates/sidepanel.html
+++ b/antismash/modules/thiopeptides/templates/sidepanel.html
@@ -6,7 +6,7 @@
   {% if cluster.motifs %}
   <dl class ="prediction-text">
   {% for motif in cluster.motifs %}
-     <dt>{{motif.locus_tag}}</dt>
+     <dt>{{motif.locus_tag.rsplit("_", 1)[0]}}</dt>
       <dd>Putative {{motif.peptide_subclass}}</dd>
         <dd>Cleavage pHMM score: {{'%0.2f' | format(motif.score)}}</dd>
         <dd>RODEO score: {{motif.detailed_information.rodeo_score}}</dd>

--- a/antismash/modules/thiopeptides/test/test_thio_specific_analysis.py
+++ b/antismash/modules/thiopeptides/test/test_thio_specific_analysis.py
@@ -145,7 +145,7 @@ class TestSpecificAnalysis(unittest.TestCase):
         assert motif.type == 'CDS_motif'
         assert motif.peptide_class == "thiopeptide"
         assert motif.peptide_subclass == "Type III"
-        assert orig_feature.locus_tag == motif.locus_tag
+        assert motif.locus_tag == f"{orig_feature.locus_tag}_{motif.peptide_class}"
         assert motif.detailed_information.rodeo_score == 51
         assert motif.score == 42
         self.assertAlmostEqual(motif.molecular_weight, 861.9, places=1)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ long_description = read('README.md')
 
 install_requires = [
     'numpy',
-    'biopython >=1.78',
+    'biopython == 1.78',
     'helperlibs',
     'jinja2',
     'joblib',


### PR DESCRIPTION
Pins `biopython` version to 1.78, as 1.79 changes the handling of inputs without sequence info (e.g. WGS inputs). The change breaks the check that works with 1.78, but the one that works with 1.79 (raising `Bio.Seq.UndefinedSequenceError` on use) doesn't exist in 1.78.

Fixes crashes due to:
- clusterblast processing sideloaded regions containing no CDS features
- RiPP modules conflicting when attempting to add prepeptide features sharing the same CDS feature (fixed by appending the RiPP type to the new feature's name)

Also fixes #370, where the post-download data preparation step didn't propagate the database directory correctly.