### PR TITLE
Contig edge detection improvements

### DIFF
--- a/antismash/common/secmet/features/cdscollection.py
+++ b/antismash/common/secmet/features/cdscollection.py
@@ -107,7 +107,11 @@ class CDSCollection(Feature):
         """
         if not self._parent_record:
             raise ValueError("Cannot determine if on contig edge without parent record")
-        return self._contig_edge
+        if self._contig_edge:
+            return self._contig_edge
+        if self._children:
+            return any(child.contig_edge for child in self._children)
+        return False
 
     def add_cds(self, cds: CDSFeature) -> None:
         """ Add a CDS to the collection covered by this feature, also adds to

--- a/antismash/common/secmet/features/protocluster.py
+++ b/antismash/common/secmet/features/protocluster.py
@@ -66,13 +66,17 @@ class Protocluster(CDSCollection):
             raise ValueError("Protocluster not in a record")
         return self._parent_record.get_protocluster_number(self)
 
-    @parent_record.setter
-    def parent_record(self, record: Any) -> None:  # again, should be Record
-        """ Sets the parent record to a secmet.Record instance """
+    @property
+    def contig_edge(self) -> bool:
+        # always trust an explicit positive
+        if super().contig_edge:
+            return True
+        # then check, and update the stored value, if either cutoff or neighbourhood extend that far
         start = min(self.location.start, self.core_location.start - self.cutoff)
         end = max(self.location.end, self.core_location.end + self.cutoff)
-        self._contig_edge = start <= 0 or end >= len(record.seq)
-        super().parent_record = record
+        contig_edge = start < 0 or end >= len(self.parent_record.seq)
+        self._contig_edge = contig_edge
+        return contig_edge
 
     @property
     def definition_cdses(self) -> Set[CDSFeature]:

--- a/antismash/common/secmet/features/protocluster.py
+++ b/antismash/common/secmet/features/protocluster.py
@@ -66,6 +66,14 @@ class Protocluster(CDSCollection):
             raise ValueError("Protocluster not in a record")
         return self._parent_record.get_protocluster_number(self)
 
+    @parent_record.setter
+    def parent_record(self, record: Any) -> None:  # again, should be Record
+        """ Sets the parent record to a secmet.Record instance """
+        start = min(self.location.start, self.core_location.start - self.cutoff)
+        end = max(self.location.end, self.core_location.end + self.cutoff)
+        self._contig_edge = start <= 0 or end >= len(record.seq)
+        super().parent_record = record
+
     @property
     def definition_cdses(self) -> Set[CDSFeature]:
         """ Returns the set of CDSFeatures responsible for the creation of this protocluster """

--- a/antismash/common/secmet/test/helpers.py
+++ b/antismash/common/secmet/test/helpers.py
@@ -19,6 +19,7 @@ from ..features import (
 )
 from ..features.candidate_cluster import CandidateClusterKind
 from ..locations import FeatureLocation
+from ..record import Record
 
 
 class DummyAntismashDomain(AntismashDomain):
@@ -112,6 +113,19 @@ class DummyPFAMDomain(PFAMDomain):
         super().__init__(location, description, protein_location, identifier, tool, locus_tag, domain=domain)
         self.domain_id = domain_id or "dummy_pfam_%d" % DummyPFAMDomain.counter
         DummyPFAMDomain.counter += 1
+
+
+class DummyRecord(Record):
+    "class for generating a Record like data structure"
+    def __init__(self, features=None, seq='AGCTACGT', taxon='bacteria',
+                 record_id=None):
+        super().__init__(seq, transl_table=11 if taxon == 'bacteria' else 1)
+        if features:
+            for feature in features:
+                self.add_feature(feature)
+        self.record_index = 0
+        if record_id is not None:
+            self.id = record_id
 
 
 class DummyRegion(Region):

--- a/antismash/common/test/helpers.py
+++ b/antismash/common/test/helpers.py
@@ -28,6 +28,7 @@ from antismash.common.secmet.test.helpers import (  # for import by others, pyli
     DummyFeature,
     DummyPFAMDomain,
     DummyProtocluster,
+    DummyRecord,
     DummyRegion,
 )
 from antismash.config import update_config
@@ -40,19 +41,6 @@ def get_simple_options(module, args):
     if module is not None:
         modules = [module]
     return build_parser(from_config_file=False, modules=modules).parse_args(args)
-
-
-class DummyRecord(Record):
-    "class for generating a Record like data structure"
-    def __init__(self, features=None, seq='AGCTACGT', taxon='bacteria',
-                 record_id=None):
-        super().__init__(seq, transl_table=11 if taxon == 'bacteria' else 1)
-        if features:
-            for feature in features:
-                self.add_feature(feature)
-        self.record_index = 0
-        if record_id is not None:
-            self.id = record_id
 
 
 class FakeHSP:


### PR DESCRIPTION
Since the first rule with a cutoff larger than it's neighbourhood was introduced in #487, it was possible for a protocluster to lie on the edge of a record and have looked _past_ the edge for part of the rules, but it still wouldn't count as being on the contig edge. That could lead to some misleading reports.

This PR changes contig edge calculations for protoclusters to use the largest of cutoff and neighbourhood ranges, and parent `CDSCollection`s now check the state of all child collections.