### PR TITLE
Fungal protocluster size multipliers

### DIFF
--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -183,7 +183,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
 
 from antismash.common.secmet import CDSFeature, FeatureLocation
 
-from .structures import ProfileHit
+from .structures import Multipliers, ProfileHit
 
 
 class RuleSyntaxError(SyntaxError):
@@ -903,9 +903,13 @@ class Parser:  # pylint: disable=too-few-public-methods
     def __init__(self, text: str, signature_names: Set[str],
                  valid_categories: Set[str],
                  existing_rules: List[DetectionRule] = None,
-                 existing_aliases: Dict[str, List[Token]] = None) -> None:
+                 existing_aliases: Dict[str, List[Token]] = None,
+                 multipliers: Multipliers = None,
+                 ) -> None:
         if not existing_rules:
             existing_rules = []
+        if multipliers is None:
+            multipliers = Multipliers()
         self.signature_names = signature_names
         self.rules = list(existing_rules)
         self.rules_by_name = {rule.name: rule for rule in self.rules}
@@ -938,6 +942,8 @@ class Parser:  # pylint: disable=too-few-public-methods
                 self.aliases[name] = tokens
                 continue
             rule = self._parse_rule()
+            rule.cutoff = int(rule.cutoff * multipliers.cutoff)
+            rule.neighbourhood = int(rule.neighbourhood * multipliers.neighbourhood)
             if rule.name in self.rules_by_name:
                 raise ValueError("Multiple rules specified for the same rule name")
             self.rules_by_name[rule.name] = rule

--- a/antismash/common/hmm_rule_parser/structures.py
+++ b/antismash/common/hmm_rule_parser/structures.py
@@ -4,7 +4,8 @@
 """ A collection of data structures for profile hits and profiles themselves
 """
 
-from typing import Callable, Dict, List
+import dataclasses
+from typing import Any, Callable, Dict, List
 
 from antismash.common.secmet import Record
 from antismash.common.signature import Signature
@@ -58,3 +59,22 @@ class DynamicProfile(Signature):
             CDS name to a list of HSPs, one for each 'hit'
         """
         return self._callable(record)
+
+
+@dataclasses.dataclass
+class Multipliers:
+    cutoff: float = 1.0
+    neighbourhood: float = 1.0
+
+    def __post_init__(self) -> None:
+        if self.cutoff <= 0:
+            raise ValueError("cutoff multiplier must be positive")
+        if self.neighbourhood <= 0:
+            raise ValueError("neighbourhood multiplier must be positive")
+
+    def to_json(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> "Multipliers":
+        return cls(**data)


### PR DESCRIPTION
Adds command line options for setting multipliers for rule cutoff and neighbourhood sizes for fungal inputs (bacterial inputs remain at 1.0):
```
  --hmmdetection-fungal-cutoff-multiplier HMMDETECTION_FUNGAL_CUTOFF_MULTIPLIER
                        Sets the multiplier for rule cutoffs in fungal inputs (default: 1.0).
  --hmmdetection-fungal-neighbourhood-multiplier HMMDETECTION_FUNGAL_NEIGHBOURHOOD_MULTIPLIER
                        Sets the multiplier for rule neighbourhoods in fungal inputs (default: 1.5).
```

Note the default fungal neighbourhood multiplier being 1.5.