### PR TITLE
Small HTML tweaks and a version bump to beta

### DIFF
--- a/antismash/common/comparippson/__init__.py
+++ b/antismash/common/comparippson/__init__.py
@@ -6,6 +6,7 @@ import os
 from typing import List
 
 from antismash.common import path, subprocessing
+from antismash.common.html_renderer import Markup, docs_link
 from antismash.config import ConfigType, get_config
 
 from .analysis import compare_precursor_cores, MultiDBResults
@@ -86,3 +87,11 @@ def check_prereqs(options: ConfigType) -> List[str]:
     failure_messages.extend(prepare_data(logging_only=True))
 
     return failure_messages
+
+
+def get_tooltip_text() -> Markup:
+    """ Returns generalised tooltip text, including link, for CompaRiPPson """
+    return Markup(
+        "Includes CompaRiPPson results for any available databases, "
+        f"with a detailed explanation {docs_link('here', 'modules/comparippson')}."
+    )

--- a/antismash/common/comparippson/analysis.py
+++ b/antismash/common/comparippson/analysis.py
@@ -124,7 +124,8 @@ class MultiDBResults(JsonConvertible):
         for db_name, hits in self.by_query[query].hits.items():
             db = self.db_by_name[db_name]
             assert isinstance(db, ComparippsonDB), type(db)
-            hits = sorted(hits, key=lambda x: (-x.match_count, x.reference.sequence))
+            hits = sorted(hits, key=lambda x: (-x.match_count, x.reference.sequence,
+                                               db.build_identifier_for_hit(x)))
             groups = []
             same = []
             current = hits[0]

--- a/antismash/common/comparippson/analysis.py
+++ b/antismash/common/comparippson/analysis.py
@@ -143,6 +143,8 @@ class MultiDBResults(JsonConvertible):
                 current = hit
                 same = []
             groups.append((current, f"and {len(same)} other{'s' if len(same) > 1 else ''}" if same else "", same))
+            # sort by descending similarity, descending group size, and ascending name, in that order
+            groups.sort(key=lambda g: (-g[0].similarity, -len(hits), db.build_identifier_for_hit(g[0])))
             chunks.append(template.render(coloured_ripp_sequence=colour_sequence,
                                           name=display_name, db=db, groups=groups))
         return Markup("".join(chunks))

--- a/antismash/common/comparippson/test/test_analysis.py
+++ b/antismash/common/comparippson/test/test_analysis.py
@@ -10,6 +10,7 @@ import json
 import unittest
 from unittest.mock import patch
 
+from antismash.common import comparippson
 from antismash.common.comparippson import analysis, databases
 from antismash.common.comparippson.databases import (
     ComparippsonDatabase as Database,
@@ -295,3 +296,13 @@ class TestFiltering(unittest.TestCase):
         cores, aliases = analysis.filter_duplicates(data)
         assert cores == {"name": "CORE", "different": "DIFF"}
         assert aliases == {"another": "name"}
+
+
+class TestTooltipText(unittest.TestCase):
+    def test_tooltip(self):
+        link = "<a dummy>text</a>"
+        with patch.object(comparippson, "docs_link", return_value=link) as patched:
+            text = comparippson.get_tooltip_text()
+            patched.assert_called_once()
+        assert isinstance(link, str)
+        assert link in text

--- a/antismash/detection/nrps_pks_domains/domain_drawing.py
+++ b/antismash/detection/nrps_pks_domains/domain_drawing.py
@@ -13,7 +13,13 @@ import string
 from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
 
 from antismash.common import path
-from antismash.common.html_renderer import FileTemplate, HTMLSections, replace_with
+from antismash.common.html_renderer import (
+    FileTemplate,
+    HTMLSections,
+    Markup,
+    docs_link,
+    replace_with,
+)
 from antismash.common.json import JSONDomain, JSONOrf, JSONModule
 from antismash.common.layers import RegionLayer, RecordLayer, OptionsLayer
 from antismash.common.module_results import ModuleResults
@@ -253,8 +259,17 @@ def generate_html(region_layer: RegionLayer, _results: ModuleResults,
     # hide lids by default if none have predictions (e.g. in a minimal run)
     hide_lids = not domains_have_predictions(region_layer)
 
+    tooltip = Markup(
+        f"Shows {docs_link('NRPS', 'glossary/#nrps')}- and {docs_link('PKS', 'glossary/#t1pks')}-"
+        "related domains for each feature that contains them. "
+        "Click on each domain for more information about the domain's location, "
+        "consensus monomer prediction, and other details.<br>"
+        f"A domain glossary is available {docs_link('here', 'modules/nrps_pks_domains/')}, "
+        f"and an explanation of the visualisation is available {docs_link('here', 'modules/nrps_pks_modules/')}."
+    )
+
     section = template.render(has_domain_details=has_domain_details, region=region_layer,
                               record=record_layer,
-                              docs_url=options_layer.urls.docs_baseurl, hide_lids=hide_lids)
+                              tooltip_text=tooltip, hide_lids=hide_lids)
     html.add_detail_section("NRPS/PKS domains", section)
     return html

--- a/antismash/detection/nrps_pks_domains/templates/details.html
+++ b/antismash/detection/nrps_pks_domains/templates/details.html
@@ -1,7 +1,7 @@
 <div class="details">
     <div class="heading">
       <span>Detailed domain annotation</span>
-      {{help_tooltip("Shows <a href='{0}glossary/#nrps' target='_blank'>NRPS</a>- and <a href='{0}glossary/#pks' target='_blank'>PKS</a>-related domains for each feature that contains them. Click on each domain for more information about the domain's location, consensus monomer prediction, and other details.<br>A glossary is available <a href='{0}modules/nrps_pks_domains/' target='_blank'>here</a>.".format(docs_url), "nrps-domain")}}
+      {{ help_tooltip(tooltip_text, "nrps-domain") }}
       <div class="download-container">
         <div class="download-icon download-svg" data-tag="{{region.anchor_id}}-details-svg" data-filename="{{record.id}}_{{region.anchor_id}}_nrps_pks.svg">
         </div>

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -40,7 +40,7 @@ from antismash.outputs import html, svg
 from antismash.support import genefinding
 from antismash.custom_typing import AntismashModule
 
-__version__ = "7.0.0alpha1"
+__version__ = "7.0.0beta1"
 
 
 def _gather_analysis_modules() -> List[AntismashModule]:

--- a/antismash/modules/lanthipeptides/html_output.py
+++ b/antismash/modules/lanthipeptides/html_output.py
@@ -7,7 +7,7 @@
 from collections import defaultdict
 from typing import List, Set
 
-from antismash.common import path
+from antismash.common import comparippson, path
 from antismash.common.html_renderer import HTMLSections, FileTemplate, Markup
 from antismash.common.layers import RegionLayer, RecordLayer, OptionsLayer
 
@@ -38,7 +38,7 @@ def generate_html(region_layer: RegionLayer, results: LanthiResults,
 
     detail_tooltip = Markup("<br>".join([
         "Shows the possible core peptides for each biosynthetic enzyme.",
-        "Includes CompaRiPPson results for any available databases."
+        comparippson.get_tooltip_text(),
     ]))
     template = FileTemplate(path.get_full_path(__file__, "templates", "details.html"))
     html.add_detail_section("Lanthipeptides", template.render(results=motifs_by_locus_by_core, tooltip=detail_tooltip,

--- a/antismash/modules/lassopeptides/html_output.py
+++ b/antismash/modules/lassopeptides/html_output.py
@@ -6,7 +6,7 @@
 
 from typing import Dict, List, Set
 
-from antismash.common import path
+from antismash.common import comparippson, path
 from antismash.common.html_renderer import HTMLSections, FileTemplate, Markup
 from antismash.common.layers import RecordLayer, RegionLayer, OptionsLayer
 
@@ -36,11 +36,13 @@ def generate_html(region_layer: RegionLayer, results: LassoResults,
             motifs_by_core[motif.core].append(motif)
         by_locus[locus] = motifs_by_core
 
-    detail_tooltip = Markup(
-        "Lists the possible core peptides for each biosynthetic enzyme. "
-        "Each core peptide shows the leader and core peptide sequences."
-        "<br>Includes CompaRiPPson results for any available databases."
-    )
+    detail_tooltip = Markup("<br>".join([
+        (
+            "Lists the possible core peptides for each biosynthetic enzyme. "
+            "Each core peptide shows the leader and core peptide sequences. "
+        ),
+        comparippson.get_tooltip_text(),
+    ]))
 
     template = FileTemplate(path.get_full_path(__file__, "templates", "details.html"))
     section = template.render(motifs_by_locus=by_locus, tooltip=detail_tooltip,

--- a/antismash/modules/sactipeptides/html_output.py
+++ b/antismash/modules/sactipeptides/html_output.py
@@ -6,7 +6,7 @@
 from collections import defaultdict
 from typing import Dict, List, Set
 
-from antismash.common import path
+from antismash.common import comparippson, path
 from antismash.common.html_renderer import HTMLSections, FileTemplate, Markup
 from antismash.common.secmet import Prepeptide
 from antismash.common.layers import RegionLayer, RecordLayer, OptionsLayer
@@ -39,11 +39,13 @@ def generate_html(region_layer: RegionLayer, results: SactiResults,
             motifs_by_core[core].append(motif)
         motifs_by_locus_by_core[locus] = motifs_by_core
 
-    detail_tooltip = Markup(
-        "Lists the possible core peptides for each biosynthetic enzyme. "
-        "Each core peptide shows the leader and core peptide sequences. "
-        "<br>Includes CompaRiPPson results for any available databases."
-    )
+    detail_tooltip = Markup("<br>".join([
+        (
+            "Lists the possible core peptides for each biosynthetic enzyme. "
+            "Each core peptide shows the leader and core peptide sequences. "
+        ),
+        comparippson.get_tooltip_text(),
+    ]))
     template = FileTemplate(path.get_full_path(__file__, "templates", "details.html"))
     details = template.render(record=record_layer,
                               options=options_layer,

--- a/antismash/modules/tfbs_finder/html_output.py
+++ b/antismash/modules/tfbs_finder/html_output.py
@@ -10,7 +10,7 @@ from typing import Any, Sequence
 from Bio.Seq import Seq
 
 from antismash.common import path
-from antismash.common.html_renderer import FileTemplate, HTMLSections, Markup
+from antismash.common.html_renderer import FileTemplate, HTMLSections, Markup, docs_link
 from antismash.common.layers import OptionsLayer, RegionLayer, RecordLayer
 from antismash.common.secmet import CDSFeature, Feature, FeatureLocation, Record, Region
 from antismash.common.secmet.locations import location_contains_other
@@ -36,7 +36,7 @@ def will_handle(_products: list[str], _categories: set[str]) -> bool:
 
 
 def generate_html(region_layer: RegionLayer, results: TFBSFinderResults,
-                  _record_layer: RecordLayer, _options_layer: OptionsLayer
+                  _record_layer: RecordLayer, options_layer: OptionsLayer
                   ) -> HTMLSections:
     """ Generates HTML output for the module """
     html = HTMLSections("tfbs-finder")
@@ -63,6 +63,8 @@ def generate_html(region_layer: RegionLayer, results: TFBSFinderResults,
         "Detailed information for Transcription Factor Binding Site hits, including "
         "surrounding genes where applicable. <br>"
         "The strand of the match is shown by an arrow underneath the match."
+        "<br>"
+        f"Detailed documentation is available {docs_link('here', 'modules/tfbs')}."
     )
     details = body.render(hits=other, weak_hits=weak, results=results,
                           tooltip=tooltip, anchor=region_layer.anchor_id)

--- a/antismash/modules/thiopeptides/html_output.py
+++ b/antismash/modules/thiopeptides/html_output.py
@@ -5,7 +5,7 @@
 
 from typing import Dict, List, Set
 
-from antismash.common import path
+from antismash.common import comparippson, path
 from antismash.common.html_renderer import HTMLSections, FileTemplate, Markup
 from antismash.common.layers import RegionLayer, RecordLayer, OptionsLayer
 from antismash.common.secmet import Prepeptide
@@ -32,11 +32,13 @@ def generate_html(region_layer: RegionLayer, results: ThioResults,
     for motif in motifs:
         motif_groups[motif.core].append(motif)
 
-    detail_tooltip = Markup(
-        "Lists the possible core peptides for each biosynthetic enzyme. "
-        "Predicted tail sequences are also shown, if present. "
-        "<br>Includes CompaRiPPson results for any available databases."
-    )
+    detail_tooltip = Markup("<br>".join([
+        (
+            "Lists the possible core peptides for each biosynthetic enzyme. "
+            "Predicted tail sequences are also shown, if present. "
+        ),
+        comparippson.get_tooltip_text(),
+    ]))
     template = FileTemplate(path.get_full_path(__file__, "templates", "details.html"))
     details = template.render(record=record_layer,
                               motif_groups=motif_groups.values(),

--- a/antismash/outputs/html/__init__.py
+++ b/antismash/outputs/html/__init__.py
@@ -24,7 +24,7 @@ from antismash.common.secmet import Record
 from antismash.custom_typing import AntismashModule
 from antismash.config import ConfigType
 from antismash.config.args import ModuleArgs
-from antismash.outputs.html.generator import generate_webpage
+from antismash.outputs.html.generator import generate_webpage, find_local_antismash_js_path
 
 NAME = "html"
 SHORT_DESCRIPTION = "HTML output"
@@ -105,15 +105,11 @@ def write(records: List[Record], results: List[Dict[str, ModuleResults]],
     copy_template_dir('js', output_dir)
     # if there wasn't an antismash.js in the JS dir, fall back to one in databases
     local_path = os.path.join(output_dir, "js", "antismash.js")
-    if os.path.exists(local_path):
-        logging.debug("Results page using antismash.js from local copy: %s",
-                      path.get_full_path(__file__, "js", "antismash.js"))
-    else:
-        version = html_renderer.get_antismash_js_version()
-        data_location = os.path.join(options.database_dir, "js", version, "antismash.js")
-        if os.path.exists(data_location):
-            logging.debug("Results page using antismash.js from local copy: %s", data_location)
-            shutil.copy(data_location, os.path.join(output_dir, "js", "antismash.js"))
+    if not os.path.exists(local_path):
+        js_path = find_local_antismash_js_path(options)
+        if js_path:
+            logging.debug("Results page using antismash.js from local copy: %s", js_path)
+            shutil.copy(js_path, os.path.join(output_dir, "js", "antismash.js"))
     # and if it's still not there, that's fine, it'll use a web-accessible URL
     if not os.path.exists(local_path):
         logging.debug("Results page using antismash.js from remote host")

--- a/antismash/outputs/html/css/style.scss
+++ b/antismash/outputs/html/css/style.scss
@@ -45,6 +45,7 @@ a, .clipboard-copy, .link-like {
     cursor: pointer;
     padding-right: 0.3em;
     padding-left: 0.3em;
+    padding-top: 0.3em;
     font-size: 95%;  /* just enough to have background between links in text */
 
     &:active {

--- a/antismash/outputs/html/generator.py
+++ b/antismash/outputs/html/generator.py
@@ -8,7 +8,7 @@ import json
 import pkgutil
 import string
 import os
-from typing import cast, Any, Dict, List, Tuple, Union
+from typing import cast, Any, Dict, List, Tuple, Union, Optional
 
 from antismash.common import path
 from antismash.common.html_renderer import (
@@ -163,6 +163,25 @@ def generate_html_sections(records: List[RecordLayer], results: Dict[str, Dict[s
     return details
 
 
+def find_local_antismash_js_path(options: ConfigType) -> Optional[str]:
+    """ Finds the a path to a local copy of antismash.js, if possible,
+        otherwise returns None.
+    """
+    # is a copy in the js directory?
+    js_path = path.locate_file(path.get_full_path(__file__, "js", "antismash.js"), silent=True)
+    if js_path:
+        return js_path
+
+    # is it in the databases?
+    version = get_antismash_js_version()
+    js_path = path.locate_file(os.path.join(options.database_dir, "as-js", version, "antismash.js"), silent=True)
+    if js_path:
+        return js_path
+
+    # then it doesn't exist
+    return None
+
+
 def build_antismash_js_url(options: ConfigType) -> str:
     """ Build the URL to the javascript that will be embedded in the HTML.
         If a local version is available, it will be copied into the output directory,
@@ -174,13 +193,8 @@ def build_antismash_js_url(options: ConfigType) -> str:
         Returns:
             a string of the URL, whether relative or absolute
     """
-    local = path.locate_file(path.get_full_path(__file__, "js", "antismash.js"), silent=True)
-    if local:
+    if find_local_antismash_js_path(options):
         return "js/antismash.js"  # generic local path after copy
-    version = get_antismash_js_version()
-    data = path.locate_file(os.path.join(options.database_dir, "as-js", version, "antismash.js"), silent=True)
-    if data:
-        return "js/antismash.js"
     return get_antismash_js_url()
 
 

--- a/antismash/outputs/html/visualisers/bubble_view.py
+++ b/antismash/outputs/html/visualisers/bubble_view.py
@@ -13,7 +13,12 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Set
 
 from antismash.common import path
-from antismash.common.html_renderer import HTMLSections, FileTemplate
+from antismash.common.html_renderer import (
+    HTMLSections,
+    FileTemplate,
+    Markup,
+    docs_link,
+)
 from antismash.common.layers import OptionsLayer, RecordLayer, RegionLayer
 from antismash.common.module_results import ModuleResults
 from antismash.common.secmet import Module, Record, Region
@@ -75,8 +80,19 @@ def generate_html(region_layer: RegionLayer, all_results: Dict[str, ModuleResult
 
     nrps_layer = NrpspksLayer(results, region_layer.region_feature, record_layer)
 
+    tooltip = Markup(
+        f"Shows module structures for each candidate cluster in {docs_link('NRPS', 'glossary/#nrps')} "
+        f"and {docs_link('PKS', 'glossary/#t1pks')} regions. "
+        "<br>"
+        "Genes are shown in predicted order, and are only present when containing at least one complete module. "
+        "<br>"
+        f"A domain glossary is available {docs_link('here', 'modules/nrps_pks_domains/')}, "
+        "and an explanation of the visualisation is available "
+        f"{docs_link('here', 'modules/nrps_pks_modules/#bubblemodule-only-drawing')}. "
+    )
     template = FileTemplate(path.get_full_path(__file__, "templates", "bubble_view.html"))
-    section = template.render(record=record_layer, region=nrps_layer, docs_url=options_layer.urls.docs_baseurl)
+    section = template.render(record=record_layer, region=nrps_layer, docs_url=options_layer.urls.docs_baseurl,
+                              tooltip_text=tooltip)
     html.add_detail_section("NRPS/PKS modules", section, "nrps-pks-bubbles")
 
     return html

--- a/antismash/outputs/html/visualisers/templates/bubble_view.html
+++ b/antismash/outputs/html/visualisers/templates/bubble_view.html
@@ -1,9 +1,7 @@
 <div class="details">
     <div class="heading">
       <span>Module view</span>
-      {{help_tooltip("Shows module structures for each candidate in <a href='{0}glossary/#nrps' target='_blank'>NRPS</a>- and <a href='{0}glossary/#t1pks' target='_blank'>PKS</a>
-                     regions. Genes are shown in predicted order, and are only present when containing at least one complete module.
-                     A domain glossary is available <a href='{0}modules/nrps_pks_domains/' target='_blank'>here</a>.".format(docs_url), "nrps-pks-bubble-tooltip")}}
+      {{help_tooltip(tooltip_text, "nrps-pks-bubble-tooltip")}}
       <div class="download-container">
         <div class="download-icon download-svg" data-tag="{{region.anchor_id}}-domain-bubble-svg" data-filename="{{record.id}}_{{region.anchor_id}}_domain_bubbles.svg">
         </div>


### PR DESCRIPTION
Updates HTML tooltips for:
- NRPS/PKS tabs to include links to the module visualisation(s) docs page (and point at an existing rule for PKSs)
- TFBS to link to the relevant docs page
- RiPP modules to link to the CompaRiPPson docs page

Also tweaks CompaRiPPson HTML output to sort groups by descending similarity, then descending group size, then accession name. This makes more common sequences more obvious.

Also bumps the version to "beta" state.