### PR TITLE
Misc fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ omit = --omit '*/external/*'
 coverage = coverage run $(omit) --source antismash -m pytest
 integration_flags = --override-ini=python_files=integration_*.py
 integration_coverage = .coverage_integration
-sanity_run = echo "sanity TTA run" && rm -rf nisin && ./run_antismash.py --minimal antismash/test/integration/data/nisin.gbk
+sanity_run = echo "sanity TTA run" && rm -rf nisin && antismash --minimal antismash/test/integration/data/nisin.gbk
 
 unit:
 	$(sanity_run)
-	echo "simple reuse test" && ./run_antismash.py --reuse-results nisin/nisin.json
+	echo "simple reuse test" && antismash --reuse-results nisin/nisin.json
 	pytest --durations=3 antismash
 
 integration: clean

--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -170,7 +170,7 @@ def find_protoclusters(record: Record, cds_by_cluster_type: Dict[str, Set[str]],
         cds_features = sorted([cds_feature_by_name[cds] for cds in cds_names])
         rule = rules_by_name[cluster_type]
         cutoff = rule.cutoff
-        core_location = cds_features[0].location
+        core_location = FeatureLocation(cds_features[0].location.start, cds_features[0].location.end)
         for cds in cds_features[1:]:
             if cds.overlaps_with(FeatureLocation(max(0, core_location.start - cutoff),
                                                  core_location.end + cutoff)):
@@ -189,7 +189,7 @@ def find_protoclusters(record: Record, cds_by_cluster_type: Dict[str, Set[str]],
                                     tool="rule-based-clusters", cutoff=cutoff,
                                     neighbourhood_range=rule.neighbourhood, product=cluster_type,
                                     detection_rule=str(rule.conditions), product_category=rule.category))
-            core_location = cds.location
+            core_location = FeatureLocation(cds.location.start, cds.location.end)
 
         # finalise the last cluster
         surrounds = FeatureLocation(max(0, core_location.start - rule.neighbourhood),

--- a/antismash/common/hmm_rule_parser/test/test_rule_parser.py
+++ b/antismash/common/hmm_rule_parser/test/test_rule_parser.py
@@ -386,11 +386,22 @@ class RuleParserTest(unittest.TestCase):
             self.parse("RULE first CATEGORY category CUTOFF 20 NEIGHBOURHOOD 20 CONDITIONS a "
                        "RULE sub CATEGORY category SUPERIORS CUTOFF 20 NEIGHBOURHOOD 20 CONDITIONS c")
 
-    def test_chained_superiors(self):
-        with self.assertRaisesRegex(ValueError, "A rule cannot have a superior which has its own superior"):
-            self.parse("RULE first CATEGORY category CUTOFF 20 NEIGHBOURHOOD 20 CONDITIONS a "
-                       "RULE second CATEGORY category SUPERIORS first CUTOFF 20 NEIGHBOURHOOD 20 CONDITIONS b "
-                       "RULE sub CATEGORY category SUPERIORS second CUTOFF 20 NEIGHBOURHOOD 20 CONDITIONS c")
+    def test_same_name(self):
+        categories = {"category"}
+        aliases = None
+
+        text = (
+            "RULE first CATEGORY category CUTOFF 20 NEIGHBOURHOOD 20 CONDITIONS a "
+            "RULE second CATEGORY category CUTOFF 20 NEIGHBOURHOOD 20 CONDITIONS b "
+        )
+        # the same name in a single pass
+        with self.assertRaisesRegex(ValueError, "same rule name"):
+            rule_parser.Parser(text * 2, self.signature_names, categories, {}, aliases)
+
+        # the same name appearing in a new pass
+        rules = rule_parser.Parser(text, self.signature_names, categories, aliases).rules
+        with self.assertRaisesRegex(ValueError, "same rule name"):
+            rule_parser.Parser(text, self.signature_names, categories, rules, aliases)
 
     def test_related(self):
         rules = self.parse("RULE name CATEGORY category RELATED b, c CUTOFF 20 NEIGHBOURHOOD 20 CONDITIONS a").rules

--- a/antismash/config/test/test_args.py
+++ b/antismash/config/test/test_args.py
@@ -92,7 +92,8 @@ class TestConfig(unittest.TestCase):
             with open("local", "w"):
                 pass  # just create the file, no need for content
             options = self.core_parser.parse_args(["--reuse-results", "local"])
-            assert options.reuse_results == os.path.join(temp_dir, "local")
+            without_symlinks = os.path.realpath(os.path.join(temp_dir, "local"))
+            assert os.path.realpath(options.reuse_results) == without_symlinks
             os.chmod("local", 0)
             with self.assertRaisesRegex(ValueError, "permission denied"):
                 self.core_parser.parse_args(["--reuse-results", "local"])

--- a/antismash/outputs/html/css/style.scss
+++ b/antismash/outputs/html/css/style.scss
@@ -1056,6 +1056,7 @@ ul.dropdown-options {
         margin-right: 0.1em;
         padding-left: 0.5em;
         padding-right: 0.5em;
+        padding-top: 1px;
 
         /* solve edge single pixel gap */
         padding-bottom: 1px;

--- a/antismash/outputs/html/visualisers/generic_domains.py
+++ b/antismash/outputs/html/visualisers/generic_domains.py
@@ -55,7 +55,7 @@ HELP = ("Shows {title} domains found in each gene within the region. "
         )
 
 PFAM_TOOL = ToolInfo("Pfam", HELP + "Domains with a bold border have Gene Ontology information.",
-                     url="https://pfam.xfam.org/family/$ACCESSION")
+                     url="https://www.ebi.ac.uk/interpro/entry/pfam/$ACCESSION")
 TOOLS = {
     tigrfam: ToolInfo("TIGRFAM", HELP,
                       url="https://www.ncbi.nlm.nih.gov/genome/annotation_prok/evidence/$ACCESSION"),
@@ -238,7 +238,7 @@ def generate_pfam_data(record: Record, region: Region) -> List[Dict[str, Any]]:
             "go_terms": js.build_pfam2go_links(pfam.gene_ontologies),
             "html_class": f"generic-type-{colour}",
             "name": pfam.domain,
-            "accession": pfam.full_identifier,
+            "accession": pfam.identifier,  # the EBI URLs fail if including the version
             "description": pfam.description,
             "evalue": f"{pfam.evalue:g}",
             "score": f"{pfam.score:.1f}",


### PR DESCRIPTION
A number of small fixes and updates:
- makes path tests resolve symlinks to avoid tests failing on Mac when using `TemporaryDirectory`
- removes the absolute path from `make unit` for Mac users with old(/as recent as apple provides) BASH versions
- removes two cases where created Protocluster could be on the negative strand (this has no real impact, but good for consistency)
- replaces the now-defunct Pfam URLs with the new host at EBI
- removes the restriction on detection rules specifying a superior that itself also had a superior
- adds a tiny bit of padding for details panel tabs in HTML to improve clearance for tall characters near the start or end