### PR TITLE
secmet: handle biopython introducing spaces into locus tags

### DIFF
--- a/antismash/common/secmet/features/antismash_domain.py
+++ b/antismash/common/secmet/features/antismash_domain.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Type, TypeVar
 from Bio.SeqFeature import SeqFeature
 
 from .domain import Domain, generate_protein_location_from_qualifiers
-from .feature import Feature, FeatureLocation, Location
+from .feature import Feature, FeatureLocation, Location, pop_locus_qualifier
 
 T = TypeVar("T", bound="AntismashDomain")
 
@@ -47,7 +47,8 @@ class AntismashDomain(Domain):
             tool = leftovers.pop("aSTool")[0]
             protein_location = generate_protein_location_from_qualifiers(leftovers, record)
             # locus tag is special, antismash versions <= 5.0 didn't require it, but > 5.0 do
-            locus_tag = leftovers.pop("locus_tag", ["(unknown)"])[0]
+            locus_tag = pop_locus_qualifier(leftovers)
+            assert locus_tag  # even if it's just the default "(unknown)"
             feature = cls(bio_feature.location, tool, protein_location, locus_tag)
 
         # for any instance, populate with the superclass info

--- a/antismash/common/secmet/features/antismash_feature.py
+++ b/antismash/common/secmet/features/antismash_feature.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Type, TypeVar
 from Bio.SeqFeature import SeqFeature
 
 from ..errors import SecmetInvalidInputError
-from .feature import Feature, Location
+from .feature import Feature, Location, pop_locus_qualifier
 
 T = TypeVar("T", bound="AntismashFeature")
 
@@ -124,7 +124,7 @@ class AntismashFeature(Feature):
             # again, long ids causing linebreaks in genbanks can have spaces inserted
             feature.label = feature.label.replace(" ", "")
         if not feature.locus_tag:  # may already be populated
-            feature.locus_tag = leftovers.pop("locus_tag", [""])[0] or None
+            feature.locus_tag = pop_locus_qualifier(leftovers, allow_missing=True, default=None)
         translation = leftovers.pop("translation", [""])[0] or None
         if translation is not None:
             feature.translation = translation

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -25,7 +25,7 @@ from ..locations import (
     frameshift_location_by_qualifier,
     Location,
 )
-from .feature import Feature
+from .feature import Feature, pop_locus_qualifier
 from .module import Module
 
 _VALID_TRANSLATION_CHARS = set(IUPACData.extended_protein_letters)
@@ -259,7 +259,7 @@ class CDSFeature(Feature):
 
         # semi-optional qualifiers
         protein_id = leftovers.pop("protein_id", [None])[0]
-        locus_tag = leftovers.pop("locus_tag", [None])[0]
+        locus_tag = pop_locus_qualifier(leftovers, allow_missing=True, default=None)
         gene = leftovers.pop("gene", [None])[0]
         if not (gene or protein_id or locus_tag):
             if "pseudo" in leftovers or "pseudogene" in leftovers:

--- a/antismash/common/secmet/features/cds_motif.py
+++ b/antismash/common/secmet/features/cds_motif.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Type, TypeVar, cast
 from Bio.SeqFeature import SeqFeature
 
 from .domain import Domain, generate_protein_location_from_qualifiers
-from .feature import Feature, FeatureLocation, Location
+from .feature import Feature, FeatureLocation, Location, pop_locus_qualifier
 
 T = TypeVar("T", bound="CDSMotif")
 ExternalT = TypeVar("ExternalT", bound="ExternalCDSMotif")  # pylint: disable=invalid-name
@@ -35,7 +35,8 @@ class CDSMotif(Domain):
             if not tool:
                 return cast(T, ExternalCDSMotif.from_biopython(bio_feature, None, leftovers, record))
             protein_location = generate_protein_location_from_qualifiers(leftovers, record)
-            locus_tag = leftovers.pop("locus_tag", ["(unknown)"])[0]
+            locus_tag = pop_locus_qualifier(leftovers)
+            assert locus_tag
             feature = cls(bio_feature.location, locus_tag, protein_location, tool=tool)
 
         updated = super().from_biopython(bio_feature, feature, leftovers, record=record)

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -282,3 +282,29 @@ class Feature:
         if "note" in qualifiers:
             qualifiers["note"] = qualifiers["note"].copy()
         return qualifiers
+
+
+def pop_locus_qualifier(qualifiers: Dict[str, List[str]], allow_missing: bool = True,
+                        default: Optional[str] = "(unknown)") -> Optional[str]:
+    """ Removes and returns a 'locus_tag' qualifier if present.
+
+        Arguments:
+            qualifiers: a dictionary of biopython-compatible qualifiers
+            allow_missing: if False, raises a KeyError if the qualifier is missing
+            default: the default value to use if the qualifier is missing
+
+        Returns:
+            the locus tag qualifier or the given default if the qualifier is missing
+    """
+    locus: Optional[str]
+    if allow_missing:
+        locus = qualifiers.pop("locus_tag", [""])[0]
+        if not locus:
+            locus = default
+    else:
+        locus = qualifiers.pop("locus_tag")[0]
+    if locus is None:
+        return locus
+    # handle long names having spaces inserted by biopython at linebreaks
+    locus = locus.replace(" ", "")
+    return locus

--- a/antismash/common/secmet/features/gene.py
+++ b/antismash/common/secmet/features/gene.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from Bio.SeqFeature import SeqFeature
 
-from .feature import Feature, Location
+from .feature import Feature, Location, pop_locus_qualifier
 
 T = TypeVar("T", bound="Gene")
 
@@ -58,7 +58,7 @@ class Gene(Feature):
         if leftovers is None:
             leftovers = Feature.make_qualifiers_copy(bio_feature)
         # grab mandatory qualifiers and create the class
-        locus = leftovers.pop("locus_tag", [""])[0] or None
+        locus = pop_locus_qualifier(leftovers, allow_missing=True, default=None)
         name = leftovers.pop("gene", [""])[0] or None
         if not (locus or name):
             name = "gene%s_%s" % (bio_feature.location.start, bio_feature.location.end)

--- a/antismash/common/secmet/features/pfam_domain.py
+++ b/antismash/common/secmet/features/pfam_domain.py
@@ -12,7 +12,7 @@ from antismash.common.secmet.locations import FeatureLocation
 from antismash.common.secmet.qualifiers import GOQualifier
 
 from ..errors import SecmetInvalidInputError
-from .feature import Feature, Location
+from .feature import Feature, Location, pop_locus_qualifier
 from .domain import Domain
 
 T = TypeVar("T", bound="PFAMDomain")
@@ -94,7 +94,8 @@ class PFAMDomain(Domain):
         if name is None:
             raise SecmetInvalidInputError("PFAMDomain missing identifier")
         tool = leftovers.pop("aSTool")[0]
-        locus_tag = leftovers.pop("locus_tag", ["(unknown)"])[0]
+        locus_tag = pop_locus_qualifier(leftovers)
+        assert locus_tag
 
         feature = cls(bio_feature.location, description, FeatureLocation(p_start, p_end),
                       identifier=name, tool=tool, locus_tag=locus_tag)

--- a/antismash/common/secmet/features/prepeptide.py
+++ b/antismash/common/secmet/features/prepeptide.py
@@ -10,7 +10,7 @@ from Bio.SeqFeature import SeqFeature
 
 from ..errors import SecmetInvalidInputError
 from .cds_motif import CDSMotif
-from .feature import Feature, FeatureLocation, Location
+from .feature import Feature, FeatureLocation, Location, pop_locus_qualifier
 from ..locations import build_location_from_others, location_from_string
 from ..qualifiers.prepeptide_qualifiers import RiPPQualifier
 from ..qualifiers.prepeptide_qualifiers import rebuild_qualifier
@@ -211,12 +211,14 @@ class Prepeptide(CDSMotif):  # pylint: disable=too-many-instance-attributes
             locations.append(tail_location)
 
         location = build_location_from_others(locations)
+        locus = pop_locus_qualifier(leftovers, allow_missing=False)
+        assert locus
 
         return cls(
             location,
             leftovers.pop("peptide")[0],
             leftovers.pop("core_sequence")[0],
-            leftovers.pop("locus_tag")[0],
+            locus,
             leftovers.pop("aSTool")[0],
             leftovers.pop("predicted_class")[0],
             float(leftovers.pop("score")[0]),

--- a/antismash/common/secmet/features/test/test_feature.py
+++ b/antismash/common/secmet/features/test/test_feature.py
@@ -13,6 +13,7 @@ from antismash.common.secmet.features.feature import (
     CompoundLocation,
     Feature,
     FeatureLocation,
+    pop_locus_qualifier as pop_locus,
     SeqFeature,
 )
 from antismash.common.secmet import features
@@ -234,3 +235,23 @@ class TestSubLocation(unittest.TestCase):
         assert self.get_sub(2, 4) == CompoundLocation([FeatureLocation(15, 18, -1),
                                                        FeatureLocation(13, 16, -1)])
         assert self.get_sub(4, 5) == FeatureLocation(10, 13, -1)
+
+
+class TestLocusPop(unittest.TestCase):
+    def test_base(self):
+        for value in ["locus", "something"]:
+            assert pop_locus({"locus_tag": [value]}) == value
+
+    def test_default(self):
+        for default in ["test", None]:
+            assert pop_locus({}, default=default) == default
+
+    def test_required(self):
+        with self.assertRaises(KeyError):
+            locus = pop_locus({}, allow_missing=False)
+        with self.assertRaises(KeyError):
+            locus = pop_locus({}, allow_missing=False, default="some value")
+
+    def test_biopython_spaces(self):
+        locus = "longnamewith space"
+        assert pop_locus({"locus_tag": [locus]}) == locus.replace(" ", "")

--- a/antismash/detection/nrps_pks_domains/modular_domain.py
+++ b/antismash/detection/nrps_pks_domains/modular_domain.py
@@ -14,7 +14,8 @@ from antismash.common.secmet.features.antismash_domain import (
     FeatureLocation,
     Location,
     register_asdomain_variant,
-    generate_protein_location_from_qualifiers
+    generate_protein_location_from_qualifiers,
+    pop_locus_qualifier,
 )
 
 T = TypeVar("T", bound="ModularDomain")
@@ -54,8 +55,8 @@ class ModularDomain(AntismashDomain):
         if tool != TOOL:
             raise ValueError(f"incompatible tool type for {cls}: {tool}")
         protein_location = generate_protein_location_from_qualifiers(leftovers, record)
-        # locus tag is special, antismash versions <= 5.0 didn't require it, but > 5.0 do
-        locus_tag = leftovers.pop("locus_tag", ["(unknown)"])[0]
+        locus_tag = pop_locus_qualifier(leftovers)
+        assert locus_tag
         feature = cls(bio_feature.location, protein_location, locus_tag)
 
         # grab optional qualifiers

--- a/antismash/detection/tigrfam/tigr_domain.py
+++ b/antismash/detection/tigrfam/tigr_domain.py
@@ -13,6 +13,7 @@ from antismash.common.secmet.features.antismash_domain import (
     Feature,
     Location,
     generate_protein_location_from_qualifiers,
+    pop_locus_qualifier,
     register_asdomain_variant,
 )
 
@@ -78,7 +79,8 @@ class TIGRDomain(AntismashDomain):
         leftovers.pop('protein_end')
 
         description = leftovers.pop('description')[0]
-        locus_tag = leftovers.pop("locus_tag")[0]
+        locus_tag = pop_locus_qualifier(leftovers, allow_missing=False)
+        assert locus_tag
         identifier = leftovers.pop('identifier')[0]
         feature = cls(bio_feature.location, description, protein_location, identifier, locus_tag)
 

--- a/antismash/modules/rrefinder/rre_domain.py
+++ b/antismash/modules/rrefinder/rre_domain.py
@@ -13,6 +13,7 @@ from antismash.common.secmet.features.antismash_domain import (
     Feature,
     Location,
     generate_protein_location_from_qualifiers,
+    pop_locus_qualifier,
     register_asdomain_variant,
 )
 
@@ -92,7 +93,8 @@ class RREDomain(AntismashDomain):
         leftovers.pop('protein_end')
 
         description = leftovers.pop('description')[0]
-        locus_tag = leftovers.pop("locus_tag")[0]
+        locus_tag = pop_locus_qualifier(leftovers, allow_missing=False)
+        assert locus_tag
         identifier = leftovers.pop('identifier')[0]
         feature = cls(bio_feature.location, description, protein_location, identifier, locus_tag)
 


### PR DESCRIPTION
Long CDS names (e.g. AB366635.1 with a `gene` qualifier of `MIPLSYAQRRMWFINRFEGPSSTYNIPLLLRFHGSLDTAALRAAFQDVLV`) are line wrapped by biopython output when using a longer qualifier name, and when those are read back in with biopython it keeps a single space where the line break was.

This PR changes all `locus_tag` qualifier parsing in features that need to point at CDS features to remove any spaces found.