### PR TITLE
Fixes for rule superior/inferior edge cases

### DIFF
--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -477,6 +477,8 @@ def build_results(clusters: list[Protocluster], record: Record, tool: str,
                                                   hit.seeds, tool))
         return domains
 
+    all_cds_results: dict[str, CDSResults] = {}
+
     cds_results_by_cluster = {}
     cdses_with_annotations = set()
     for cluster in clusters:
@@ -484,7 +486,14 @@ def build_results(clusters: list[Protocluster], record: Record, tool: str,
         for cds in record.get_cds_features_within_location(cluster.location):
             domains = get_domains_for_cds(cds)
             if domains:
-                cds_results.append(CDSResults(cds, domains, cds_domains_by_cluster.get(cds.get_name(), {})))
+                def_domains = cds_domains_by_cluster.get(cds.get_name(), {}).get(cluster.product, set())
+                cds_result = all_cds_results.get(cds.get_name())
+                if not cds_result:
+                    cds_result = CDSResults(cds, domains, {})
+                    all_cds_results[cds.get_name()] = cds_result
+                cds_result.definition_domains[cluster.product] = def_domains
+
+                cds_results.append(cds_result)
                 cdses_with_annotations.add(cds)
         cds_results_by_cluster[cluster] = cds_results
 

--- a/antismash/common/test/helpers.py
+++ b/antismash/common/test/helpers.py
@@ -52,13 +52,14 @@ class FakeHSP:
 
 class FakeHSPHit:
     "class for generating a HSP like datastructure"
-    def __init__(self, query_id, hit_id, hit_start, hit_end, bitscore, evalue):
+    def __init__(self, query_id, hit_id, hit_start=0, hit_end=10, bitscore=10, evalue=1e-10, seeds=1):
         self.query_id = query_id
         self.hit_id = hit_id
         self.hit_start = hit_start
         self.hit_end = hit_end
         self.bitscore = bitscore
         self.evalue = evalue
+        self.seeds = seeds
 
     def __repr__(self):
         return "FakeHSP({})".format(str(vars(self)))


### PR DESCRIPTION
A example was discovered of genes being marked as core genes without being contained by a protocluster core, like so:
![example](https://user-images.githubusercontent.com/1700735/216092898-05e7988c-4f74-4377-af29-d462d2aa8590.png)
The gene above overlaps with it's neighbour by 10 bases. It's considered a core gene for a protocluster type not present, but both of the protoclusters present are superiors to the missing protocluster.

There were two separate issues causing this to happen, both of which are handled by this pull request.

1. It was possible for a protocluster to be lost during candidate cluster creation, due to the deduplication process using only coordinates. This meant that the interleaved candidate that would have contained the missing protocluster was being dropped, orphaning the protocluster and resulting in it being discarded.
This was fixed by including the product list in the uniqueness check. On top of the tests, an assertion now ensures that protoclusters can't be lost in this way again without being noticed.

2. It was possible for a protocluster with an adjacent superior to be discarded when the adjacent genes overlapped slightly, as in this case with a 10 base overlap. This was fixed by moving from a checking if the locations overlapped to checking that the core CDS features overlapped.