### PR TITLE
Misc fixes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,7 +1,7 @@
 [MASTER]
 ignore=external
 reports=y
-disable=bad-continuation,too-few-public-methods
+disable=too-few-public-methods
 
 [MESSAGES CONTROL]
 # raising 'from' is almost entirely false positives

--- a/antismash/common/all_orfs.py
+++ b/antismash/common/all_orfs.py
@@ -205,13 +205,14 @@ def find_all_orfs(record: Record, area: Optional[CDSCollection] = None,
     # Get sequence for the range
     offset = 0
     seq = record.seq
+    offset_end = len(record.seq)
     existing: Iterable[CDSFeature] = record.get_cds_features()
     if area:
-        seq = area.extract(seq)
         offset = area.location.start
+        offset_end = area.location.end
         existing = record.get_cds_features_within_location(area.location,
                                                            with_overlapping=True)
-    intergenic_areas = find_intergenic_areas(offset, offset + len(seq), existing,
+    intergenic_areas = find_intergenic_areas(offset, offset_end, existing,
                                              min_length=min_length, padding=max_overlap)
 
     # Find orfs throughout the range

--- a/antismash/common/comparippson/test/test_analysis.py
+++ b/antismash/common/comparippson/test/test_analysis.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import glob
 from io import StringIO

--- a/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,too-many-public-methods
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,too-many-public-methods
 
 import unittest
 

--- a/antismash/common/hmm_rule_parser/test/test_rule_parser.py
+++ b/antismash/common/hmm_rule_parser/test/test_rule_parser.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,too-many-public-methods
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,too-many-public-methods
 
 from collections import defaultdict
 import unittest

--- a/antismash/common/secmet/features/candidate_cluster/test/test_candidate_cluster.py
+++ b/antismash/common/secmet/features/candidate_cluster/test/test_candidate_cluster.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/secmet/features/candidate_cluster/test/test_formation.py
+++ b/antismash/common/secmet/features/candidate_cluster/test/test_formation.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/secmet/features/test/test_antismash_domain.py
+++ b/antismash/common/secmet/features/test/test_antismash_domain.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/secmet/features/test/test_cds_feature.py
+++ b/antismash/common/secmet/features/test/test_cds_feature.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/secmet/features/test/test_cds_motif.py
+++ b/antismash/common/secmet/features/test/test_cds_motif.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/secmet/features/test/test_cdscollection.py
+++ b/antismash/common/secmet/features/test/test_cdscollection.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/secmet/features/test/test_domain.py
+++ b/antismash/common/secmet/features/test/test_domain.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/secmet/features/test/test_feature.py
+++ b/antismash/common/secmet/features/test/test_feature.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from unittest.mock import patch

--- a/antismash/common/secmet/features/test/test_module.py
+++ b/antismash/common/secmet/features/test/test_module.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,assigning-non-slot
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,assigning-non-slot
 
 import unittest
 

--- a/antismash/common/secmet/features/test/test_pfam.py
+++ b/antismash/common/secmet/features/test/test_pfam.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/secmet/features/test/test_prepeptide.py
+++ b/antismash/common/secmet/features/test/test_prepeptide.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,unbalanced-tuple-unpacking
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,unbalanced-tuple-unpacking
 
 import unittest
 

--- a/antismash/common/secmet/features/test/test_protocluster.py
+++ b/antismash/common/secmet/features/test/test_protocluster.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/secmet/features/test/test_region.py
+++ b/antismash/common/secmet/features/test/test_region.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 from tempfile import NamedTemporaryFile
 import unittest

--- a/antismash/common/secmet/features/test/test_subregion.py
+++ b/antismash/common/secmet/features/test/test_subregion.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/secmet/qualifiers/test/test_genefunction.py
+++ b/antismash/common/secmet/qualifiers/test/test_genefunction.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/secmet/qualifiers/test/test_go.py
+++ b/antismash/common/secmet/qualifiers/test/test_go.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/secmet/qualifiers/test/test_nrpspks.py
+++ b/antismash/common/secmet/qualifiers/test/test_nrpspks.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/secmet/qualifiers/test/test_prepeptide_quals.py
+++ b/antismash/common/secmet/qualifiers/test/test_prepeptide_quals.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/secmet/qualifiers/test/test_secmet.py
+++ b/antismash/common/secmet/qualifiers/test/test_secmet.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import json
 import unittest

--- a/antismash/common/secmet/test/test_circular_conversion.py
+++ b/antismash/common/secmet/test/test_circular_conversion.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 # reusing variables in different argument positions seems to trick pylint
 # pylint: disable=arguments-out-of-order
 

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 from collections import defaultdict
 import unittest

--- a/antismash/common/subprocessing/test/integration_subprocessing.py
+++ b/antismash/common/subprocessing/test/integration_subprocessing.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import os
 import time

--- a/antismash/common/subprocessing/test/test_diamond.py
+++ b/antismash/common/subprocessing/test/test_diamond.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from unittest.mock import patch

--- a/antismash/common/subprocessing/test/test_java.py
+++ b/antismash/common/subprocessing/test/test_java.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from unittest.mock import patch

--- a/antismash/common/test/integration_mac_bug.py
+++ b/antismash/common/test/integration_mac_bug.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 from unittest import mock, TestCase
 

--- a/antismash/common/test/test_all_orfs.py
+++ b/antismash/common/test/test_all_orfs.py
@@ -16,6 +16,7 @@ from antismash.common.all_orfs import (
 )
 
 from .helpers import DummyCDS, DummyRecord
+from antismash.common.secmet.test.helpers import DummySubRegion
 
 
 class TestOrfCounts(unittest.TestCase):
@@ -90,6 +91,17 @@ class TestOrfCounts(unittest.TestCase):
         seq = str(DummyRecord(seq=seq).seq.reverse_complement())
         expected = [FeatureLocation(ExactPosition(6), ExactPosition(72), strand=-1)]
         assert expected == [feat.location for feat in find_all_orfs(DummyRecord(seq=seq))]
+
+    def test_area_offsets(self):
+        seq = "".join(["C" * 10, "ATG", "N" * 60, "TAGNNNTAG", "C" * 10])
+        area = DummySubRegion(5, len(seq) - 5)
+
+        expected = [FeatureLocation(ExactPosition(10), ExactPosition(76), strand=1)]
+        assert expected == [feat.location for feat in find_all_orfs(DummyRecord(seq=seq), area=area)]
+
+        seq = str(DummyRecord(seq=seq).seq.reverse_complement())
+        expected = [FeatureLocation(ExactPosition(16), ExactPosition(82), strand=-1)]
+        assert expected == [feat.location for feat in find_all_orfs(DummyRecord(seq=seq), area=area)]
 
     def test_interleaved(self):
         expected = [FeatureLocation(ExactPosition(0), ExactPosition(72), strand=1),

--- a/antismash/common/test/test_all_orfs.py
+++ b/antismash/common/test/test_all_orfs.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/common/test/test_gff_parser.py
+++ b/antismash/common/test/test_gff_parser.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,consider-using-with
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,consider-using-with
 
 from unittest import TestCase
 from Bio.SeqFeature import CompoundLocation, SeqFeature

--- a/antismash/common/test/test_hmmer.py
+++ b/antismash/common/test/test_hmmer.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 from collections import defaultdict
 from dataclasses import FrozenInstanceError, dataclass

--- a/antismash/common/test/test_hmmscan_refinement.py
+++ b/antismash/common/test/test_hmmscan_refinement.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 import warnings

--- a/antismash/common/test/test_html_renderer.py
+++ b/antismash/common/test/test_html_renderer.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,too-many-public-methods
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,too-many-public-methods
 
 import re
 import unittest

--- a/antismash/common/test/test_logs.py
+++ b/antismash/common/test/test_logs.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import logging
 import os

--- a/antismash/common/test/test_path.py
+++ b/antismash/common/test/test_path.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,too-many-public-methods
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,too-many-public-methods
 
 import os
 from tempfile import TemporaryDirectory

--- a/antismash/common/test/test_pfamdb.py
+++ b/antismash/common/test/test_pfamdb.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import os
 import tempfile

--- a/antismash/common/test/test_record_processing.py
+++ b/antismash/common/test/test_record_processing.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 from tempfile import NamedTemporaryFile
 import unittest

--- a/antismash/common/test/test_serialiser.py
+++ b/antismash/common/test/test_serialiser.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,consider-using-with
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,consider-using-with
 
 from collections import OrderedDict
 from io import StringIO

--- a/antismash/common/test/test_utils.py
+++ b/antismash/common/test/test_utils.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/config/test/test_args.py
+++ b/antismash/config/test/test_args.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 from argparse import ArgumentError, Namespace
 import os

--- a/antismash/config/test/test_executables.py
+++ b/antismash/config/test/test_executables.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 from collections import OrderedDict
 import os

--- a/antismash/config/test/test_loader.py
+++ b/antismash/config/test/test_loader.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import os
 import unittest

--- a/antismash/detection/cassis/test/integration_cassis.py
+++ b/antismash/detection/cassis/test/integration_cassis.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,consider-using-with
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,consider-using-with
 
 import os
 from tempfile import TemporaryDirectory

--- a/antismash/detection/cassis/test/test_cassis.py
+++ b/antismash/detection/cassis/test/test_cassis.py
@@ -4,7 +4,7 @@
 """Test suite for the cassis cluster detection plugin"""
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,consider-using-with
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,consider-using-with
 
 from argparse import Namespace
 import os

--- a/antismash/detection/cassis/test/test_cluster_predictions.py
+++ b/antismash/detection/cassis/test/test_cluster_predictions.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/detection/cassis/test/test_islands.py
+++ b/antismash/detection/cassis/test/test_islands.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/detection/cassis/test/test_motifs.py
+++ b/antismash/detection/cassis/test/test_motifs.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import os
 from shutil import copy

--- a/antismash/detection/cassis/test/test_pairings.py
+++ b/antismash/detection/cassis/test/test_pairings.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/detection/cassis/test/test_promoters.py
+++ b/antismash/detection/cassis/test/test_promoters.py
@@ -4,7 +4,7 @@
 """ Tests for CASSIS promoters. """
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from unittest.mock import patch

--- a/antismash/detection/cassis/test/test_runners.py
+++ b/antismash/detection/cassis/test/test_runners.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import os
 from shutil import copy

--- a/antismash/detection/cluster_hmmer/test/integration_cluster_hmmer.py
+++ b/antismash/detection/cluster_hmmer/test/integration_cluster_hmmer.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/detection/cluster_hmmer/test/test_clusterhmmer.py
+++ b/antismash/detection/cluster_hmmer/test/test_clusterhmmer.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from unittest.mock import patch

--- a/antismash/detection/full_hmmer/test/integration_full_hmmer.py
+++ b/antismash/detection/full_hmmer/test/integration_full_hmmer.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/detection/full_hmmer/test/test_fullhmmer.py
+++ b/antismash/detection/full_hmmer/test/test_fullhmmer.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from unittest.mock import patch

--- a/antismash/detection/genefunctions/test/integration_smcogs.py
+++ b/antismash/detection/genefunctions/test/integration_smcogs.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/detection/genefunctions/test/test_core.py
+++ b/antismash/detection/genefunctions/test/test_core.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/detection/genefunctions/test/test_smcogs.py
+++ b/antismash/detection/genefunctions/test/test_smcogs.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/detection/hmm_detection/test/integration_hmm_detection.py
+++ b/antismash/detection/hmm_detection/test/integration_hmm_detection.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import json
 import unittest

--- a/antismash/detection/hmm_detection/test/test_extract_details.py
+++ b/antismash/detection/hmm_detection/test/test_extract_details.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,consider-using-with
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,consider-using-with
 
 from io import StringIO
 import profile

--- a/antismash/detection/hmm_detection/test/test_hmm_detection.py
+++ b/antismash/detection/hmm_detection/test/test_hmm_detection.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,consider-using-with
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,consider-using-with
 
 import glob
 import os

--- a/antismash/detection/nrps_pks_domains/test/integration_domains.py
+++ b/antismash/detection/nrps_pks_domains/test/integration_domains.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from unittest.mock import patch

--- a/antismash/detection/nrps_pks_domains/test/test_modular_domain.py
+++ b/antismash/detection/nrps_pks_domains/test/test_modular_domain.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/detection/nrps_pks_domains/test/test_modules.py
+++ b/antismash/detection/nrps_pks_domains/test/test_modules.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,too-many-public-methods
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,too-many-public-methods
 
 import json
 import unittest

--- a/antismash/detection/sideloader/test/integration_loader.py
+++ b/antismash/detection/sideloader/test/integration_loader.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,too-many-public-methods
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,too-many-public-methods
 
 import unittest
 

--- a/antismash/detection/sideloader/test/test_general.py
+++ b/antismash/detection/sideloader/test/test_general.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,too-many-public-methods
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,too-many-public-methods
 
 import unittest
 

--- a/antismash/detection/sideloader/test/test_loading.py
+++ b/antismash/detection/sideloader/test/test_loading.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,too-many-public-methods
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,too-many-public-methods
 
 import json
 import unittest

--- a/antismash/detection/sideloader/test/test_structures.py
+++ b/antismash/detection/sideloader/test/test_structures.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,too-many-public-methods
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,too-many-public-methods
 
 import json
 import unittest

--- a/antismash/detection/tigrfam/test/integration_tigrfam.py
+++ b/antismash/detection/tigrfam/test/integration_tigrfam.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/detection/tigrfam/test/test_tigrfam.py
+++ b/antismash/detection/tigrfam/test/test_tigrfam.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from unittest.mock import patch

--- a/antismash/modules/active_site_finder/test/integration_analysis.py
+++ b/antismash/modules/active_site_finder/test/integration_analysis.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/active_site_finder/test/test_analysis.py
+++ b/antismash/modules/active_site_finder/test/test_analysis.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,invalid-name,too-few-public-methods
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,invalid-name,too-few-public-methods
 
 import string
 import unittest

--- a/antismash/modules/active_site_finder/test/test_common.py
+++ b/antismash/modules/active_site_finder/test/test_common.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,consider-using-with
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,consider-using-with
 
 import unittest
 from unittest.mock import patch

--- a/antismash/modules/cluster_compare/test/integration_cc.py
+++ b/antismash/modules/cluster_compare/test/integration_cc.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import json
 import unittest

--- a/antismash/modules/cluster_compare/test/test_analysis.py
+++ b/antismash/modules/cluster_compare/test/test_analysis.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import math
 import unittest

--- a/antismash/modules/cluster_compare/test/test_components.py
+++ b/antismash/modules/cluster_compare/test/test_components.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/cluster_compare/test/test_data_structures.py
+++ b/antismash/modules/cluster_compare/test/test_data_structures.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/cluster_compare/test/test_order.py
+++ b/antismash/modules/cluster_compare/test/test_order.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/clusterblast/test/integration_clusterblast.py
+++ b/antismash/modules/clusterblast/test/integration_clusterblast.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import glob
 import os

--- a/antismash/modules/clusterblast/test/test_clusterblast.py
+++ b/antismash/modules/clusterblast/test/test_clusterblast.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 from collections import OrderedDict
 import os

--- a/antismash/modules/clusterblast/test/test_svg_builder.py
+++ b/antismash/modules/clusterblast/test/test_svg_builder.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/lanthipeptides/test/integration_lanthipeptides.py
+++ b/antismash/modules/lanthipeptides/test/integration_lanthipeptides.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import os
 import unittest

--- a/antismash/modules/lanthipeptides/test/test_check_prereqs.py
+++ b/antismash/modules/lanthipeptides/test/test_check_prereqs.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/lanthipeptides/test/test_rodeo.py
+++ b/antismash/modules/lanthipeptides/test/test_rodeo.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/lanthipeptides/test/test_specific_analysis.py
+++ b/antismash/modules/lanthipeptides/test/test_specific_analysis.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from unittest.mock import patch

--- a/antismash/modules/lassopeptides/test/integration_lasso.py
+++ b/antismash/modules/lassopeptides/test/integration_lasso.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/lassopeptides/test/test_prereqs.py
+++ b/antismash/modules/lassopeptides/test/test_prereqs.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/lassopeptides/test/test_specific_analysis.py
+++ b/antismash/modules/lassopeptides/test/test_specific_analysis.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from unittest.mock import patch

--- a/antismash/modules/nrps_pks/at_analysis/test/integration_at_analysis.py
+++ b/antismash/modules/nrps_pks/at_analysis/test/integration_at_analysis.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/nrps_pks/at_analysis/test/test_at_analysis.py
+++ b/antismash/modules/nrps_pks/at_analysis/test/test_at_analysis.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/nrps_pks/kr_analysis/test/integration_kr_analysis.py
+++ b/antismash/modules/nrps_pks/kr_analysis/test/integration_kr_analysis.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/nrps_pks/kr_analysis/test/test_kr_analysis.py
+++ b/antismash/modules/nrps_pks/kr_analysis/test/test_kr_analysis.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import random
 import unittest

--- a/antismash/modules/nrps_pks/minowa/test/integration_minowa.py
+++ b/antismash/modules/nrps_pks/minowa/test/integration_minowa.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
+++ b/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from unittest.mock import patch

--- a/antismash/modules/nrps_pks/test/integration/integration_orderfinder.py
+++ b/antismash/modules/nrps_pks/test/integration/integration_orderfinder.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import os
 import unittest

--- a/antismash/modules/nrps_pks/test/test_nrps_predictor.py
+++ b/antismash/modules/nrps_pks/test/test_nrps_predictor.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from unittest.mock import patch

--- a/antismash/modules/nrps_pks/test/test_orderfinder.py
+++ b/antismash/modules/nrps_pks/test/test_orderfinder.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/nrps_pks/test/test_pks_names.py
+++ b/antismash/modules/nrps_pks/test/test_pks_names.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from antismash.modules.nrps_pks.pks_names import get_long_form, get_short_form

--- a/antismash/modules/nrps_pks/test/test_smiles_generator.py
+++ b/antismash/modules/nrps_pks/test/test_smiles_generator.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from antismash.modules.nrps_pks.smiles_generator import (

--- a/antismash/modules/pfam2go/test/integration_pfam2go.py
+++ b/antismash/modules/pfam2go/test/integration_pfam2go.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/pfam2go/test/test_pfam2go.py
+++ b/antismash/modules/pfam2go/test/test_pfam2go.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/pfam2go/test/test_pfam2go_check_prereqs.py
+++ b/antismash/modules/pfam2go/test/test_pfam2go_check_prereqs.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from unittest.mock import patch

--- a/antismash/modules/rrefinder/test/integration_rrefinder.py
+++ b/antismash/modules/rrefinder/test/integration_rrefinder.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/rrefinder/test/test_rre_domain.py
+++ b/antismash/modules/rrefinder/test/test_rre_domain.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/rrefinder/test/test_rrefinder.py
+++ b/antismash/modules/rrefinder/test/test_rrefinder.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 from collections import defaultdict
 import json as jsonlib

--- a/antismash/modules/sactipeptides/test/integration_sactipeptides.py
+++ b/antismash/modules/sactipeptides/test/integration_sactipeptides.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/sactipeptides/test/test_sactipeptides.py
+++ b/antismash/modules/sactipeptides/test/test_sactipeptides.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/smcog_trees/test/integration_smcogs.py
+++ b/antismash/modules/smcog_trees/test/integration_smcogs.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import glob
 import os

--- a/antismash/modules/t2pks/test/integration_t2pks.py
+++ b/antismash/modules/t2pks/test/integration_t2pks.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/t2pks/test/test_analysis.py
+++ b/antismash/modules/t2pks/test/test_analysis.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from unittest.mock import patch

--- a/antismash/modules/t2pks/test/test_results.py
+++ b/antismash/modules/t2pks/test/test_results.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import json
 import unittest

--- a/antismash/modules/thiopeptides/specific_analysis.py
+++ b/antismash/modules/thiopeptides/specific_analysis.py
@@ -36,7 +36,7 @@ MAX_PRECURSOR_LENGTH = 200
 
 class ThioResults(module_results.ModuleResults):
     """ Results container for thiopeptides """
-    schema_version = 2
+    schema_version = 3
 
     def __init__(self, record_id: str, comparippson_results: comparippson.MultiDBResults = None) -> None:
         super().__init__(record_id)
@@ -69,6 +69,8 @@ class ThioResults(module_results.ModuleResults):
             return None
         if json.get("comparippson") is not None:
             comparison_results = comparippson.MultiDBResults.from_json(json["comparippson"])
+        else:
+            comparison_results = None
         results = ThioResults(json["record_id"], comparippson_results=comparison_results)
         for motif in json["motifs"]:
             results.motifs.append(secmet.Prepeptide.from_json(motif))

--- a/antismash/modules/thiopeptides/test/integration_thiopeptides.py
+++ b/antismash/modules/thiopeptides/test/integration_thiopeptides.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import os
 import unittest

--- a/antismash/modules/thiopeptides/test/test_rodeo.py
+++ b/antismash/modules/thiopeptides/test/test_rodeo.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/thiopeptides/test/test_thio_specific_analysis.py
+++ b/antismash/modules/thiopeptides/test/test_thio_specific_analysis.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,unbalanced-tuple-unpacking
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,unbalanced-tuple-unpacking
 
 import unittest
 from unittest.mock import patch

--- a/antismash/modules/tta/test/integration_tta.py
+++ b/antismash/modules/tta/test/integration_tta.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import os
 from tempfile import TemporaryDirectory

--- a/antismash/modules/tta/test/test_tta.py
+++ b/antismash/modules/tta/test/test_tta.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 from argparse import Namespace
 import unittest

--- a/antismash/outputs/html/test/test_css_components.py
+++ b/antismash/outputs/html/test/test_css_components.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/outputs/html/test/test_generation.py
+++ b/antismash/outputs/html/test/test_generation.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/outputs/html/test/test_json.py
+++ b/antismash/outputs/html/test/test_json.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/outputs/html/test/test_pfam.py
+++ b/antismash/outputs/html/test/test_pfam.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/support/genefinding/test/integration_glimmerhmm.py
+++ b/antismash/support/genefinding/test/integration_glimmerhmm.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import os
 from unittest import TestCase

--- a/antismash/support/genefinding/test/integration_prodigal.py
+++ b/antismash/support/genefinding/test/integration_prodigal.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 from unittest import TestCase
 

--- a/antismash/support/genefinding/test/test_genefinding.py
+++ b/antismash/support/genefinding/test/test_genefinding.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
 from argparse import Namespace

--- a/antismash/test/integration/integration_antismash.py
+++ b/antismash/test/integration/integration_antismash.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,consider-using-with
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,consider-using-with
 
 from argparse import Namespace
 import glob

--- a/antismash/test/test_antismash.py
+++ b/antismash/test/test_antismash.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 from argparse import Namespace
 import logging


### PR DESCRIPTION
Fixes the thiopeptides module schema results having been missed in the CompaRiPPson update (only affected runs with a version post-b8eff304 (merged a day or so ago), with results from prior to b8eff304, merged a day or so ago. Future runs with old results will work as expected.

Fixes `antismash.common.all_orfs.find_all_orfs()` having incorrect behaviour when provided a specific area to search in. This only affected RiPP modules when searching for unannotated precursors. The precursors found would have existed, but their locations within the area were incorrect.

Updates pylint exclusions to remove obsolete message types and add new exclusions for message types which are commonly false positives (e.g. the test files doing equality checks against a specific empty type is important and shouldn't be simplified down to a simple "falsey" value).