### PR TITLE
Small fixes

### DIFF
--- a/antismash/common/html_renderer.py
+++ b/antismash/common/html_renderer.py
@@ -9,7 +9,7 @@ import os
 from typing import Any, List, Optional
 
 import jinja2 as _jinja2
-from jinja2 import Markup
+from markupsafe import Markup
 
 from antismash.config import get_config
 

--- a/antismash/modules/nrps_pks/at_analysis/at_analysis.py
+++ b/antismash/modules/nrps_pks/at_analysis/at_analysis.py
@@ -5,9 +5,8 @@
 
 from typing import Any, Dict, List, Tuple
 
-from jinja2 import Markup
-
 from antismash.common import path, subprocessing, utils, fasta
+from antismash.common.html_renderer import Markup
 from antismash.modules.nrps_pks.data_structures import Prediction
 from antismash.modules.nrps_pks.pks_names import get_long_form
 

--- a/antismash/modules/nrps_pks/data_structures.py
+++ b/antismash/modules/nrps_pks/data_structures.py
@@ -5,7 +5,7 @@
 
 from typing import Any, Dict, List
 
-from jinja2 import Markup
+from antismash.common.html_renderer import Markup
 
 
 class Prediction:

--- a/antismash/modules/nrps_pks/minowa/base.py
+++ b/antismash/modules/nrps_pks/minowa/base.py
@@ -9,9 +9,8 @@ import logging
 from os import path
 from typing import Any, Dict, List, Tuple
 
-from jinja2 import Markup
-
 from antismash.common import subprocessing, utils
+from antismash.common.html_renderer import Markup
 from antismash.modules.nrps_pks.data_structures import Prediction
 
 

--- a/antismash/modules/nrps_pks/nrps_predictor.py
+++ b/antismash/modules/nrps_pks/nrps_predictor.py
@@ -11,9 +11,9 @@ import sys
 from typing import Any, Dict, List, Set
 
 from helperlibs.wrappers.io import TemporaryDirectory
-from jinja2 import Markup
 
 from antismash.common import path, subprocessing
+from antismash.common.html_renderer import Markup
 from antismash.config import ConfigType
 from antismash.detection.nrps_pks_domains import ModularDomain
 

--- a/antismash/modules/nrps_pks/test/test_nrps_predictor.py
+++ b/antismash/modules/nrps_pks/test/test_nrps_predictor.py
@@ -7,9 +7,9 @@
 import unittest
 from unittest.mock import patch
 
-from jinja2 import Markup
 
 from antismash.common import path, fasta, subprocessing
+from antismash.common.html_renderer import Markup
 from antismash.common.test.helpers import DummyAntismashDomain
 from antismash.modules.nrps_pks import nrps_predictor, data_structures
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ install_requires = [
     'jinja2',
     'joblib',
     'jsonschema',
+    'markupsafe >= 2.0',
     'pysvg-py3',
     'bcbio-gff',
     'pyScss',


### PR DESCRIPTION
Fixes genes and other non-CDS features from GFF inputs not being added to records (specifically fixes an issue where CASSIS was rendered useless with GFF inputs).

Also pins the version of `jinja2` and `markupsafe` to avoid issues with deprecations in newer `jinja2`.