### PR TITLE
Fix incorrect merging of cross-CDS NRPS/PKS modules

### DIFF
--- a/antismash/detection/nrps_pks_domains/domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/domain_identification.py
@@ -224,6 +224,7 @@ def generate_domains(record: Record) -> NRPSPKSDomains:
         domains = cds_domains.get(cds.get_name(), [])
         motifs = cds_motifs.get(cds.get_name(), [])
         if not (domains or motifs):
+            prev = None
             continue
         subtype_names = match_subtypes_to_ks_domains(domains, cds_ks_subtypes.get(cds.get_name(), []))
         domain_type = classify_cds([domain.hit_id for domain in domains], subtype_names)

--- a/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
@@ -5,7 +5,10 @@
 # pylint: disable=no-self-use,protected-access,missing-docstring
 
 import unittest
+from unittest.mock import patch
 
+from antismash.common import fasta
+from antismash.common.secmet import Record
 from antismash.common.test.helpers import DummyCDS, DummyHMMResult, DummyRecord
 from antismash.detection.nrps_pks_domains import domain_identification
 
@@ -193,3 +196,55 @@ class TestKSSubtypeMatching(unittest.TestCase):
             DummyHMMResult("trans-AT", start=99, end=139)
         ]
         assert self.func(domains, sub_hits) == ["", "trans-AT"]
+
+
+@patch.object(fasta, "get_fasta_from_features", return_value={})
+@patch.object(domain_identification, "find_ab_motifs", return_value={})
+class TestModuleMerging(unittest.TestCase):
+    def setUp(self):
+        self.record = DummyRecord(seq="A"*300)
+        self.cdses = {
+            "head": DummyCDS(locus_tag="head", start=0, end=90),
+            "tail": DummyCDS(locus_tag="tail", start=200, end=290),
+        }
+        for cds in self.cdses.values():
+            self.record.add_cds_feature(cds)
+
+        self.domains = {
+            "head": [DummyHMMResult("PKS_KS", start=0, end=10), DummyHMMResult("PKS_AT", start=20, end=30)],
+            "tail": [DummyHMMResult("PKS_ER", start=0, end=10), DummyHMMResult("PP-binding", start=10, end=20)],
+        }
+        self.ks_subtypes = {'head': [DummyHMMResult("Iterative-KS", start=0, end=10)]}
+
+    def test_merge(self, _patched_fasta, _patched_motifs):
+        cdses = self.record.get_cds_features()
+        with patch.object(Record, "get_cds_features_within_regions", return_value=cdses):
+            with patch.object(domain_identification, "find_domains", return_value=self.domains):
+                with patch.object(domain_identification, "find_ks_domains", return_value=self.ks_subtypes):
+                    results = domain_identification.generate_domains(self.record)
+        assert results
+        head = results.cds_results[self.cdses["head"]]
+        tail = results.cds_results[self.cdses["tail"]]
+        assert len(head.modules) == 1
+        assert len(tail.modules) == 0  # should have merged into the head
+        module = head.modules[0]
+        assert module.is_complete()  # only because it was merged
+
+    def test_interrupted_merge(self, _patched_fasta, _patched_motifs):
+        # insert the interrupt CDS between the two "halves" of the potential module
+        spacer_cds = DummyCDS(locus_tag="mid", start=100, end=130)
+        self.record.add_cds_feature(spacer_cds)
+
+        cdses = self.record.get_cds_features()
+        with patch.object(Record, "get_cds_features_within_regions", return_value=cdses):
+            with patch.object(domain_identification, "find_domains", return_value=self.domains):
+                with patch.object(domain_identification, "find_ks_domains", return_value=self.ks_subtypes):
+                    results = domain_identification.generate_domains(self.record)
+        assert results
+        head = results.cds_results[self.cdses["head"]]
+        assert spacer_cds not in results.cds_results
+        tail = results.cds_results[self.cdses["tail"]]
+        assert len(head.modules) == 1
+        assert len(tail.modules) == 1  # should *not* have merged into head
+        assert not head.modules[0].is_complete()
+        assert not tail.modules[0].is_complete()


### PR DESCRIPTION
It was possible for NRPS/PKS modules to be formed when the genes in question weren't sequential. This is now fixed.

This also incidentally fixes a crash in the bubbles visualiser that occurred when a module like this was generated and crossed candidate cluster boundaries,