### PR TITLE
Misc fixes

### DIFF
--- a/antismash/common/all_orfs.py
+++ b/antismash/common/all_orfs.py
@@ -174,16 +174,16 @@ def find_intergenic_areas(start: int, end: int, cds_features: Iterable[CDSFeatur
     last = start
     for cds in cds_features:
         # if there's a gap of sufficient size, add it
-        if cds.location.start > last:
-            intergenic_areas.append((max(start, last - padding),
+        if cds.location.start + padding > last:
+            intergenic_areas.append((max(start, last),
                                      min(end, int(cds.location.start) + padding)))
-            last = int(cds.location.end)
+            last = int(cds.location.end) - padding
             continue
         # in case of existing CDS features overlapping, update the last end position
         if cds.location.start <= last <= cds.location.end:
-            last = int(cds.location.end)
+            last = int(cds.location.end) - padding
     if last < end:
-        intergenic_areas.append((max(start, last - padding), end))
+        intergenic_areas.append((max(start, last), end))
     return list(filter(lambda area: area[1] - area[0] >= min_length, intergenic_areas))
 
 

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -131,7 +131,7 @@ def parse_input_sequence(filename: str, taxon: str = "bacteria", minimum_length:
 
     logging.debug("Converting records from biopython to secmet")
     try:
-        records = [Record.from_biopython(record, taxon) for record in records]
+        records = [Record.from_biopython(record, taxon, discard_antismash_features=True) for record in records]
     except SecmetInvalidInputError as err:
         raise AntismashInputError(str(err)) from err
 

--- a/antismash/common/secmet/features/candidate_cluster/structures.py
+++ b/antismash/common/secmet/features/candidate_cluster/structures.py
@@ -156,7 +156,10 @@ class CandidateCluster(CDSCollection):
             raise ValueError("record instance required for regenerating CandidateCluster from biopython")
 
         all_protoclusters = record.get_protoclusters()
-        protocluster_numbers = [int(num) for num in leftovers.pop("protoclusters")]
+        try:
+            protocluster_numbers = [int(num) for num in leftovers.pop("protoclusters")]
+        except KeyError as err:
+            raise ValueError(f"{cls.FEATURE_TYPE} missing expected qualifier: {err}")
 
         if max(protocluster_numbers) > len(all_protoclusters):
             raise ValueError("record does not contain all expected protoclusters")

--- a/antismash/common/secmet/features/protocluster.py
+++ b/antismash/common/secmet/features/protocluster.py
@@ -123,12 +123,15 @@ class Protocluster(CDSCollection):
         if not feature:
             category = leftovers.pop("category", [""])[0]
             # grab mandatory qualifiers and create the class
-            neighbourhood_range = int(leftovers.pop("neighbourhood")[0])
-            cutoff = int(leftovers.pop("cutoff")[0])
-            product = leftovers.pop("product")[0]
-            tool = leftovers.pop("aStool")[0]
-            rule = leftovers.pop("detection_rule")[0]
-            core_location = location_from_string(leftovers.pop("core_location")[0])
+            try:
+                neighbourhood_range = int(leftovers.pop("neighbourhood")[0])
+                cutoff = int(leftovers.pop("cutoff")[0])
+                product = leftovers.pop("product")[0]
+                tool = leftovers.pop("aStool")[0]
+                rule = leftovers.pop("detection_rule")[0]
+                core_location = location_from_string(leftovers.pop("core_location")[0])
+            except KeyError as err:
+                raise ValueError(f"{cls.FEATURE_TYPE} missing expected qualifier: {err}")
             feature = cls(core_location, bio_feature.location,
                           tool, product, cutoff, neighbourhood_range, rule, product_category=category)
 

--- a/antismash/common/secmet/features/subregion.py
+++ b/antismash/common/secmet/features/subregion.py
@@ -50,12 +50,16 @@ class SubRegion(CDSCollection):
         if leftovers is None:
             leftovers = Feature.make_qualifiers_copy(bio_feature)
 
-        if leftovers["aStool"][0].startswith("externally annotated"):
+        try:
+            tool = leftovers["aStool"][0]
+        except KeyError as err:
+            raise ValueError(f"{cls.FEATURE_TYPE} missing expected qualifier: {err}")
+        if tool.startswith("externally annotated"):
             external = SideloadedSubRegion.from_biopython(bio_feature)
             assert isinstance(external, cls)
             return external
 
-        tool = leftovers.pop("aStool")[0]
+        leftovers.pop("aStool")
         label = leftovers.pop("label", [""])[0]
         if not label:
             label = leftovers.pop("anchor", [""])[0]  # backwards compatibility

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -120,6 +120,11 @@ class TestConversion(unittest.TestCase):
         assert len(rec.features) == 1
         assert rec.features[0].location.parts == [location.parts[0], location.parts[2]]
 
+        features = sec_rec.get_all_features()
+        assert len(features) == 2
+        assert features[0].location.parts == [location.parts[2]]
+        assert features[1].location.parts == [location.parts[0]]
+
     def test_discard(self):
         bio = list(Bio.SeqIO.parse(get_path_to_nisin_genbank(), "genbank"))[0]
         for feature_type in ANTISMASH_SPECIFIC_TYPES:

--- a/antismash/common/test/test_all_orfs.py
+++ b/antismash/common/test/test_all_orfs.py
@@ -121,17 +121,17 @@ class TestIntegenic(unittest.TestCase):
 
     def test_simple(self):
         cdses = [DummyCDS(30, 36, strand=1), DummyCDS(39, 45, strand=-1)]
-        areas = find_intergenic_areas(0, 120, []) == [(0, 30), (36, 39), (45, 120)]
+        assert find_intergenic_areas(0, 120, cdses) == [(0, 30), (36, 39), (45, 120)]
 
     def test_padding(self):
         cdses = [DummyCDS(30, 45, strand=1)]
-        areas = find_intergenic_areas(0, 60, cdses, padding=0) == [(0, 30), (45, 60)]
-        areas = find_intergenic_areas(0, 60, cdses, padding=3) == [(0, 27), (48, 60)]
-        areas = find_intergenic_areas(12, 50, cdses, padding=3) == [(12, 27), (48, 50)]
+        assert find_intergenic_areas(0, 60, cdses, padding=0) == [(0, 30), (45, 60)]
+        assert find_intergenic_areas(0, 60, cdses, padding=3) == [(0, 33), (42, 60)]
+        assert find_intergenic_areas(12, 50, cdses, padding=3) == [(12, 33), (42, 50)]
 
     def test_overlapping_cds(self):
         cdses = [DummyCDS(30, 42, strand=1), DummyCDS(41, 50, strand=-1)]
-        areas = find_intergenic_areas(0, 60, cdses) == [(0, 30), (50, 60)]
+        assert find_intergenic_areas(0, 60, cdses) == [(0, 30), (50, 60)]
 
 
 class TestOrfLocations(unittest.TestCase):

--- a/antismash/modules/clusterblast/svg_builder.py
+++ b/antismash/modules/clusterblast/svg_builder.py
@@ -526,14 +526,12 @@ class ClusterSVGBuilder:
         self.query_cluster = QueryRegion(region)
         region_number = region.get_region_number()
         cluster_limit = get_config().cb_nclusters
-        self.colour_lookup = build_colour_groups(list(region.cds_children), ranking[:cluster_limit])
+        assert len(ranking) <= cluster_limit, f"{len(ranking)} <= {cluster_limit}"
+        self.colour_lookup = build_colour_groups(list(region.cds_children), ranking)
         self.hits: List[Cluster] = []
-        record_prefix = (region.parent_record.original_id or region.parent_record.id).split(".", 1)[0]
         num_added = 0
         queries = set()
         for cluster, score in ranking:
-            if prefix != "subclusterblast" and record_prefix == cluster.accession:
-                continue
             # determine overall strand direction of hits
             hit_genes = set()
             strand = determine_strand_of_cluster(region, score.scored_pairings)
@@ -546,9 +544,6 @@ class ClusterSVGBuilder:
                                                          strand, self.prefix)
             self.hits.append(svg_cluster)
             num_added += 1
-            # obey the cluster display limit from options
-            if num_added >= cluster_limit:
-                break
 
         self.max_length = self._size_of_largest_cluster()
         self._organise_strands()


### PR DESCRIPTION
Adds functionality to discard corrupted antiSMASH-specific feature types to handle parsing failures (e.g. an `aSModule` with no relevant qualifiers). Missing qualifiers raising `KeyError` (deliberately or not) will not be caught by this system.

Fixes a number of issues:
- ClusterBlast SVGs would have the last hit missing colours due to skipping the same accession as the input _after_ the colours were generated
- the new intergenic area search for finding all ORFs was using the wrong directionality for padding, and related tests weren't correctly checking values
- improves testing of split cross-origin features, previously only the original biopython feature was being tested