### PR TITLE
secmet: handle bad NCBI misc features for Pfam hits

### DIFF
--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -46,6 +46,7 @@ from .locations import (
     split_origin_bridging_location,
     combine_locations,
     ensure_valid_locations,
+    remove_redundant_exons,
 )
 
 T = TypeVar("T", bound="Record")
@@ -734,6 +735,10 @@ class Record:
 
             locations_adjusted = False
             name_modified = False
+
+            # prefilter some NCBI Pfam hits locations that are generated poorly
+            if can_be_circular and feature.type == "misc_feature" and location_bridges_origin(feature.location, allow_reversing=False):
+                feature.location = remove_redundant_exons(feature.location)
 
             if can_be_circular and location_bridges_origin(feature.location, allow_reversing=False):
                 locations_adjusted = True

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -34,6 +34,9 @@ from .helpers import (
     DummyRegion,
     DummySubRegion,
 )
+from ..locations import (
+    CompoundLocation,
+)
 from ..qualifiers import SecMetQualifier, GeneFunction
 from ..record import Record
 
@@ -98,6 +101,24 @@ class TestConversion(unittest.TestCase):
         rec.features.append(SeqFeature(None, type="broken"))
         with self.assertRaisesRegex(SecmetInvalidInputError, "missing or invalid location"):
             Record.from_biopython(rec, taxon="bacteria")
+
+    def test_origin_crossing_splits(self):
+        rec = list(Bio.SeqIO.parse(get_path_to_nisin_genbank(), "genbank"))[0]
+        rec.features = []
+        location = CompoundLocation([
+            FeatureLocation(3, 12, -1),
+            FeatureLocation(6, 9, -1),
+            FeatureLocation(15, 21, -1),
+        ], operator="order")
+        # should still error with meaningful features
+        rec.features.append(SeqFeature(location, type="gene"))
+        with self.assertRaisesRegex(SecmetInvalidInputError, "cannot determine correct ordering"):
+            Record.from_biopython(rec, taxon="bacteria")
+        # but not with misc features
+        rec.features[0].type = "misc_feature"
+        sec_rec = Record.from_biopython(rec, taxon="bacteria")
+        assert len(rec.features) == 1
+        assert rec.features[0].location.parts == [location.parts[0], location.parts[2]]
 
 
 class TestStripping(unittest.TestCase):


### PR DESCRIPTION
Some NCBI annotations of Pfam hits can end up with very strange locations, e.g. this from `AM743169.1`, where the parent CDS location is `complement(join(3683384..3684415,3684417..3686921))`
```
     misc_feature    complement(order(3683871..3684154,3683813..3684415))
                     /locus_tag="Smlt3626"
                     /inference="protein motif:HMMPfam:PF02518"
                     /note="HMMPfam hit to PF02518, Histidine kinase-, DNA
                     gyrase B-, and HS, score 3.6e-44"
                     /pseudo
```

This PR removes any of these redundant exons to avoid triggering the origin-crossing detection logic.