### PR TITLE
switch from crc32 to md5 to properly hash locations without clashes

### DIFF
--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -15,7 +15,7 @@ import bisect
 from collections import Counter, defaultdict, OrderedDict
 import logging
 from typing import Any, Dict, List, Optional, Sequence, Type, Tuple, Union, cast
-from zlib import crc32
+from hashlib import md5
 
 from Bio import SeqIO
 from Bio.Seq import Seq
@@ -1009,17 +1009,17 @@ class Record:
         return len(other) < 0.2 * len(sequence)
 
 
-def _calculate_crc32(string: str) -> str:
-    """ Calculates the crc32 checksum of an input string and returns the resulting checksum in hex.
+def _calculate_md5(string: str) -> str:
+    """ Calculates the md5 checksum of an input string and returns the resulting checksum in hex.
 
         Arguments:
             string: The string to generate the checksum for
 
         Returns:
-            A string containing the hexadecimal representation of the crc32 checksum
+            A string containing the hexadecimal representation of the md5 checksum
     """
-    checksum = crc32(string.encode("utf-8"))
-    return f"{checksum:x}"
+    checksum = md5(string.encode("utf-8"))
+    return checksum.hexdigest()
 
 
 def _location_checksum(feature: Feature) -> str:
@@ -1031,4 +1031,4 @@ def _location_checksum(feature: Feature) -> str:
         Returns:
             A string containing the feature's location checksum in hex
     """
-    return _calculate_crc32(str(feature.location))
+    return _calculate_md5(str(feature.location))


### PR DESCRIPTION
crc32 "is not cryptographically strong, and should not be used for authentication or digital signatures" according to [zlib docs](https://docs.python.org/3/library/zlib.html#zlib.crc32) .  

We ran into a clash rather quickly with the following locations, which result in the exact same crc32 digests:

    >>> from zlib import crc32
    >>> checksum=crc32('[5206081:5207221](-)'.encode('utf-8'))
    >>> f"{checksum:x}"
    '6dea7c77'
    >>> checksum=crc32('[1964876:1965035](-)'.encode('utf-8'))
    >>> f"{checksum:x}"
    '6dea7c77'

A hash isn't really necessary because python creates one anyway in the dict, but hashlib.md5 should work:

    >>> from hashlib import md5
    >>> checksum=md5('[5206081:5207221](-)'.encode('utf-8'))
    >>> checksum.hexdigest()
    '4dbae8825761207cab29f6dcdf97785a'
    >>> checksum=md5('[1964876:1965035](-)'.encode('utf-8'))
    >>> checksum.hexdigest()
    'a6d96d4f1f461226fefeb93ea67e110b'