### PR TITLE
cluster_compare: don't create HTML content for search types with no results

### DIFF
--- a/antismash/modules/cluster_compare/html_output.py
+++ b/antismash/modules/cluster_compare/html_output.py
@@ -43,6 +43,8 @@ def generate_html(region_layer: RegionLayer, results: ClusterCompareResults,
         divs: List[Tuple[str, str, Markup]] = []
         for variant, result in sorted(variant_results.items()):
             scores = result.scores_by_region[:DISPLAY_LIMIT]
+            if not scores:
+                continue
             scores_by_proto = result.details.details
             tag = variant.replace(" ", "-")
             search_type = "row"


### PR DESCRIPTION
This reliably happens when a region contains no protoclusters, but the comparison config includes one of the protocluster search modes (e.g. via sideloading). The javascript data already has this condition, which led to javascript errors attempting to access missing information because the selector still existed.

Existing code in the HTML template handles the case for when all search modes have no results.