### PR TITLE
nrps_pks_domains: fix default state of modules showing domains

### DIFF
--- a/antismash/detection/nrps_pks_domains/domain_drawing.py
+++ b/antismash/detection/nrps_pks_domains/domain_drawing.py
@@ -236,7 +236,7 @@ def domains_have_predictions(region: Union[Region, RegionLayer]) -> bool:
     """ Returns True if any domain in the region has a prediction made for it """
     for feature in region.cds_children:
         for domain in feature.nrps_pks.domains:
-            if "consensus" in domain.get_predictions():
+            if "substrate consensus" in domain.get_predictions():
                 return True
     return False
 


### PR DESCRIPTION
In 4ece39d74 I changed the name of the NRPS/PKS substrate consensus key, but didn't update it in the drawing logic, which disabled, by default, the showing of module lids with substrates even when there were substrates predicted for modules.

This PR fixes that and changes the tests to catch similar issues in future.