### PR TITLE
Fix some database dir HMMs not being repressed when necessary

### DIFF
--- a/antismash/common/pfamdb.py
+++ b/antismash/common/pfamdb.py
@@ -9,7 +9,7 @@ import logging
 import os
 from typing import Dict, List, Optional
 
-from antismash.common import path
+from antismash.common import hmmer, path
 
 KNOWN_MAPPINGS: Dict[str, Dict[str, str]] = {}  # tracks name mappings per database
 KNOWN_CUTOFFS: Dict[str, Dict[str, float]] = {}  # tracks profile cutoffs per database
@@ -43,11 +43,12 @@ def find_latest_database_version(database_dir: str) -> str:
 def check_db(db_path: str) -> List[str]:
     "Check that all required files exist for a database"
     failure_messages = []
-    for file_name in ['Pfam-A.hmm', 'Pfam-A.hmm.h3f', 'Pfam-A.hmm.h3i',
-                      'Pfam-A.hmm.h3m', 'Pfam-A.hmm.h3p']:
-        if not path.locate_file(os.path.join(db_path, file_name)):
-            failure_messages.append("Failed to locate file: %r in %s" % (file_name, db_path))
-
+    file_name = 'Pfam-A.hmm'
+    full_path = os.path.join(db_path, file_name)
+    if not path.locate_file(full_path):
+        failure_messages.append("Failed to locate file: %r in %s" % (file_name, db_path))
+    else:
+        failure_messages.extend(hmmer.ensure_database_pressed(full_path, return_not_raise=True))
     return failure_messages
 
 

--- a/antismash/detection/genefunctions/__init__.py
+++ b/antismash/detection/genefunctions/__init__.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 
 from antismash.common import hmmer, module_results, path
 from antismash.common.secmet import Record
-from antismash.config import ConfigType
+from antismash.config import ConfigType, get_config
 from antismash.config.args import ModuleArgs
 from antismash.detection import DetectionStage
 
@@ -90,8 +90,13 @@ def prepare_data(logging_only: bool = False) -> List[str]:
         Returns:
             a list of error messages (only if logging_only is True)
     """
-    database = path.get_full_path(__file__, 'data', 'smcogs.hmm')
-    return hmmer.ensure_database_pressed(database, return_not_raise=logging_only)
+    failures = []
+    for database in [
+        path.get_full_path(__file__, 'data', 'smcogs.hmm'),
+        os.path.join(get_config().database_dir, 'resfam', 'Resfams.hmm'),
+    ]:
+        failures.extend(hmmer.ensure_database_pressed(database, return_not_raise=logging_only))
+    return failures
 
 
 def check_prereqs(options: ConfigType) -> List[str]:


### PR DESCRIPTION
Fixes an edge case where one was doing development work with `make clean` and `--database-dir` was using the `databases` directory in the source tree rather than in another location.