### PR TITLE
Misc fixes

### DIFF
--- a/antismash/common/hmm_rule_parser/structures.py
+++ b/antismash/common/hmm_rule_parser/structures.py
@@ -35,7 +35,7 @@ class HMMerHit(ProfileHit):
     @classmethod
     def from_hsp(cls, hsp: HSP, seeds: int) -> "HMMerHit":
         """ Constructs an instance from an HSP """
-        return cls(hsp.hit_id, hsp.query_id, seeds, hsp.query_start, hsp.query_end, hsp.evalue, hsp.bitscore)
+        return cls(hsp.hit_id, hsp.query_id, hsp.query_start, hsp.query_end, seeds, hsp.evalue, hsp.bitscore)
 
 
 class DynamicHit(ProfileHit):

--- a/antismash/detection/hmm_detection/cluster_rules/strict.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/strict.txt
@@ -174,7 +174,7 @@ RULE lanthipeptide-class-i
 
 RULE lanthipeptide-class-ii
     CATEGORY RiPP
-    DESCRIPTION Clas II lanthipeptide
+    DESCRIPTION Class II lanthipeptide
     EXAMPLE NCBI U40620.1 0-3480 mutacin II
     CUTOFF 20
     NEIGHBOURHOOD 10
@@ -182,7 +182,7 @@ RULE lanthipeptide-class-ii
 
 RULE lanthipeptide-class-iii
     CATEGORY RiPP
-    DESCRIPTION Clas III lanthipeptide clusters
+    DESCRIPTION Class III lanthipeptide clusters
     EXAMPLE NCBI FN178622.1 0-6400 labyrinthopeptin
     CUTOFF 20
     NEIGHBOURHOOD 10
@@ -348,7 +348,7 @@ RULE ranthipeptide
                 rSAM_with_SPASM and ANY_RRE
                 and not (TIGR01716 or              # avoid co-detecting RaS-RiPPs
                          subtilosin or             # avoid co-detecting sactipeptides
-                         TIGR02111 or TIGR03966 or # avoid co-detecting redox-cofactor clusers
+                         TIGR02111 or TIGR03966 or # avoid co-detecting redox-cofactor clusters
                          TIGR04103 or              # avoid co-detecting spliceotides
                          all_YcaO)                 # avoid co-detecting thiopeptides
                )

--- a/antismash/detection/hmm_detection/cluster_rules/strict.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/strict.txt
@@ -645,24 +645,27 @@ RULE NRP-metallophore
 
 RULE methanobactin
     CATEGORY RiPP
-    DESCRIPTION Copper-chelating/transporting peptides (10.1126/science.aap9437)
-    EXAMPLE NCBI CP023737.1 1498747-1508549      # BGC0002004
+    DESCRIPTION Copper-chelating/transporting peptides
+    # see DOI: 10.1126/science.aap9437
+    EXAMPLE NCBI CP023737.1 1498747-1508549 methanobactin  # BGC0002004
     CUTOFF 5
     NEIGHBOURHOOD 10
     CONDITIONS DUF692 and MbnC
 
 RULE opine-like-metallophore
     CATEGORY other
-    DESCRIPTION Opine-like zincophores like staphylopine (10.1128/mSystems.00554-20)
-    EXAMPLE NCBI BA000017.4 2598076-2607334     # BGC0002487
+    DESCRIPTION Opine-like zincophores
+    # see DOI: 10.1128/mSystems.00554-20
+    EXAMPLE NCBI BA000017.4 2598076-2607334 staphylopine  # BGC0002487
     CUTOFF 5
     NEIGHBOURHOOD 10
     CONDITIONS CntL and CntM
 
 RULE aminopolycarboxylic-acid
     CATEGORY other
-    DESCRIPTION Aminopolycarboxylic acid metallophores (10.1039/C8MT00009C)
-    EXAMPLE NCBI OLMK01000008.1 45415-56279     # BGC0002567
+    DESCRIPTION Aminopolycarboxylic acid metallophores
+    # see DOI: 10.1039/C8MT00009C
+    EXAMPLE NCBI OLMK01000008.1 45415-56279 ethylenediaminesuccinic acid hydroxyarginine  # BGC0002567
     CUTOFF 10
     NEIGHBOURHOOD 5
     CONDITIONS AesA and AesB and AesC

--- a/antismash/detection/hmm_detection/test/test_hmm_detection.py
+++ b/antismash/detection/hmm_detection/test/test_hmm_detection.py
@@ -414,14 +414,14 @@ class TestMultipliers(unittest.TestCase):
         assert regenerated.rule_results.multipliers == results.rule_results.multipliers
 
         # ensure a changed cutoff multiplier breaks results reuse
-        new_options = build_config([
+        options = build_config([
             "--taxon", "fungi",
             "--hmmdetection-fungal-cutoff-multiplier", "2.0",
         ], modules=[core])
         with self.assertRaisesRegex(RuntimeError, "cutoff multiplier .* incompatible"):
             core.regenerate_previous_results(as_json, self.record, options)
 
-        new_options = build_config([
+        options = build_config([
             "--taxon", "fungi",
             "--hmmdetection-fungal-neighbourhood-multiplier", "0.5",
         ], modules=[core])

--- a/antismash/detection/nrps_pks_domains/__init__.py
+++ b/antismash/detection/nrps_pks_domains/__init__.py
@@ -77,7 +77,14 @@ def prepare_data(logging_only: bool = False) -> List[str]:
     if "mounted_at_runtime" in options.database_dir:
         return failure_messages
     for subdir, filename in [("transATor", "transATor.hmm")]:
-        full_path = get_database_path(subdir, filename)
+        try:
+            full_path = get_database_path(subdir, filename)
+        except ValueError as err:
+            if logging_only:
+                failure_messages.append(str(err))
+                continue
+            else:
+                raise
         failure_messages.extend(hmmer.ensure_database_pressed(full_path, return_not_raise=logging_only))
     return failure_messages
 

--- a/antismash/modules/t2pks/templates/sidepanel.html
+++ b/antismash/modules/t2pks/templates/sidepanel.html
@@ -38,7 +38,7 @@
 		<dt><strong>Product molecular weight(s):</strong></dt>
 		<dd>
 			{% for comb, weight in prediction.molecular_weights.items() | sort %}
-			{{ comb }}: {{ '%0.2f'| format(weight|float) }} Da<br>
+			{{ comb }}: {{ '%d'| format(weight|int) }} Da<br>
 			{% endfor %}
 		</dd>
 		{% endif %}

--- a/antismash/outputs/html/css/style.scss
+++ b/antismash/outputs/html/css/style.scss
@@ -1275,7 +1275,8 @@ ul.dropdown-options {
         padding-bottom: 0.5em;
     }
     * .cc-heat-product {
-        writing-mode: sideways-lr;
+        writing-mode: vertical-lr;
+        transform: rotate(180deg);
         text-orientation: mixed;
         text-align: left;
         cursor: pointer;


### PR DESCRIPTION
- fixes up some typos and missing compounds in detection rules
- fixes bad arg order leading to seeds being used as a start coordinate
- trims off fractions from molecular weight estimates for Type II PKS results
- fixes TransAT profiles not properly respecting `logging_only` mode, which crashed `--check-prereqs`
- changes CSS for cluster compare's table headers so that chromium-based browsers display the same as firefox