### PR TITLE
ClusterCompare MIBiG database update

### DIFF
--- a/antismash/download_databases.py
+++ b/antismash/download_databases.py
@@ -31,9 +31,9 @@ CLUSTERBLAST_FASTA_CHECKSUM = "ea43624407ae399cd6e78bf2e6868e9ff0b9581f333645063
 
 CLUSTERCOMPARE_DBS = {
     "mibig": {
-        "url": "https://dl.secondarymetabolites.org/releases/clustercompare/cc_mibig_20201210.tar.xz",
-        "archive": "25bc9ce7d09f8325d93c0345367def76147e0c6c4c8bd5adbd2ecc79a1827170",
-        "fasta": "3fe75f4a95823297ea14817da328000f160f15e5e78335c629812a6cc0c64dcf",
+        "url": "https://dl.secondarymetabolites.org/releases/clustercompare/cc_mibig_20211216.tar.xz",
+        "archive": "47eb75862e2e11a10664a0ca5f40fed3285f96e18c48ebe19ccb46ddd0fd2c3e",
+        "fasta": "4470c429601aa5cf0b0ecd3fa785fccceaf6eaeb7f92599d835429348bd6f52b",
     },
 }
 

--- a/antismash/modules/cluster_compare/data/build_cluster_compare.py
+++ b/antismash/modules/cluster_compare/data/build_cluster_compare.py
@@ -39,9 +39,19 @@ def convert_module(module: secmet.Module) -> Dict[str, Any]:
 
 
 def convert_cds(cds: secmet.CDSFeature) -> Dict[str, Any]:
+    function = secmet.GeneFunction.OTHER
+    if cds.gene_function == secmet.GeneFunction.CORE:
+        function = secmet.GeneFunction.CORE
+    else:
+        annotations = cds.gene_functions.get_by_tool("smcogs")
+        if not annotations:
+            annotations = cds.gene_functions.get_by_tool("rule-based-clusters")
+        if annotations:
+            function = annotations[0].function
+
     result = {
         "location": str(cds.location),
-        "function": str(cds.gene_function),
+        "function": str(function),
         "components": {
             "secmet": [] if not cds.sec_met else cds.sec_met.domain_ids,
             "modules": [convert_module(module) for module in cds.modules],

--- a/antismash/modules/cluster_compare/data/build_cluster_compare.py
+++ b/antismash/modules/cluster_compare/data/build_cluster_compare.py
@@ -120,7 +120,8 @@ def convert_all_mibig(input_dir: str, output_dir: str, accessions: List[str]) ->
                     converted = convert_record(record, fasta, skip_contig_edge=False)
                     converted["regions"][0]["products"] = mibig_data["cluster"]["biosyn_class"]
                     if mibig_data["cluster"].get("other", {}).get("subclass"):
-                        converted["regions"][0]["products"] += " (%s)" % mibig_data["cluster"]["other"]["subclass"]
+                        index = converted["regions"][0]["products"].index("Other")
+                        converted["regions"][0]["products"][index] += " (%s)" % mibig_data["cluster"]["other"]["subclass"]
                     converted["regions"][0]["organism"] = mibig_data["cluster"]["organism_name"]
                     converted["regions"][0]["description"] = ", ".join([compound["compound"] for compound in mibig_data["cluster"]["compounds"]])
                     result[record.id] = converted


### PR DESCRIPTION
With the addition of new NRPS/PKS profiles and changes to how NRPS/PKS modules are detected, and many other changes, the accuracy of the clustercompare comparisons was decreasing.

This PR uses the current master of antiSMASH on MIBiG JSON as at `2.0-11abfec` to regenerate the comparison database.

Some fixes for the database generation are also included:
- gene function now only considers detection-stage gene function annotations
- subclasses of `Other` category MIBiG entries no longer build with mistaken comma joins for each character in the subclass
- the `--mibig` build option now takes a file with accessions to include, to more easily separate pending and active entries that may reside in the same input directory