### PR TITLE
secmet: Fix locus tag duplicates even if the conflicting CDSes only overlap with a gene feature of the same name

### DIFF
--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -158,11 +158,13 @@ class Feature:
         assert qualifier is None
         return True
 
-    def overlaps_with(self, other: Union["Feature", Location]) -> bool:
+    def overlaps_with(self, other: Union["Feature", Location, None]) -> bool:
         """ Returns True if the given feature overlaps with this feature.
             This operation is commutative, a.overlaps_with(b) is equivalent to
             b.overlaps_with(a).
         """
+        if other is None:
+            return False
         if isinstance(other, Feature):
             location = other.location
         elif isinstance(other, (CompoundLocation, FeatureLocation)):

--- a/antismash/common/secmet/features/test/test_module.py
+++ b/antismash/common/secmet/features/test/test_module.py
@@ -19,13 +19,13 @@ def create_module(domains=None, **kwargs):
 
 
 def add_module_references_to_record(module, record):
-    for domain in module.domains:
+    for i, domain in enumerate(module.domains):
         record.add_antismash_domain(domain)
         try:
             record.get_cds_by_name(domain.locus_tag)
         except KeyError:
-            record.add_cds_feature(DummyCDS(start=max(0, module.location.start - 10),
-                                            end=module.location.end + 10,
+            record.add_cds_feature(DummyCDS(start=max(i, module.location.start - 10),
+                                            end=module.location.end + 10 + i,
                                             locus_tag=domain.locus_tag))
 
 

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -791,7 +791,7 @@ class TestCDSUniqueness(unittest.TestCase):
         record = Record("A" * 100)
         cds = CDSFeature(FeatureLocation(0, 6, 1), locus_tag="test", translation="MA")
         record.add_cds_feature(cds)
-        with self.assertRaisesRegex(ValueError, "same name for mapping"):
+        with self.assertRaisesRegex(ValueError, "same location"):
             record.add_cds_feature(cds)
 
         cds = CDSFeature(FeatureLocation(3, 9, 1), locus_tag="test", protein_id="prot", translation="MA")
@@ -800,14 +800,18 @@ class TestCDSUniqueness(unittest.TestCase):
 
         # still a duplicate
         cds = CDSFeature(FeatureLocation(3, 9, 1), locus_tag="test", protein_id="prot", translation="MA")
-        with self.assertRaisesRegex(ValueError, "same name for mapping"):
+        with self.assertRaisesRegex(ValueError, "same location"):
             record.add_cds_feature(cds)
+
+        # reverse strand, same coordinates are fine
+        cds = CDSFeature(FeatureLocation(0, 6, -1), locus_tag="test_reverse", translation="MA")
+        record.add_cds_feature(cds)
 
     def test_nonoverlapping_location(self):
         record = Record("A" * 100)
         cds = CDSFeature(FeatureLocation(0, 6, 1), locus_tag="test", translation="MA")
         record.add_cds_feature(cds)
-        with self.assertRaisesRegex(ValueError, "same name for mapping"):
+        with self.assertRaisesRegex(ValueError, "same location"):
             record.add_cds_feature(cds)
 
         cds = CDSFeature(FeatureLocation(12, 18, 1), locus_tag="test", protein_id="prot", translation="MA")


### PR DESCRIPTION

Signed-off-by: Kai Blin <kblin@biosustain.dtu.dk>