### PR TITLE
Update NAPDOS links to v2, and other small changes

### DIFF
--- a/antismash/detection/nrps_pks_domains/domain_drawing.py
+++ b/antismash/detection/nrps_pks_domains/domain_drawing.py
@@ -13,7 +13,7 @@ import string
 from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
 
 from antismash.common import path
-from antismash.common.html_renderer import FileTemplate, HTMLSections
+from antismash.common.html_renderer import FileTemplate, HTMLSections, replace_with
 from antismash.common.json import JSONDomain, JSONOrf, JSONModule
 from antismash.common.layers import RegionLayer, RecordLayer, OptionsLayer
 from antismash.common.module_results import ModuleResults
@@ -146,13 +146,13 @@ def _parse_domain(record: Record, domain: NRPSPKSQualifier.Domain,
             "query_type=aa&amp;ref_seq_file={0}"
             "&amp;Sequence=%3E{0}_domain_from_antiSMASH%0D{1}")
     if domain.name == "PKS_KS":
-        napdoslink = base.format(_NAPDOS_REFERENCES["KS"], domainseq)
+        napdoslink = base.format(_NAPDOS_REFERENCES["KS"], replace_with("sequence"))
     elif "Condensation" in domain.name:
-        napdoslink = base.format(_NAPDOS_REFERENCES["C"], domainseq)
+        napdoslink = base.format(_NAPDOS_REFERENCES["C"], replace_with("sequence"))
     blastlink = ("http://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE=Proteins"
                  "&amp;PROGRAM=blastp&amp;BLAST_PROGRAMS=blastp"
-                 "&amp;QUERY={}"
-                 "&amp;LINK_LOC=protein&amp;PAGE_TYPE=BlastSearch").format(domainseq)
+                 f"&amp;QUERY={replace_with('sequence')}"
+                 "&amp;LINK_LOC=protein&amp;PAGE_TYPE=BlastSearch")
 
     dna_sequence = ""
     for as_domain in record.get_antismash_domains_in_cds(feature):

--- a/antismash/detection/nrps_pks_domains/domain_drawing.py
+++ b/antismash/detection/nrps_pks_domains/domain_drawing.py
@@ -91,6 +91,10 @@ _CLASS_BY_NAME = {
     "Trans-AT_docking": "docking",
     "TD": "terminal",
 }
+_NAPDOS_REFERENCES = {
+    "C": "all_C_190411_273.faa",
+    "KS": "all_KS_191020_1877.faa",
+}
 
 
 def will_handle(_products: List[str], product_categories: Set[str]) -> bool:
@@ -138,13 +142,13 @@ def _parse_domain(record: Record, domain: NRPSPKSQualifier.Domain,
     # Create url_link to NaPDoS for C and KS domains
     napdoslink = ""
     domainseq = str(feature.translation)[domain.start:domain.end]
-    base = ("http://napdos.ucsd.edu/cgi-bin/process_request.cgi?"
-            "query_type=aa&amp;ref_seq_file=all_{0}_public_12062011.faa"
+    base = ("https://npdomainseeker.sdsc.edu/cgi-bin/process_request_napdos2.cgi?"
+            "query_type=aa&amp;ref_seq_file={0}"
             "&amp;Sequence=%3E{0}_domain_from_antiSMASH%0D{1}")
     if domain.name == "PKS_KS":
-        napdoslink = base.format("KS", domainseq)
+        napdoslink = base.format(_NAPDOS_REFERENCES["KS"], domainseq)
     elif "Condensation" in domain.name:
-        napdoslink = base.format("C", domainseq)
+        napdoslink = base.format(_NAPDOS_REFERENCES["C"], domainseq)
     blastlink = ("http://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE=Proteins"
                  "&amp;PROGRAM=blastp&amp;BLAST_PROGRAMS=blastp"
                  "&amp;QUERY={}"

--- a/antismash/outputs/html/css/style.scss
+++ b/antismash/outputs/html/css/style.scss
@@ -1448,6 +1448,11 @@ ul.dropdown-options {
     stroke: black;
 }
 
+.bubble-module-line-non-elongating {
+    @extend .bubble-module-line;
+    stroke-dasharray: 0.5em;
+}
+
 .domain-bubble-container {
     * .bubble-module-label {
         .bubble-module-monomer {

--- a/antismash/outputs/html/test/test_generation.py
+++ b/antismash/outputs/html/test/test_generation.py
@@ -6,6 +6,8 @@
 
 import unittest
 
+from helperlibs.wrappers.io import TemporaryDirectory
+
 from antismash.main import get_all_modules
 from antismash.common.secmet.test.helpers import DummySubRegion
 from antismash.common.test.helpers import DummyRecord
@@ -31,4 +33,6 @@ class TestOutput(unittest.TestCase):
         update_config({"triggered_limit": False})
 
         # make sure HTML is generated without errors
-        assert generate_webpage([record], [{}], self.options, get_all_modules())
+        with TemporaryDirectory() as temp_dir:
+            update_config({"output_dir": temp_dir})
+            assert generate_webpage([record], [{}], self.options, get_all_modules())


### PR DESCRIPTION
Also includes a couple of small fixes for test file creation and deduplication of domain sequences in NRPS/PKS domain tooltips.