### PR TITLE
config: Allow long headers by default

### DIFF
--- a/antismash/common/test/test_record_processing.py
+++ b/antismash/common/test/test_record_processing.py
@@ -292,14 +292,14 @@ class TestPreprocessRecords(unittest.TestCase):
         record.id = "A" * 17
         record.name = record.id
         self.run_on_records([record])
-        assert len(record.id) <= 16
-        assert len(record.name) <= 16
+        assert record.id == record.name == "A" * 17
 
-        config.update_config({"allow_long_headers": True})
+        config.update_config({"allow_long_headers": False})
         record.id = "A" * 17
         record.name = record.id
         self.run_on_records([record])
-        assert record.id == record.name == "A" * 17
+        assert len(record.id) <= 16
+        assert len(record.name) <= 16
 
     def test_mac_bad_parallel(self):
         """ For python 3.8+ on mac, parallel behaviour of Pool() changed

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -580,9 +580,9 @@ def advanced_options() -> ModuleArgs:
                            "E.g. diamond=/alternate/path/to/diamond,hmmpfam2=hmm2pfam"))
     group.add_option('--allow-long-headers',
                      dest='allow_long_headers',
-                     action='store_true',
-                     default=False,
-                     help="Prevents long headers from being renamed")
+                     action=argparse.BooleanOptionalAction,
+                     default=True,
+                     help="Should sequence identifiers longer than 16 characters be allowed")
     return group
 
 


### PR DESCRIPTION
Also rename the option to just 'long_headers'

Signed-off-by: Kai Blin <kblin@biosustain.dtu.dk>