### PR TITLE
Small fixes

### DIFF
--- a/antismash/detection/genefunctions/__init__.py
+++ b/antismash/detection/genefunctions/__init__.py
@@ -43,7 +43,7 @@ class AllFunctionResults(module_results.DetectionResults):
 
     @staticmethod
     def from_json(json: Dict[str, Any], record: Record) -> Optional["AllFunctionResults"]:
-        if json.get("schema_version") != FunctionResults.schema_version:
+        if json.get("schema_version") != AllFunctionResults.schema_version:
             logging.debug("Schema version mismatch, discarding %s results", NAME)
             return None
         if record.id != json.get("record_id"):

--- a/antismash/detection/genefunctions/core.py
+++ b/antismash/detection/genefunctions/core.py
@@ -15,7 +15,7 @@ from antismash.common.secmet.qualifiers import GeneFunction
 
 class FunctionResults(DetectionResults):
     """ A results container for results functions for a particular tool """
-    schema_version = 1
+    schema_version = 2
 
     def __init__(self, record_id: str, tool: str, best_hits: Dict[str, HMMResult],
                  function_mapping: Dict[str, GeneFunction]) -> None:
@@ -46,7 +46,7 @@ class FunctionResults(DetectionResults):
             return None
         hits = {}
         for hit, parts in json["best_hits"].items():
-            hits[hit] = HMMResult(*parts)
+            hits[hit] = HMMResult.from_json(parts)
 
         mapping = {}
         for cds_name, simple_function in json["mapping"].items():
@@ -59,8 +59,7 @@ class FunctionResults(DetectionResults):
         return {"schema_version": self.schema_version,
                 "record_id": self.record_id,
                 "tool": self.tool,
-                "best_hits": {key: [getattr(val, attr) for attr in val.__slots__]
-                              for key, val in self.best_hits.items()},
+                "best_hits": {key: val.to_json() for key, val in self.best_hits.items()},
                 "mapping": {name: str(function) for name, function in self.function_mapping.items()},
                 }
 

--- a/antismash/detection/genefunctions/test/integration_smcogs.py
+++ b/antismash/detection/genefunctions/test/integration_smcogs.py
@@ -4,6 +4,7 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
+import json
 import unittest
 
 from helperlibs.bio import seqio
@@ -76,13 +77,11 @@ class TestSMCOGs(unittest.TestCase):
         assert results.tool == "smcogs"
         assert results.best_hits["nisB"].hit_id == 'SMCOG1155:Lantibiotic dehydratase domain protein'
 
-        json = results.to_json()
-        assert json["best_hits"]["nisB"][0] == 'SMCOG1155:Lantibiotic dehydratase domain protein'
-
-        reconstructed = core.FunctionResults.from_json(json, self.record)
+        data = json.loads(json.dumps(results.to_json()))
+        reconstructed = core.FunctionResults.from_json(data, self.record)
         assert reconstructed.tool == "smcogs"
         assert reconstructed.best_hits["nisB"].hit_id == 'SMCOG1155:Lantibiotic dehydratase domain protein'
-        assert reconstructed.to_json() == json
+        assert reconstructed.to_json() == data
 
     def test_annotations(self):
         results = smcogs.classify(self.record.id, self.record.get_cds_features(), self.options)

--- a/antismash/detection/genefunctions/test/test_core.py
+++ b/antismash/detection/genefunctions/test/test_core.py
@@ -4,6 +4,7 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
+import json
 import unittest
 
 import antismash
@@ -54,20 +55,20 @@ class SimpleResultsMixin:
     """
 
     def test_bad_record_id(self):
-        json = self.results.to_json()
+        data = json.loads(json.dumps(self.results.to_json()))
         self.record.id = "other"
-        assert self.res_class.from_json(json, self.record) is None
+        assert self.res_class.from_json(data, self.record) is None
 
-        del json["record_id"]
-        assert self.res_class.from_json(json, self.record) is None
+        del data["record_id"]
+        assert self.res_class.from_json(data, self.record) is None
 
     def test_bad_schema_version(self):
-        json = self.results.to_json()
-        json["schema_version"] += 1
-        assert self.res_class.from_json(json, self.record) is None
+        data = json.loads(json.dumps(self.results.to_json()))
+        data["schema_version"] += 1
+        assert self.res_class.from_json(data, self.record) is None
 
-        del json["schema_version"]
-        assert self.res_class.from_json(json, self.record) is None
+        del data["schema_version"]
+        assert self.res_class.from_json(data, self.record) is None
 
 
 class TestFunctionResults(unittest.TestCase, SimpleResultsMixin):
@@ -104,13 +105,13 @@ class TestFunctionResults(unittest.TestCase, SimpleResultsMixin):
                                  function_mapping=mapping)
         check_results(results)
 
-        json = results.to_json()
-        assert json["best_hits"]["cds1"][0] == hits["cds1"].hit_id
+        data = json.loads(json.dumps(results.to_json()))
 
         record = DummyRecord()
         record.id = "rec_id"
-        reconstructed = self.res_class.from_json(json, record)
+        reconstructed = self.res_class.from_json(data, record)
         check_results(reconstructed)
+        assert reconstructed.best_hits["cds1"].hit_id == hits["cds1"].hit_id
 
 
 class TestAllFunctionResults(unittest.TestCase, SimpleResultsMixin):
@@ -143,10 +144,10 @@ class TestAllFunctionResults(unittest.TestCase, SimpleResultsMixin):
         self.results.add_tool_results(tool_result)
         check_results(self.results, mapping)
 
-        json = self.results.to_json()
-        assert json["tools"]
-        reconstructed = self.res_class.from_json(json, self.record)
+        data = json.loads(json.dumps(self.results.to_json()))
+        assert data["tools"]
+        reconstructed = self.res_class.from_json(data, self.record)
         check_results(reconstructed, mapping)
 
-        reconstructed = genefunctions.regenerate_previous_results(json, self.record, None)
+        reconstructed = genefunctions.regenerate_previous_results(data, self.record, None)
         check_results(reconstructed, mapping)

--- a/antismash/detection/nrps_pks_domains/domain_drawing.py
+++ b/antismash/detection/nrps_pks_domains/domain_drawing.py
@@ -150,7 +150,12 @@ def _parse_domain(record: Record, domain: NRPSPKSQualifier.Domain,
                  "&amp;QUERY={}"
                  "&amp;LINK_LOC=protein&amp;PAGE_TYPE=BlastSearch").format(domainseq)
 
-    dna_sequence = feature.extract(record.seq)
+    dna_sequence = ""
+    for as_domain in record.get_antismash_domains_in_cds(feature):
+        if as_domain.get_name() == domain.feature_name:
+            dna_sequence = as_domain.extract(record.seq)
+            break
+    assert dna_sequence
     css, abbreviation = get_css_class_and_abbreviation(domain.name)
     return JSONDomain(domain, predictions, napdoslink, blastlink, domainseq, dna_sequence,
                       abbreviation, css)

--- a/antismash/test/test_antismash.py
+++ b/antismash/test/test_antismash.py
@@ -38,7 +38,9 @@ class TestAntismash(unittest.TestCase):
     def test_help_options(self):
         for option in ["--list-plugins"]:
             options = build_config([option], isolated=False, modules=self.all_modules)
-            ret_val = main.run_antismash("", options)
+            # don't bother with executables, that's not relevant for this
+            with patch.object(main, "_log_found_executables", return_value=None):
+                ret_val = main.run_antismash("", options)
             assert ret_val == 0
 
     def test_prepare(self):


### PR DESCRIPTION
- adds support for adding/overriding environment variables when executing external commands
- disables the phoning home of NCBI command line tools, responsible for a silly amount of time used when NCBI has network issues
- changes genefunctions results to use proper JSON converters for future conversions (and cleans up the tests to allow better testing of those conversions)
- fixes #341 