### PR TITLE
main: Make sure the output zipfile has sane permissions

### DIFF
--- a/antismash/main.py
+++ b/antismash/main.py
@@ -478,6 +478,7 @@ def write_outputs(results: serialiser.AntismashResults, options: ConfigType) -> 
         with tempfile.NamedTemporaryFile(prefix="as_zip_tmp", suffix=".zip") as temp:
             shutil.make_archive(temp.name.replace(".zip", ""), "zip", root_dir=options.output_dir)
             shutil.copy(temp.name, zipfile)
+            os.chmod(zipfile, 0o644)
         assert os.path.exists(zipfile)
 
 


### PR DESCRIPTION
By default the NamedTemporaryFile has 0600 permissions, change to 0644 after copying to the outdir to match the other files.

Signed-off-by: Kai Blin <kblin@biosustain.dtu.dk>