### PR TITLE
PKS order finding tweaks

### DIFF
--- a/antismash/modules/nrps_pks/orderfinder.py
+++ b/antismash/modules/nrps_pks/orderfinder.py
@@ -197,8 +197,9 @@ def find_first_and_last_cds(cds_features: List[CDSFeature]) -> Tuple[Optional[CD
     # find the end
     for cds in cds_features:
         if cds.modules and cds.modules[-1].is_final_module():
-            # if this CDS is not the tail end, then don't use it unless it's the last CDS
-            if len(cds.modules[-1].parent_cds_names) > 1 and cds != cds_features[-1]:
+            module = cds.modules[-1]
+            # if this CDS contains the head of a cross-CDS module, it can't be the end
+            if len(module.parent_cds_names) > 1 and cds.get_name() == module.parent_cds_names[0]:
                 continue
             # two possible ends, this really ought to be two products
             if end_cds:

--- a/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
+++ b/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
@@ -132,7 +132,7 @@ class IntegrationNRPSPKS(unittest.TestCase):
         sc_pred = results.region_predictions[1][0]
         assert sc_pred.polymer == '(Me-ccmal) + (Me-ccmal) + (Me-ccmal)'
         assert sc_pred.domain_docking_used
-        assert sc_pred.ordering == ['STAUR_3983', 'STAUR_3984', 'STAUR_3982']
+        assert sc_pred.ordering == ['STAUR_3984', 'STAUR_3983', 'STAUR_3982']
         assert len(results.domain_predictions) == 10
         expected_domains = {'nrpspksdomains_STAUR_3982_PKS_AT.1',
                             'nrpspksdomains_STAUR_3983_PKS_AT.1',

--- a/antismash/modules/nrps_pks/test/test_orderfinder.py
+++ b/antismash/modules/nrps_pks/test/test_orderfinder.py
@@ -116,6 +116,22 @@ class TestOrdering(unittest.TestCase):
         assert not start
         assert not end
 
+    def test_cross_cds_with_terminal(self):
+        other = DummyCDS(locus_tag="other")
+        normal = DummyModule(domains=["PKS_KS", "PKS_AT", "ACP"], complete=True, final=False)
+        other.add_module(normal)
+
+        head = DummyCDS(locus_tag="head")
+        tail = DummyCDS(locus_tag="tail")
+        split = DummyModule(domains=["PKS_KS", "PKS_AT", "ACP", "Thioesterase"], complete=True, final=True)
+        for cds in [head, tail]:
+            cds.add_module(split)
+        assert split.is_final_module()
+        split._parent_cds_names = ["head", "tail"]
+        start, end = orderfinder.find_first_and_last_cds([head, tail, other])
+        assert not start
+        assert end is tail
+
     def test_finding_start_gene(self):
         inputs = {
             "STAUR_3972": {


### PR DESCRIPTION
Fixes finding a final gene for the order when thioesterases and other terminal domains were in a cross-CDS module.

Tweaks the order finding itself to bias towards keeping consecutive genes together.