### PR TITLE
common.record_processing: catch bad qualifier warnings early

### DIFF
--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -38,6 +38,7 @@ def _strict_parse(filename: str) -> List[SeqRecord]:
         r".*invalid location.*",
         r".*Expected sequence length.*",
         r".*Couldn't parse feature location.*",
+        r".*double-quote characters.*should be escaped.*",
     ]
     try:
         # prepend warning filters to raise exceptions on certain messages

--- a/antismash/common/test/data/incomplete_qualifier.gbk
+++ b/antismash/common/test/data/incomplete_qualifier.gbk
@@ -1,0 +1,22 @@
+LOCUS       Dummy                  15016 bp    DNA     linear   BCT 05-OCT-2011
+DEFINITION  a.
+ACCESSION   a
+VERSION     a
+KEYWORDS    .
+SOURCE      
+  ORGANISM  
+COMMENT     Missing the closing quote is detected by biopython, but it carries
+            on anyway, resulting in incorrect qualifiers and, in this particular
+            case, a failure to properly strip the feature pre-analysis as it no
+            longer has the `tool` qualifier.
+            .
+FEATURES             Location/Qualifiers
+     feature         1234..2345
+                     /monomer_pairings="tyr -
+                     /tool="antismash"
+ORIGIN
+         1 tctcttaact ccgtgtctag tttttcgttg actttccatt atgcttggat tttttattgt
+        61 ttaattccct ttttttgtat acaagctcgt attcttaaca aataattggc atatcgggtt
+       121 taaaaatact atgtgtttta aagaatctct catgagtttg acgccaataa cttagattaa
+       181 aatcaccgtc accttatttt taggcacgtt cggcagtaac cttatcaaag gtatctcagt
+//

--- a/antismash/common/test/test_record_processing.py
+++ b/antismash/common/test/test_record_processing.py
@@ -63,6 +63,12 @@ class TestParseRecords(unittest.TestCase):
             with self.assertRaisesRegex(AntismashInputError, "no valid records found"):
                 record_processing.parse_input_sequence(temp.name)
 
+    def test_malformed_qualifiers(self):
+        filepath = path.get_full_path(__file__, "data", "incomplete_qualifier.gbk")
+        warning = "double-quote characters like \" should be escaped"
+        with self.assertRaisesRegex(AntismashInputError, warning):
+            record_processing.parse_input_sequence(filepath)
+
 
 class TestGapNotation(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Biopython is too permissive with malformed qualifiers, leading to failures later on when features don't have expected information or aren't handled correctly.

This PR converts a `BiopythonParserWarning` in the form of:
```
The NCBI states double-quote characters like " should be escaped as "" (two double - quotes), but here it was not: ...
```
into an exception instead, so it progresses no further in the pipeline.