### PR TITLE
Misc fixes

### DIFF
--- a/antismash/common/secmet/features/module.py
+++ b/antismash/common/secmet/features/module.py
@@ -71,7 +71,11 @@ class Module(Feature):
         if not isinstance(module_type, ModuleType):
             raise TypeError("module_type must be a ModuleType instance, not %s" % type(module_type))
 
-        self._parent_cds_names = sorted({dom.locus_tag for dom in domains})
+        # parent CDS name order should match that of the domains provided
+        self._parent_cds_names: List[str] = []
+        for domain in domains:
+            if domain.locus_tag not in self._parent_cds_names:
+                self._parent_cds_names.append(domain.locus_tag)
         self._domains = domains
         self._substrate_monomer_pairs: List[Tuple[str, str]] = []
         self._complete = complete

--- a/antismash/common/secmet/features/test/test_cds_feature.py
+++ b/antismash/common/secmet/features/test/test_cds_feature.py
@@ -14,6 +14,7 @@ from antismash.common.secmet.features import FeatureLocation, CDSFeature
 from antismash.common.secmet.features.cds_feature import (
     _is_valid_translation_length,
     _translation_fits_in_record,
+    MAX_TRANSLATION_LENGTH,
 )
 from antismash.common.secmet.features.feature import CompoundLocation
 from antismash.common.secmet.locations import AfterPosition, BeforePosition
@@ -46,6 +47,14 @@ class TestCDSFeature(unittest.TestCase):
         for trans in [None, "A?", "A!", ""]:
             with self.assertRaisesRegex(ValueError, "valid translation required|invalid translation characters"):
                 CDSFeature(loc, locus_tag="test", translation=trans)
+
+    def test_max_translation_length(self):
+        loc = FeatureLocation(0, (MAX_TRANSLATION_LENGTH - 1) * 3, 1)
+        CDSFeature(loc, locus_tag="test", translation="A" * (MAX_TRANSLATION_LENGTH - 1))
+
+        loc = FeatureLocation(0, MAX_TRANSLATION_LENGTH * 3, 1)
+        with self.assertRaisesRegex(ValueError, "translation too long"):
+            CDSFeature(loc, locus_tag="test", translation="A" * MAX_TRANSLATION_LENGTH)
 
 
 class TestCDSBiopythonConversion(unittest.TestCase):

--- a/antismash/common/secmet/features/test/test_module.py
+++ b/antismash/common/secmet/features/test/test_module.py
@@ -155,6 +155,11 @@ class TestModule(unittest.TestCase):
         module._parent_cds_names.append("more")
         assert len(module.parent_cds_names) == 2 and module.is_multigene_module()
 
+    def test_cross_gene_ordering(self):
+        domains = [DummyAntismashDomain(locus_tag="A"), DummyAntismashDomain(locus_tag="B")]
+        for doms in [domains, domains[::-1]]:
+            assert Module(doms).parent_cds_names == tuple([dom.locus_tag for dom in doms])
+
     def test_type(self):
         assert create_module().module_type == ModuleType.UNKNOWN
 

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -535,6 +535,8 @@ class Record:
         # ensure it has a translation
         if not cds_feature.translation:
             raise ValueError("Missing translation info for %s" % cds_feature)
+        if len(cds_feature.translation) > 100000:
+            raise ValueError(f"Translation too large: {cds_feature} {len(cds_feature.translation)}")
         location_key = str(cds_feature.location)
         if location_key in self._cds_by_location:
             raise SecmetInvalidInputError(

--- a/antismash/detection/sideloader/general.py
+++ b/antismash/detection/sideloader/general.py
@@ -55,7 +55,7 @@ def load_single_record_annotations(annotation_files: List[str], record: Record,
 
     tool = Tool("manual", "N/A", "command line argument", {})
     if manual and manual.accession == record.id:
-        subregion = SubRegionAnnotation(manual.start, manual.end, "", tool, {})
+        subregion = SubRegionAnnotation(manual.start, min(manual.end, len(record.seq)), "", tool, {})
         subregions.append(subregion)
 
     if cds_markers:

--- a/antismash/detection/sideloader/test/test_general.py
+++ b/antismash/detection/sideloader/test/test_general.py
@@ -36,7 +36,9 @@ class TestSimple(unittest.TestCase):
         result = general.load_single_record_annotations([], make_record("AXC"), _parse_arg("AcC:1-50"))
         assert not result.subregions
 
-        result = general.load_single_record_annotations([], make_record("AcC", 30), _parse_arg("AcC:1-50"))
+        record = make_record("AcC", 30)
+        record.seq = "A" * 100
+        result = general.load_single_record_annotations([], record, _parse_arg("AcC:1-50"))
         assert not result.protoclusters
         assert len(result.subregions) == 1
         sub = result.subregions[0]
@@ -44,6 +46,14 @@ class TestSimple(unittest.TestCase):
         assert sub.start == 1
         assert sub.end == 50
         assert result.record_id == "AcC"
+
+    def test_end_overflow(self):
+        length = 50
+        features = [DummyCDS(start=10, end = 18)]
+        record = DummyRecord(seq="A"*length, record_id="A", features=features)
+        results = general.load_single_record_annotations([], record, _parse_arg(f"A:1-{length * 10}"))
+        assert len(results.subregions) == 1
+        assert results.subregions[0].end == length
 
     def test_empty(self):
         with self.assertRaisesRegex(AntismashInputError, "area contains no complete CDS"):

--- a/antismash/support/genefinding/run_glimmerhmm.py
+++ b/antismash/support/genefinding/run_glimmerhmm.py
@@ -15,6 +15,7 @@ from helperlibs.wrappers.io import TemporaryDirectory
 from antismash.common import path
 from antismash.common.gff_parser import get_features_from_file
 from antismash.common.secmet import Record
+from antismash.common.secmet.features.cds_feature import MAX_TRANSLATION_LENGTH
 from antismash.common.subprocessing import execute
 
 
@@ -63,4 +64,6 @@ def run_glimmerhmm(record: Record) -> None:
     handle = StringIO(results_text)
     features = get_features_from_file(handle)["input"]
     for feature in features:
+        if len(feature.location) >= (MAX_TRANSLATION_LENGTH * 3) * .9:
+            logging.warning(f"Ignoring potential gene too long for dependencies: {len(feature.location) // 1000}kb")
         record.add_biopython_feature(feature)

--- a/antismash/support/genefinding/run_prodigal.py
+++ b/antismash/support/genefinding/run_prodigal.py
@@ -12,6 +12,7 @@ from helperlibs.wrappers.io import TemporaryDirectory
 
 from antismash.common.fasta import write_fasta
 from antismash.common.secmet import CDSFeature, Record
+from antismash.common.secmet.features.cds_feature import MAX_TRANSLATION_LENGTH
 from antismash.common.subprocessing import execute
 from antismash.config import ConfigType
 
@@ -64,6 +65,11 @@ def run_prodigal(record: Record, options: ConfigType) -> None:
             if start > end:
                 strand = -1
                 start, end = end, start
+
+            length = end - start
+            if length > (MAX_TRANSLATION_LENGTH * 3) * .9:
+                logging.warning(f"Ignoring potential gene too long for dependencies: {length // 1000}kb")
+                continue
 
             loc = FeatureLocation(start-1, end, strand=strand)
             translation = record.get_aa_translation_from_location(loc)


### PR DESCRIPTION
Fixes a few minor issues:
- introduces a cap of 100,000 aminos for translations, which is the maximum for external tools like hmmscan
- prevents genefinding from calling a gene with more than 90% of the new cap (since it was including half megabase stretches of `N` in some odd assemblies)
- allows `--sideload-simple` to specify an end-point past the record end, automatically truncating it to the record end if necessary
- corrects cross-CDS module parent name ordering to match the order of domains provided, rather than alphabetically sorted