### PR TITLE
hmm_detection: rename siderophore rule to NRPS-independent siderophore

### DIFF
--- a/antismash/detection/hmm_detection/cluster_rules/strict.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/strict.txt
@@ -440,9 +440,9 @@ RULE aminocoumarin
     NEIGHBOURHOOD 10
     CONDITIONS novK or novJ or novI or novH or SpcDK_cou
 
-RULE siderophore
+RULE NRPS-independent-siderophore
     CATEGORY other
-    DESCRIPTION Siderophore
+    DESCRIPTION IucA/IucC-like siderophores
     CUTOFF 20
     NEIGHBOURHOOD 5
     CONDITIONS IucA_IucC

--- a/antismash/outputs/html/css/secmet.scss
+++ b/antismash/outputs/html/css/secmet.scss
@@ -127,7 +127,7 @@
     @include secmet(white, crimson, blue);
 }
 
-.siderophore {
+.NRPS-independent-siderophore {
     @include metallophore;
 }
 


### PR DESCRIPTION
Renamed siderophore rule to NRPS-independent-siderophore, to match the name of the biosynthetic pathway rather than the biological function (10.1080/10409238.2018.1476449)

split from https://github.com/antismash/antismash/pull/514

Sorry for the mixup 😬 