### PR TITLE
Style pass

### DIFF
--- a/antismash/__main__.py
+++ b/antismash/__main__.py
@@ -70,7 +70,7 @@ def main(args: List[str]) -> int:
 
     # if --help, show help texts and exit
     if set(args).intersection({"-h", "--help", "--help-showall"}):
-        parser.print_help(None, "--help-showall" in args)
+        parser.print_help(show_all="--help-showall" in args)
         return 0
 
     options = antismash.config.build_config(args, parser=parser)

--- a/antismash/__main__.py
+++ b/antismash/__main__.py
@@ -36,7 +36,7 @@ def get_git_version(fallback_filename: Optional[str] = GIT_VERSION_FALLBACK_FILE
         pass
     if git_version == "" and fallback_filename:
         if locate_file(fallback_filename, silent=True):
-            with open(fallback_filename, 'rt') as handle:
+            with open(fallback_filename, "rt", encoding="utf-8") as handle:
                 git_version = handle.read().strip()
     return git_version
 

--- a/antismash/__main__.py
+++ b/antismash/__main__.py
@@ -46,8 +46,7 @@ def get_version() -> str:
     version = antismash.__version__
     git_version = get_git_version()
     if git_version:
-        version += "-%s" % git_version
-
+        version += f"-{git_version}"
     return version
 
 
@@ -82,7 +81,7 @@ def main(args: List[str]) -> int:
 
     # if -V, show version text and exit
     if options.version:
-        print("antiSMASH %s" % get_version())
+        print(f"antiSMASH {get_version()}")
         return 0
 
     if len(options.sequences) > 1:
@@ -95,17 +94,17 @@ def main(args: List[str]) -> int:
     if options.sequences:
         sequence = options.sequences[0]
         if not os.path.exists(sequence):
-            parser.error("Input file does not exist: %s" % sequence)
+            parser.error(f"Input file does not exist: {sequence}")
         if not os.path.isfile(sequence):
-            parser.error("input %s is not a file" % sequence)
+            parser.error(f"input {sequence} is not a file")
     else:
         sequence = ""
 
     if options.reuse_results and not os.path.exists(options.reuse_results):
-        parser.error("Input file does not exist: %s" % options.reuse_results)
+        parser.error(f"Input file does not exist: {options.reuse_results}")
 
     if os.sep in options.output_basename:
-        parser.error("Output basename cannot contain a path separator character {}".format(os.sep))
+        parser.error(f"Output basename cannot contain a path separator character {os.sep}")
 
     options.version = get_version()
 

--- a/antismash/common/brawn.py
+++ b/antismash/common/brawn.py
@@ -36,7 +36,7 @@ def get_cached_alignment(fasta_path: str, cache_dir: str, keep_in_memory: bool =
             with open(real_path, encoding="utf-8") as handle:
                 alignment = Alignment.from_cache_file(handle)
         except FileNotFoundError:
-            with open(fasta_path) as handle:
+            with open(fasta_path, encoding="utf-8") as handle:
                 alignment = Alignment.from_file(handle)
             with open(real_path, "w", encoding="utf-8") as handle:
                 alignment.to_cache_file(handle)

--- a/antismash/common/comparippson/__init__.py
+++ b/antismash/common/comparippson/__init__.py
@@ -1,6 +1,14 @@
 # License: GNU Affero General Public License v3 or later
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
+""" A module for comparing precursor cores of various RiPPs to precursors
+annotated in existing databases.
+
+Includes helper functions for building and checking distinct
+datasets, along with HTML templates for showing the results.
+"""
+
+
 import logging
 import os
 from typing import List
@@ -29,7 +37,7 @@ def ensure_database_built(filepath: str, return_not_raise: bool = False) -> List
     components = [f"{filepath}.{ext}" for ext in ["pdb", "phr", "pin", "pot", "psq", "ptf", "pto"]]
 
     if path.is_outdated(components, filepath):
-        logging.info(f"{filepath} components missing or obsolete, rebuilding database")
+        logging.info("%s components missing or obsolete, rebuilding database", filepath)
         result = subprocessing.run_makeblastdb(filepath)
         if not result.successful():
             msg = f"Failed to build blast database {filepath!r}: {result.stderr}"

--- a/antismash/common/comparippson/__init__.py
+++ b/antismash/common/comparippson/__init__.py
@@ -26,13 +26,13 @@ def ensure_database_built(filepath: str, return_not_raise: bool = False) -> List
         Returns:
             any encountered error messages, will never be populated without return_not_raise == True
     """
-    components = ["{}.{}".format(filepath, ext) for ext in ["pdb", "phr", "pin", "pot", "psq", "ptf", "pto"]]
+    components = [f"{filepath}.{ext}" for ext in ["pdb", "phr", "pin", "pot", "psq", "ptf", "pto"]]
 
     if path.is_outdated(components, filepath):
         logging.info(f"{filepath} components missing or obsolete, rebuilding database")
         result = subprocessing.run_makeblastdb(filepath)
         if not result.successful():
-            msg = "Failed to build blast database {!r}: {}".format(filepath, result.stderr)
+            msg = f"Failed to build blast database {filepath!r}: {result.stderr}"
             if not return_not_raise:
                 raise RuntimeError(msg)
             return [msg]
@@ -82,7 +82,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
     failure_messages = []
     for binary_name in required_binaries:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate file: %r" % binary_name)
+            failure_messages.append(f"Failed to locate file: {binary_name!r}")
 
     failure_messages.extend(prepare_data(logging_only=True))
 

--- a/antismash/common/comparippson/analysis.py
+++ b/antismash/common/comparippson/analysis.py
@@ -125,7 +125,7 @@ class MultiDBResults(JsonConvertible):
             db = self.db_by_name[db_name]
             assert isinstance(db, ComparippsonDB), type(db)
             hits = sorted(hits, key=lambda x: (-x.match_count, x.reference.sequence,
-                                               db.build_identifier_for_hit(x)))
+                                               db.build_identifier_for_hit(x)))  # pylint:disable=cell-var-from-loop
             groups = []
             same = []
             current = hits[0]
@@ -144,9 +144,11 @@ class MultiDBResults(JsonConvertible):
                 same = []
             groups.append((current, f"and {len(same)} other{'s' if len(same) > 1 else ''}" if same else "", same))
             # sort by descending similarity, descending group size, and ascending name, in that order
+            # pylint:disable=cell-var-from-loop
             groups.sort(key=lambda g: (-g[0].similarity, -len(hits), db.build_identifier_for_hit(g[0])))
             chunks.append(template.render(coloured_ripp_sequence=colour_sequence,
                                           name=display_name, db=db, groups=groups))
+            # pylint:enable=cell-var-from-loop
         return Markup("".join(chunks))
 
 

--- a/antismash/common/fasta.py
+++ b/antismash/common/fasta.py
@@ -64,7 +64,7 @@ def write_fasta(names: List[str], seqs: List[str], filename: str) -> None:
         Returns:
             None
     """
-    with open(filename, "w") as out_file:
+    with open(filename, "w", encoding="utf-8") as out_file:
         for name, seq in zip(names, seqs):
             out_file.write(f">{name}\n{seq}\n")
 
@@ -81,7 +81,7 @@ def read_fasta(filename: str) -> Dict[str, str]:
     """
     ids = []
     sequence_info = []
-    with open(filename, "r") as fasta:
+    with open(filename, "r", encoding="utf-8") as fasta:
         current_seq: List[str] = []
         for line in fasta:
             line = line.strip()

--- a/antismash/common/fasta.py
+++ b/antismash/common/fasta.py
@@ -28,10 +28,10 @@ def get_fasta_from_features(features: Union[Iterable[CDSFeature], Iterable[Domai
     all_fastas = []
     if not numeric_names:
         for feature in features:
-            all_fastas.append(">%s\n%s" % (feature.get_name(), feature.translation))
+            all_fastas.append(f">{feature.get_name()}\n{feature.translation}")
     else:
         for i, feature in enumerate(features):  # type: ignore # because mypy can't handle the union in enumerate
-            all_fastas.append(">%d\n%s" % (i, feature.translation))
+            all_fastas.append(f">{i}\n{feature.translation}")
     return "\n".join(all_fastas)
 
 
@@ -49,7 +49,7 @@ def get_fasta_from_record(record: Record) -> str:
     for feature in features:
         gene_id = feature.get_name()
         fasta_seq = feature.translation
-        all_fastas.append(">%s\n%s" % (gene_id, fasta_seq))
+        all_fastas.append(f">{gene_id}\n{fasta_seq}")
     return "\n".join(all_fastas)
 
 
@@ -66,7 +66,7 @@ def write_fasta(names: List[str], seqs: List[str], filename: str) -> None:
     """
     with open(filename, "w") as out_file:
         for name, seq in zip(names, seqs):
-            out_file.write(">%s\n%s\n" % (name, seq))
+            out_file.write(f">{name}\n{seq}\n")
 
 
 def read_fasta(filename: str) -> Dict[str, str]:

--- a/antismash/common/gff_parser.py
+++ b/antismash/common/gff_parser.py
@@ -58,7 +58,7 @@ def check_gff_suitability(gff_file: str, sequences: List[SeqRecord]) -> None:
             if not record.features:
                 raise AntismashInputError(f"GFF3 record {record.id} contains no features")
 
-            coord_max = max([n.location.end.real for n in record.features])
+            coord_max = max(n.location.end.real for n in record.features)
             if coord_max > len(sequences[0]):
                 logging.error('GFF3 record and sequence coordinates are not compatible.')
                 raise AntismashInputError('incompatible GFF record and sequence coordinates')

--- a/antismash/common/gff_parser.py
+++ b/antismash/common/gff_parser.py
@@ -56,7 +56,7 @@ def check_gff_suitability(gff_file: str, sequences: List[SeqRecord]) -> None:
                 raise AntismashInputError("could not parse records from GFF3 file")
 
             if not record.features:
-                raise AntismashInputError('GFF3 record %s contains no features' % record.id)
+                raise AntismashInputError(f"GFF3 record {record.id} contains no features")
 
             coord_max = max([n.location.end.real for n in record.features])
             if coord_max > len(sequences[0]):
@@ -82,7 +82,7 @@ def check_gff_suitability(gff_file: str, sequences: List[SeqRecord]) -> None:
         # usually the assertion "assert len(parts) >= 8, line"
         # so strip the newline and improve the error message
         message = str(err).strip()
-        raise AntismashInputError("parsing GFF failed with invalid format: %r" % message) from err
+        raise AntismashInputError(f"parsing GFF failed with invalid format: {message!r}") from err
 
 
 def get_features_from_file(handle: IO) -> Dict[str, List[SeqFeature]]:
@@ -128,7 +128,7 @@ def get_features_from_file(handle: IO) -> Dict[str, List[SeqFeature]]:
             for i, new_feature in enumerate(new_features):
                 variant = name
                 if new_feature.type == "CDS" and multiple_cds:
-                    variant = "{0}_{1}".format(name, i)
+                    variant = f"{name}_{i}"
                 new_feature.qualifiers['gene'] = [variant]
                 if locus_tag is not None:
                     new_feature.qualifiers["locus_tag"] = locus_tag

--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -252,7 +252,7 @@ def filter_results(results: List[HSP], results_by_id: Dict[str, List[HSP]], filt
         equivalence_group = set(line.split(","))
         unknown = equivalence_group - signature_names
         if unknown:
-            raise ValueError("Equivalence group contains unknown identifiers: %s" % (unknown))
+            raise ValueError("Equivalence group contains unknown identifiers: {unknown}")
         removed_ids: Set[int] = set()
         for cds, cdsresults in results_by_id.items():
             # Check if multiple competing HMM hits are present
@@ -425,8 +425,7 @@ def find_hmmer_hits(record: Record, sig_by_name: Dict[str, Signature],
             elif acc in sig_by_name:
                 sig = sig_by_name[acc]
             else:
-                raise ValueError('Failed to find signature for ID %s / ACC %s' % (
-                                                    hsp.query_id, acc))
+                raise ValueError(f"Failed to find signature for ID {hsp.query_id} / ACC {acc}")
             if hsp.bitscore > sig.cutoff:
                 results.append(hsp)
                 if hsp.hit_id not in results_by_id:
@@ -630,7 +629,7 @@ def get_sequence_counts(details_file: str) -> Dict[str, int]:
                 result[hmm.name] = int(line[6:].strip())
                 break
         if hmm.name not in result:
-            raise ValueError("Unknown number of seeds for hmm file: %s" % details_file)
+            raise ValueError(f"Unknown number of seeds for hmm file: {details_file}")
 
     return result
 

--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -247,7 +247,7 @@ def hsp_overlap_size(first: HSP, second: HSP) -> int:
 def filter_results(results: List[HSP], results_by_id: Dict[str, List[HSP]], filter_file: str,
                    signature_names: Set[str]) -> Tuple[List[HSP], Dict[str, List[HSP]]]:
     """ Filter results by comparing scores of different models """
-    for line in open(filter_file, "r"):
+    for line in open(filter_file, "r", encoding="utf-8"):
         line = line.strip()
         equivalence_group = set(line.split(","))
         unknown = equivalence_group - signature_names
@@ -331,7 +331,7 @@ def create_rules(rule_file: str, signature_names: Set[str],
     """
     rules = existing_rules or []
     multipliers = multipliers or Multipliers()
-    with open(rule_file, "r") as ruledata:
+    with open(rule_file, "r", encoding="utf-8") as ruledata:
         parser = rule_parser.Parser("".join(ruledata.readlines()), signature_names,
                                     valid_categories, rules, existing_aliases=existing_aliases,
                                     multipliers=multipliers)
@@ -622,7 +622,7 @@ def get_sequence_counts(details_file: str) -> Dict[str, int]:
     result = {}
     for hmm in get_signature_profiles(details_file):
         assert isinstance(hmm, HmmSignature)
-        with open(path.get_full_path(details_file, hmm.hmm_file), 'r') as handle:
+        with open(path.get_full_path(details_file, hmm.hmm_file), "r", encoding="utf-8") as handle:
             lines = handle.readlines()
         for line in lines:
             if line.startswith('NSEQ '):

--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -201,18 +201,18 @@ def find_protoclusters(record: Record, cds_by_cluster_type: Dict[str, Set[str]],
             real_end = max(contained.location.end for contained in surrounding_cdses)
             surrounds = FeatureLocation(real_start, real_end)
             clusters.append(Protocluster(core_location, surrounding_location=surrounds,
-                                    tool="rule-based-clusters", cutoff=cutoff,
-                                    neighbourhood_range=rule.neighbourhood, product=cluster_type,
-                                    detection_rule=str(rule.conditions), product_category=rule.category))
+                                         tool="rule-based-clusters", cutoff=cutoff,
+                                         neighbourhood_range=rule.neighbourhood, product=cluster_type,
+                                         detection_rule=str(rule.conditions), product_category=rule.category))
             core_location = FeatureLocation(cds.location.start, cds.location.end)
 
         # finalise the last cluster
         surrounds = FeatureLocation(max(0, core_location.start - rule.neighbourhood),
                                     min(core_location.end + rule.neighbourhood, len(record)))
         clusters.append(Protocluster(core_location, surrounding_location=surrounds,
-                                tool="rule-based-clusters", cutoff=cutoff,
-                                neighbourhood_range=rule.neighbourhood, product=cluster_type,
-                                detection_rule=str(rule.conditions), product_category=rule.category))
+                                     tool="rule-based-clusters", cutoff=cutoff,
+                                     neighbourhood_range=rule.neighbourhood, product=cluster_type,
+                                     detection_rule=str(rule.conditions), product_category=rule.category))
 
     # fit to record if outside
     for cluster in clusters:
@@ -247,7 +247,9 @@ def hsp_overlap_size(first: HSP, second: HSP) -> int:
 def filter_results(results: List[HSP], results_by_id: Dict[str, List[HSP]], filter_file: str,
                    signature_names: Set[str]) -> Tuple[List[HSP], Dict[str, List[HSP]]]:
     """ Filter results by comparing scores of different models """
-    for line in open(filter_file, "r", encoding="utf-8"):
+    with open(filter_file, "r", encoding="utf-8") as handle:
+        lines = handle.readlines()
+    for line in lines:
         line = line.strip()
         equivalence_group = set(line.split(","))
         unknown = equivalence_group - signature_names

--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -1062,7 +1062,8 @@ class Parser:  # pylint: disable=too-few-public-methods
             raise RuleSyntaxError(f"Invalid category {category}, use one of {valid_categories}")
         if not self.current_token:
             raise RuleSyntaxError(f"expected {TokenTypes.DESCRIPTION}, {TokenTypes.EXAMPLE}, "
-                                  f"{TokenTypes.SUPERIORS}, or {TokenTypes.CUTOFF} sections after {TokenTypes.CATEGORY}")
+                                  f"{TokenTypes.SUPERIORS}, "
+                                  "or {TokenTypes.CUTOFF} sections after {TokenTypes.CATEGORY}")
         if self.current_token.type == TokenTypes.DESCRIPTION:
             description = self._parse_description()
             prev = TokenTypes.DESCRIPTION
@@ -1107,7 +1108,6 @@ class Parser:  # pylint: disable=too-few-public-methods
                 raise err
         return " ".join([token.token_text for token in description_tokens])
 
-
     def _parse_example(self) -> "ExampleRecord":
         """ EXAMPLE = EXAMPLE_MARKER ID ID DOT INT INT-INT [compound_name:TEXT]"""
         self._consume(TokenTypes.EXAMPLE)
@@ -1115,7 +1115,7 @@ class Parser:  # pylint: disable=too-few-public-methods
         accession = self._consume_identifier()
         self._consume(TokenTypes.DOT)
         version = self._consume_int()
-        range_str =  self._consume(TokenTypes.TEXT).token_text
+        range_str = self._consume(TokenTypes.TEXT).token_text
         parts = range_str.split("-")
         compound_name = None
         compound_tokens = []
@@ -1142,7 +1142,6 @@ class Parser:  # pylint: disable=too-few-public-methods
             raise RuleSyntaxError(f"Invalid range end {parts[1]} in {TokenTypes.EXAMPLE}")
 
         return ExampleRecord(database, accession, version, start, end, compound_name)
-
 
     def _parse_related(self) -> List[str]:
         """ RELATED = RELATED_MARKER related:COMMA_SEPARATED_IDS

--- a/antismash/common/hmm_rule_parser/structures.py
+++ b/antismash/common/hmm_rule_parser/structures.py
@@ -63,6 +63,7 @@ class DynamicProfile(Signature):
 
 @dataclasses.dataclass
 class Multipliers:
+    """ Multipliers for use in scaling appropriate values within rules. """
     cutoff: float = 1.0
     neighbourhood: float = 1.0
 
@@ -73,8 +74,10 @@ class Multipliers:
             raise ValueError("neighbourhood multiplier must be positive")
 
     def to_json(self) -> dict[str, Any]:
+        """ Converts the instance to a JSON-friendly representation """
         return dataclasses.asdict(self)
 
     @classmethod
     def from_json(cls, data: dict[str, Any]) -> "Multipliers":
+        """ Rebuilds an instance from a JSON-friendly representation """
         return cls(**data)

--- a/antismash/common/hmm_rule_parser/test/helpers.py
+++ b/antismash/common/hmm_rule_parser/test/helpers.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring,too-many-public-methods
+# pylint: disable=protected-access,missing-docstring,too-many-public-methods
 
 """ helper functions for testing modules using hmm_rule_parser """
 

--- a/antismash/common/hmm_rule_parser/test/helpers.py
+++ b/antismash/common/hmm_rule_parser/test/helpers.py
@@ -21,4 +21,4 @@ def check_hmm_signatures(signature_file, hmm_dir):
             if line.startswith("NAME"):
                 name = line.split()[-1]
         assert name
-        assert name == sig.name, "%s != %s" % (name, sig.name)
+        assert name == sig.name, f"{name} != {sig.name}"

--- a/antismash/common/hmm_rule_parser/test/helpers.py
+++ b/antismash/common/hmm_rule_parser/test/helpers.py
@@ -17,7 +17,7 @@ def check_hmm_signatures(signature_file, hmm_dir):
         hmm_file = os.path.abspath(os.path.join(hmm_dir, sig.path))
         assert os.path.exists(hmm_file)
         name = None
-        for line in open(hmm_file):
+        for line in open(hmm_file, encoding="utf-8"):
             if line.startswith("NAME"):
                 name = line.split()[-1]
         assert name

--- a/antismash/common/hmm_rule_parser/test/helpers.py
+++ b/antismash/common/hmm_rule_parser/test/helpers.py
@@ -17,8 +17,9 @@ def check_hmm_signatures(signature_file, hmm_dir):
         hmm_file = os.path.abspath(os.path.join(hmm_dir, sig.path))
         assert os.path.exists(hmm_file)
         name = None
-        for line in open(hmm_file, encoding="utf-8"):
-            if line.startswith("NAME"):
-                name = line.split()[-1]
+        with open(hmm_file, encoding="utf-8") as handle:
+            for line in handle:
+                if line.startswith("NAME"):
+                    name = line.split()[-1]
         assert name
         assert name == sig.name, f"{name} != {sig.name}"

--- a/antismash/common/hmm_rule_parser/test/test_rule_parser.py
+++ b/antismash/common/hmm_rule_parser/test/test_rule_parser.py
@@ -349,24 +349,24 @@ class RuleParserTest(unittest.TestCase):
                            " EXAMPLE NCBI Y16952.3 1-66669 balhimycin"
                            " CUTOFF 20 NEIGHBOURHOOD 20 CONDITIONS a").rules
         assert len(rules) == 1 and len(rules[0].examples) == 1 and \
-                rules[0].examples[0].database == "NCBI" and \
-                rules[0].examples[0].accession == "Y16952" and \
-                rules[0].examples[0].version == 3 and \
-                rules[0].examples[0].start == 1 and \
-                rules[0].examples[0].end == 66669 and \
-                rules[0].examples[0].compound_name == "balhimycin"
+            rules[0].examples[0].database == "NCBI" and \
+            rules[0].examples[0].accession == "Y16952" and \
+            rules[0].examples[0].version == 3 and \
+            rules[0].examples[0].start == 1 and \
+            rules[0].examples[0].end == 66669 and \
+            rules[0].examples[0].compound_name == "balhimycin"
 
     def test_multiple_examples(self):
         rules = self.parse("RULE name CATEGORY category DESCRIPTION this is a comment"
                            " EXAMPLE NCBI Y16952.3 1-66669 EXAMPLE NCBI EX12345.6 23-42 examplomycin dipeptide"
                            " CUTOFF 20 NEIGHBOURHOOD 20 CONDITIONS a").rules
         assert len(rules) == 1 and len(rules[0].examples) == 2 and \
-                rules[0].examples[1].database == "NCBI" and \
-                rules[0].examples[1].accession == "EX12345" and \
-                rules[0].examples[1].version == 6 and \
-                rules[0].examples[1].start == 23 and \
-                rules[0].examples[1].end == 42 and \
-                rules[0].examples[1].compound_name == "examplomycin dipeptide"
+            rules[0].examples[1].database == "NCBI" and \
+            rules[0].examples[1].accession == "EX12345" and \
+            rules[0].examples[1].version == 6 and \
+            rules[0].examples[1].start == 23 and \
+            rules[0].examples[1].end == 42 and \
+            rules[0].examples[1].compound_name == "examplomycin dipeptide"
 
     def test_single_superior(self):
         rules = self.parse("RULE first CATEGORY category CUTOFF 20 NEIGHBOURHOOD 20 CONDITIONS a "

--- a/antismash/common/hmm_rule_parser/test/test_rule_parser.py
+++ b/antismash/common/hmm_rule_parser/test/test_rule_parser.py
@@ -72,7 +72,7 @@ class DetectionTest(unittest.TestCase):
 
     def expect(self, results, genes_to_hit):
         expected = {gene: set("A") for gene in genes_to_hit}
-        assert results == expected, "%s != %s" % (set(results), set(expected))
+        assert results == expected, f"{set(results)} != {set(expected)}"
 
     def test_single(self):
         results = self.run_test("A", 10, 20, "a")

--- a/antismash/common/hmmscan_refinement.py
+++ b/antismash/common/hmmscan_refinement.py
@@ -128,8 +128,8 @@ class HMMResult:
         subtypes = ""
         if self.detailed_names[1:]:
             subtypes = f", subtypes=[{', '.join(self.detailed_names[1:])}]"
-        return "HMMResult(%s, %d, %d, evalue=%g, bitscore=%g%s)" % (self.hit_id,
-                   self.query_start, self.query_end, self.evalue, self.bitscore, subtypes)
+        return (f"HMMResult({self.hit_id}, {self.query_start}, {self.query_end}, "
+                f"evalue={self.evalue:g}, bitscore={self.bitscore}{subtypes})")
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, HMMResult):

--- a/antismash/common/html_renderer.py
+++ b/antismash/common/html_renderer.py
@@ -59,7 +59,7 @@ class HTMLSections:
         self.sidepanel_sections.append(HTMLSection(label, section, class_name or self.name))
 
     def __repr__(self) -> str:
-        return "HTMLSections(%s)" % (self.name)
+        return f"HTMLSections({self.name})"
 
 
 def _safe_selector(name: str) -> str:
@@ -126,14 +126,15 @@ def collapser_start(target: str, level: str = "all") -> Markup:
             HTML fragments as a Markup instance
     """
     if level not in ["all", "candidate", "protocluster", "cds", "none"]:
-        raise ValueError("unknown collapser level: %s" % level)
-    classes = ["collapser", "collapser-target-%s" % _safe_selector(target)]
-    classes.append("collapser-level-%s" % level)
+        raise ValueError(f"unknown collapser level: {level}")
+    classes = ["collapser", f"collapser-target-{_safe_selector(target)}"]
+    classes.append(f"collapser-level-{level}")
     child = '<div class="collapser-content">'
     if level == "all":
         classes.append("expanded")
         child = child[:-1] + ' style="display:block;">'
-    return Markup('<div class="%s"> </div>%s' % (" ".join(classes), child))
+    class_string = ' '.join(classes)
+    return Markup(f'<div class="{class_string}"> </div>{child}')
 
 
 def spanned_sequence(sequence: str, class_mapping: Dict[str, str],
@@ -203,11 +204,13 @@ def help_tooltip(text: str, name: str) -> Markup:
     """
     global _TOOLTIP_COUNTER  # pylint: disable=global-statement
     _TOOLTIP_COUNTER += 1
-    unique_id = "%s-help-%d" % (name, _TOOLTIP_COUNTER)
-    return Markup(('<div class="help-container">'
-                   ' <div class="help-icon" data-id="{0}"></div>'
-                   ' <span class="help-tooltip" id="{0}">{1}</span>'
-                   '</div>').format(unique_id, text))
+    unique_id = f"{name}-help-{_TOOLTIP_COUNTER}"
+    return Markup(
+        '<div class="help-container">'
+        f' <div class="help-icon" data-id="{unique_id}"></div>'
+        f' <span class="help-tooltip" id="{unique_id}">{text}</span>'
+        '</div>'
+    )
 
 
 def replace_with(key: str) -> Markup:
@@ -266,12 +269,14 @@ def switch(label: str, classname: str, id_attr: str = "", starts_on: bool = Fals
     """
     id_attr = f' id="{id_attr}"' if id_attr else ""
     check_attr = " checked" if starts_on else ""
-    return Markup(('<div class="{0} switch-container"><span class="switch-desc">{1}</span>'
-                   ' <label class="switch">'
-                   '  <input class="{0}" type="checkbox"{2}{3}>'
-                   '  <span class="slider"></span>'
-                   ' </label>'
-                   '</div>').format(classname, label, id_attr, check_attr))
+    return Markup(
+        f'<div class="{classname} switch-container"><span class="switch-desc">{label}</span>'
+        ' <label class="switch">'
+        f'  <input class="{classname}" type="checkbox"{id_attr}{check_attr}>'
+        '  <span class="slider"></span>'
+        ' </label>'
+        '</div>'
+    )
 
 
 class _Template:  # pylint: disable=too-few-public-methods

--- a/antismash/common/layers.py
+++ b/antismash/common/layers.py
@@ -66,21 +66,21 @@ class RecordLayer:
     def get_from_record(self) -> Markup:
         """ Returns the text to be displayed in the HTML overview page """
 
-        current_id = "<strong>%s</strong>" % self.seq_record.id
+        current_id = f"<strong>{self.seq_record.id}</strong>"
 
         orig_id = self.seq_record.original_id
 
         if orig_id:
             if len(orig_id) < 40:
-                current_id += " (original name was: %s)" % orig_id
+                current_id += f" (original name was: {orig_id})"
             else:
-                current_id += " (original name was: %s...)" % orig_id[:60]
+                current_id += f" (original name was: {orig_id[:60]}...)"
 
         source = self.annotations.get("source", "")
         if source:
-            source = " (%s)" % source
+            source = f" ({source})"
 
-        return Markup('%s%s' % (current_id, source))
+        return Markup(f"{current_id}{source}")
 
 
 class RegionLayer:
@@ -153,14 +153,15 @@ class RegionLayer:
     @property
     def detection_rules(self) -> List[str]:
         """ The details of rules that caused the Region to be defined """
-        return ["%s: %s" % (product, rules) for product, rules in
+        return [f"{product}: {rules}" for product, rules in
                 zip(self.region_feature.products, self.region_feature.detection_rules)]
 
     def description_text(self) -> str:
         """ returns the Region description """
-        description_text = 'Location: {:,d} - {:,d} nt. (total: {:,d} nt)'.format(
-            self.location.start + 1, self.location.end, len(self.location))
-
+        description_text = (
+            f"Location: {self.location.start + 1:,d} - {self.location.end:,d} nt."
+            f" (total: {len(self.location):,d} nt)"
+        )
         return description_text
 
     def cluster_blast_generator(self) -> List[Tuple[str, str]]:  # TODO: deduplicate
@@ -170,8 +171,7 @@ class RegionLayer:
         results = []
         for i, label in enumerate(top_hits):
             i += 1  # 1-indexed
-            svg_file = os.path.join('svg', 'clusterblast_r%dc%d_%s.svg' % (
-                            self.record.record_index, self.get_region_number(), i))
+            svg_file = os.path.join("svg", f"clusterblast_{self.build_anchor_id(self.region_feature)}_{i}.svg")
             results.append((label, svg_file))
         return results
 
@@ -182,8 +182,7 @@ class RegionLayer:
         results = []
         for i, summary in enumerate(top_hits):
             i += 1  # 1-indexed
-            svg_file = os.path.join('svg', 'knownclusterblast_r%dc%d_%s.svg' % (
-                            self.record.record_index, self.get_region_number(), i))
+            svg_file = os.path.join("svg", f"knownclusterblast_{self.build_anchor_id(self.region_feature)}_{i}.svg")
             results.append((summary.name, svg_file))
         return results
 
@@ -195,8 +194,7 @@ class RegionLayer:
         results = []
         for i, label in enumerate(top_hits):
             i += 1  # since one-indexed
-            svg_file = os.path.join('svg', 'subclusterblast_r%dc%d_%s.svg' % (
-                            self.record.record_index, self.get_region_number(), i))
+            svg_file = os.path.join("svg", f"subclusterblast_{self.build_anchor_id(self.region_feature)}_{i}.svg")
             results.append((label, svg_file))
         return results
 
@@ -236,5 +234,4 @@ class RegionLayer:
     @staticmethod
     def build_anchor_id(region: Region) -> str:
         """ Builds a consistent HTML anchor identifier for a Region """
-        return "r{}c{}".format(region.parent_record.record_index,
-                               region.get_region_number())
+        return f"r{region.parent_record.record_index}c{region.get_region_number()}"

--- a/antismash/common/logs.py
+++ b/antismash/common/logs.py
@@ -34,7 +34,7 @@ def changed_logging(logfile: str = None, verbose: bool = False, debug: bool = Fa
     try:
         def new_critical(*args: Any) -> None:
             """ make critical messages yellow and without the normal timestamp """
-            msg = "\033[1;33m{}\033[0m".format(args[0])
+            msg = f"\033[1;33m{args[0]}\033[0m"
             print(msg % args[1:], file=sys.stderr)
         logging.critical = new_critical  # type: ignore
 

--- a/antismash/common/module_results.py
+++ b/antismash/common/module_results.py
@@ -60,13 +60,13 @@ class DetectionResults(ModuleResults):  # keeping abstract is deliberate, pylint
     def add_to_record(self, record: Record) -> None:
         pass
 
-    def get_predicted_protoclusters(self) -> List[Protocluster]:  # pylint: disable=no-self-use
+    def get_predicted_protoclusters(self) -> List[Protocluster]:
         """ Returns a list of Protocluster features predicted by the module.
             Should be overridden by any subclass that makes cluster predictions.
         """
         return []
 
-    def get_predicted_subregions(self) -> List[SubRegion]:  # pylint: disable=no-self-use
+    def get_predicted_subregions(self) -> List[SubRegion]:
         """ Returns a list of SubRegion features predicted by the module.
             Should be overridden by any subclass that makes region predictions.
         """

--- a/antismash/common/pfamdb.py
+++ b/antismash/common/pfamdb.py
@@ -35,7 +35,7 @@ def check_db(db_path: str) -> List[str]:
     file_name = 'Pfam-A.hmm'
     full_path = os.path.join(db_path, file_name)
     if not path.locate_file(full_path):
-        failure_messages.append("Failed to locate file: %r in %s" % (file_name, db_path))
+        failure_messages.append(f"Failed to locate file: {file_name!r} in {db_path}")
     else:
         failure_messages.extend(hmmer.ensure_database_pressed(full_path, return_not_raise=True))
     return failure_messages

--- a/antismash/common/pfamdb.py
+++ b/antismash/common/pfamdb.py
@@ -94,7 +94,7 @@ def _build_mapping(database: str) -> Dict[str, str]:
     """
     logging.debug("Building name mapping for HMMer database %s", os.path.basename(database))
 
-    with open(database) as handle:
+    with open(database, encoding="utf-8") as handle:
         entries = handle.read().split("\n//\n")
     mapping = {}
     for entry in entries:
@@ -115,7 +115,7 @@ def _build_cutoff_mapping(database: str) -> Dict[str, float]:
             a dictionary mapping ACC field to TC value
     """
     logging.debug("Building cutoff mapping for HMMer database %s", database)
-    with open(database) as handle:
+    with open(database, encoding="utf-8") as handle:
         entries = handle.read().split("\n//\n")
     mapping = {}
     for entry in entries:

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -57,7 +57,7 @@ def _strict_parse(filename: str) -> List[SeqRecord]:
         warnings.filters = warnings.filters[len(filter_messages):]
 
     if not records:
-        raise AntismashInputError("no valid records found in file %s" % filename)
+        raise AntismashInputError(f"no valid records found in file {filename}")
     return records
 
 
@@ -93,11 +93,11 @@ def parse_input_sequence(filename: str, taxon: str = "bacteria", minimum_length:
 
     # if no records are left, that's a problem
     if not records:
-        raise AntismashInputError("all input records smaller than minimum length (%d)" % minimum_length)
+        raise AntismashInputError(f"all input records smaller than minimum length ({minimum_length})")
 
     for record in records:
         if not Record.is_nucleotide_sequence(record.seq):
-            raise AntismashInputError("protein records are not supported: %s" % record.id)
+            raise AntismashInputError(f"protein records are not supported: {record.id}")
 
     # before conversion to secmet records, trim if required
     if start > -1 or end > -1:
@@ -271,13 +271,13 @@ def filter_records_by_name(sequences: List[Record], target: str) -> None:
     matching_filter = 0
     for sequence in sequences:
         if sequence.id != target:
-            sequence.skip = "did not match filter: %s" % target
+            sequence.skip = f"did not match filter: {target}"
         else:
             matching_filter += 1
 
     if matching_filter == 0:
         logging.error("No sequences matched filter: %s", target)
-        raise AntismashInputError("no sequences matched filter: %s" % target)
+        raise AntismashInputError(f"no sequences matched filter: {target}")
 
     logging.info("Skipped %d sequences not matching filter: %s",
                  len(sequences) - matching_filter, target)
@@ -309,7 +309,7 @@ def filter_records_by_count(records: List[Record], maximum: int) -> bool:
         meaningful += 1
         if meaningful > maximum:
             limit_hit = True
-            record.skip = "skipping all but largest {0} meaningful records (--limit {0}) ".format(maximum)
+            record.skip = f"skipping all but largest {maximum} meaningful records (--limit) "
 
     return limit_hit
 
@@ -355,7 +355,7 @@ def pre_process_sequences(sequences: List[Record], options: ConfigType, genefind
                     record.original_id = record.id
                     record.id = generate_unique_id(record.id, all_record_ids)[0]
                 all_record_ids.add(record.id)
-            assert len(all_record_ids) == len(sequences), "%d != %d" % (len(all_record_ids), len(sequences))
+            assert len(all_record_ids) == len(sequences), f"{len(all_record_ids)} != {len(sequences)}"
         # Ensure all records have valid names
         for record in sequences:
             fix_record_name_id(record, all_record_ids, options.allow_long_headers)
@@ -377,7 +377,7 @@ def pre_process_sequences(sequences: List[Record], options: ConfigType, genefind
     logging.debug("Removing sequences smaller than %d bases", options.minlength)
     for sequence in sequences:
         if len(sequence.seq) < options.minlength:
-            sequence.skip = "smaller than minimum length (%d)" % options.minlength
+            sequence.skip = f"smaller than minimum length ({options.minlength})"
 
     # Make sure we don't waste weeks of runtime on huge records, unless requested by the user
     limit_hit = filter_records_by_count(sequences, options.limit)
@@ -438,9 +438,9 @@ def trim_sequence(record: SeqRecord, start: int, end: int) -> SeqRecord:
             A new, shortened Bio.SeqRecord instance
     """
     if start >= len(record):
-        raise ValueError('Specified analysis start point of %r is outside record' % start)
+        raise ValueError(f"Specified analysis start point of {start!r} is outside record")
     if end > len(record):
-        raise ValueError('Specified analysis end point of %r is outside record' % end)
+        raise ValueError(f"Specified analysis end point of {end!r} is outside record")
     if -1 < end <= start:
         raise ValueError("Trim region start cannot be greater than or equal to end")
 
@@ -500,7 +500,7 @@ def fix_record_name_id(record: Record, all_record_ids: Set[str],
             assert isinstance(record.record_index, int)
             contig_no = record.record_index
 
-        return "c{ctg:05d}_{origid}..".format(ctg=contig_no, origid=idstring[:7])
+        return f"c{contig_no:05d}_{idstring[:7]}.."
 
     old_id = record.id
 
@@ -572,5 +572,5 @@ def generate_unique_id(prefix: str, existing_ids: Set[str], start: int = 0,
         counter += 1
         name = f"{prefix}_{counter}"
     if 0 < max_length < len(name):
-        raise RuntimeError("Could not generate unique id for %s after %d iterations" % (prefix, counter - start))
+        raise RuntimeError(f"Could not generate unique id for {prefix} after {counter - start} iterations")
     return name, counter

--- a/antismash/common/secmet/features/antismash_feature.py
+++ b/antismash/common/secmet/features/antismash_feature.py
@@ -39,7 +39,7 @@ class AntismashFeature(Feature):
     def translation(self) -> str:
         """ The amino acid translation of the feature. """
         if not self._translation:
-            raise ValueError("Domain has no translation: %s" % self.domain_id)
+            raise ValueError(f"Domain has no translation: {self.domain_id}")
         return self._translation
 
     @translation.setter
@@ -81,7 +81,7 @@ class AntismashFeature(Feature):
         if self.score is not None:
             mine["score"] = [str(self.score)]
         if self.evalue is not None:
-            mine["evalue"] = [str("{:.2E}".format(self.evalue))]
+            mine["evalue"] = [f"{self.evalue:.2E}"]
         if self.locus_tag:
             mine["locus_tag"] = [self.locus_tag]
         if self._translation:

--- a/antismash/common/secmet/features/candidate_cluster/structures.py
+++ b/antismash/common/secmet/features/candidate_cluster/structures.py
@@ -38,7 +38,7 @@ class CandidateClusterKind(Enum):
         for value in CandidateClusterKind:
             if str(value) == label:
                 return value
-        raise ValueError("unknown candidate cluster kind: %s" % label)
+        raise ValueError(f"unknown candidate cluster kind: {label}")
 
 
 class CandidateCluster(CDSCollection):
@@ -57,7 +57,7 @@ class CandidateCluster(CDSCollection):
         for protocluster in protoclusters:
             assert isinstance(protocluster, Protocluster), type(protocluster)
         if not isinstance(kind, CandidateClusterKind):
-            raise TypeError("argument 1 should be CandidateClusterKind, had %s" % type(kind))
+            raise TypeError(f"argument 1 should be CandidateClusterKind, had {type(kind)}")
         location = combine_locations(cluster.location for cluster in protoclusters)
         super().__init__(location, feature_type=CandidateCluster.FEATURE_TYPE, child_collections=protoclusters)
         self._protoclusters = protoclusters
@@ -67,7 +67,7 @@ class CandidateCluster(CDSCollection):
         self._core_location = None
 
     def __repr__(self) -> str:
-        return "CandidateCluster(%s, %s)" % (self.location, self.kind)
+        return f"CandidateCluster({self.location}, {self.kind})"
 
     def get_candidate_cluster_number(self) -> int:
         """ Returns the candidate clusters's numeric ID, only guaranteed to be consistent for

--- a/antismash/common/secmet/features/candidate_cluster/test/test_candidate_cluster.py
+++ b/antismash/common/secmet/features/candidate_cluster/test/test_candidate_cluster.py
@@ -18,7 +18,7 @@ from antismash.common.secmet.test.helpers import DummyCDS
 
 
 def create_cds(start, end, products):
-    cds = DummyCDS(start, end, locus_tag="%s-%s-%s" % (start, end, "-".join(products)))
+    cds = DummyCDS(start, end, locus_tag=f"{start}-{end}-{'-'.join(products)}")
     for product in products:
         cds.gene_functions.add(GeneFunction.CORE, "test", "dummy", product)
     return cds

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -102,8 +102,7 @@ def _ensure_valid_translation(translation: str, location: Location, transl_table
             translation = ""
     # ensure that the translation fits
     if not _is_valid_translation_length(translation, location):
-        raise ValueError("translation longer than location allows: %s > %s" % (
-                         len(translation) * 3, len(location)))
+        raise ValueError(f"translation longer than location allows: {len(translation) * 3} > {len(location)}")
     # if an arbitrary section of a record is used, the record can be too short for a given translation
     if record and not _translation_fits_in_record(len(translation)*3, location, len(record.seq)):
         raise ValueError("feature translation extends out of record")
@@ -118,7 +117,7 @@ def _ensure_valid_translation(translation: str, location: Location, transl_table
         try:
             translation = record.get_aa_translation_from_location(location, transl_table)
         except CodonTable.TranslationError as err:
-            raise ValueError("invalid codon: %s" % err)
+            raise ValueError(f"invalid codon: {err}")
 
     if len(translation) >= MAX_TRANSLATION_LENGTH:
         raise ValueError(f"translation too long for dependencies: {len(translation)}")
@@ -132,7 +131,7 @@ def _verify_location(location: Location) -> None:
     if location.strand not in [1, -1]:
         if len(location.parts) > 1 and location.parts[0].strand in [1, -1]:
             raise ValueError("compound locations with mixed strands are not supported")
-        raise ValueError("invalid strand: %s" % location.strand)
+        raise ValueError(f"invalid strand: {location.strand}")
 
 
 class CDSFeature(Feature):
@@ -160,7 +159,7 @@ class CDSFeature(Feature):
 
         # optional
         if not isinstance(product, str):
-            raise TypeError("product must be a string, not %s" % type(product))
+            raise TypeError(f"product must be a string, not {type(product)}")
         self.product = product
         self.transl_table = int(translation_table)
         self._sec_met = SecMetQualifier()
@@ -223,10 +222,9 @@ class CDSFeature(Feature):
             raise ValueError(f"translation too long for dependencies in {detail}")
         invalid = set(translation) - _VALID_TRANSLATION_CHARS
         if invalid:
-            raise ValueError("invalid translation characters: %s" % invalid)
+            raise ValueError(f"invalid translation characters: {invalid}")
         if not _is_valid_translation_length(translation, self.location):
-            raise ValueError("translation longer than location allows: %s > %s" % (
-                                len(translation) * 3, len(self.location)))
+            raise ValueError(f"translation longer than location allows: {len(translation) * 3} > {len(self.location)}")
         self._translation = translation  # pylint: disable=attribute-defined-outside-init
 
     @property
@@ -246,14 +244,14 @@ class CDSFeature(Feature):
         for val in [self.protein_id, self.gene, self.locus_tag]:
             if val:
                 return val
-        raise ValueError("%s altered to contain no identifiers" % self)
+        raise ValueError(f"{self} altered to contain no identifiers")
 
     def get_name(self) -> str:
         "Get the gene ID from locus_tag, gene name or protein id, in that order"
         for val in [self.locus_tag, self.gene, self.protein_id]:
             if val:
                 return val
-        raise ValueError("%s altered to contain no identifiers" % self)
+        raise ValueError(f"{self} altered to contain no identifiers")
 
     @classmethod
     def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,
@@ -282,12 +280,12 @@ class CDSFeature(Feature):
             try:
                 transl_table = int(raw_table)
             except ValueError:
-                raise SecmetInvalidInputError("invalid translation table '%s' for CDS '%s'" % (raw_table, name))
+                raise SecmetInvalidInputError(f"invalid translation table {raw_table!r} for CDS {name!r}")
 
         try:
             _verify_location(bio_feature.location)
         except Exception as err:
-            message = "invalid location for %s: %s" % (name, str(err))
+            message = f"invalid location for {name}: {err}"
             raise SecmetInvalidInputError(message) from err
 
         try:
@@ -299,7 +297,7 @@ class CDSFeature(Feature):
             translation = _ensure_valid_translation(leftovers.pop("translation", [""])[0],
                                                     location, transl_table, record)
         except ValueError as err:
-            raise SecmetInvalidInputError(str(err) + ": %s" % name) from err
+            raise SecmetInvalidInputError(f"{err}: {name}") from err
 
         feature = cls(bio_feature.location, translation, gene=gene,
                       locus_tag=locus_tag, protein_id=protein_id,
@@ -346,7 +344,7 @@ class CDSFeature(Feature):
         return str(self)
 
     def __str__(self) -> str:
-        return "CDS(%s, %s)" % (self.get_name(), self.location)
+        return f"CDS(self.get_name(), {self.location})"
 
     def strip_antismash_annotations(self) -> None:
         """ Remove all antiSMASH-specific annotations from the feature """

--- a/antismash/common/secmet/features/domain.py
+++ b/antismash/common/secmet/features/domain.py
@@ -60,13 +60,13 @@ class Domain(AntismashFeature):
         super().__init__(location, feature_type, tool=tool, created_by_antismash=created_by_antismash)
         if domain is not None:
             if not isinstance(domain, str):
-                raise TypeError("Domain must be given domain as a string, not %s" % type(domain))
+                raise TypeError(f"Domain must be given domain as a string, not {type(domain)}")
             if not domain:
                 raise ValueError("Domain cannot be an empty string")
         self.domain = domain
         self.protein_location = protein_location
         if not isinstance(protein_location, FeatureLocation):
-            raise TypeError("protein location must be a FeatureLocation, not %s" % type(protein_location))
+            raise TypeError(f"protein location must be a FeatureLocation, not {type(protein_location)}")
         if not locus_tag:
             raise ValueError("locus tag cannot be an empty string")
         self.locus_tag: str = str(locus_tag)

--- a/antismash/common/secmet/features/feature.py
+++ b/antismash/common/secmet/features/feature.py
@@ -41,16 +41,16 @@ class Feature:
                  created_by_antismash: bool = False) -> None:
         assert isinstance(location, (FeatureLocation, CompoundLocation)), type(location)
         if location_bridges_origin(location):
-            raise ValueError("Features that bridge the record origin cannot be directly created: %s" % location)
+            raise ValueError(f"Features that bridge the record origin cannot be directly created: {location}")
         if location_contains_overlapping_exons(location):
-            raise ValueError("location contains overlapping exons: %s" % location)
-        assert location.start <= location.end, "Feature location invalid: %s" % location
+            raise ValueError(f"location contains overlapping exons: {location}")
+        assert location.start <= location.end, f"Feature location invalid: {location}"
         if location.start < 0:
-            raise ValueError("location contains negative coordinate: %s" % location)
+            raise ValueError(f"location contains negative coordinate: {location}")
         self.location = location
         self.notes: List[str] = []
         if not 1 <= len(feature_type) < 16:  # at 16 the name merges with location in genbanks
-            raise ValueError("feature type has invalid length: '%s'" % feature_type)
+            raise ValueError(f"feature type has invalid length: {feature_type!r}")
         self.type = str(feature_type)
         self._qualifiers: Dict[str, Optional[List[str]]] = OrderedDict()
         self.created_by_antismash = bool(created_by_antismash)
@@ -98,9 +98,9 @@ class Feature:
 
         dna_start, dna_end = convert_protein_position_to_dna(start, end, self.location)
         if not dna_start < dna_end:
-            raise ValueError("Invalid protein coordinate conversion (start %d, end %d)" % (dna_start, dna_end))
+            raise ValueError(f"Invalid protein coordinate conversion (start {dna_start}, end {dna_end})")
         if dna_start not in self.location:
-            raise ValueError("Protein coordinate start %d (nucl %d) is outside feature %s" % (start, dna_start, self))
+            raise ValueError(f"Protein coordinate start {start} (nucl {dna_start}) is outside feature {self}")
         # end check is more complicated as 'in' is inclusive and end is exclusive
         end_contained = dna_end in self.location or dna_end == self.location.end
         for part in self.location.parts:
@@ -108,7 +108,7 @@ class Feature:
                 end_contained = True
                 break
         if not end_contained:
-            raise ValueError("Protein coordinate end %d (nucl %d) is outside feature %s" % (end, dna_end, self))
+            raise ValueError(f"Protein coordinate end {end} (nucl {dna_end}) is outside feature {self}")
 
         if not isinstance(self.location, CompoundLocation):
             return FeatureLocation(dna_start, dna_end, self.location.strand)
@@ -130,9 +130,11 @@ class Feature:
                 new_locations.append(location)
 
         if not new_locations:
-            raise ValueError(("Could not create compound location from"
-                              " %s and internal protein coordinates %d..%d (dna %d..%d)") % (
-                                str(self.location), start, end, dna_start, dna_end))
+            raise ValueError(
+                "Could not create compound location from"
+                f" {self.location} and internal protein coordinates {start}..{end}"
+                f" (dna {dna_start}..{dna_end})"
+            )
         if self.location.strand == -1:
             new_locations.reverse()
 
@@ -170,7 +172,7 @@ class Feature:
         elif isinstance(other, (CompoundLocation, FeatureLocation)):
             location = other
         else:
-            raise TypeError("Container must be a Feature, CompoundLocation, or FeatureLocation, not %s" % type(other))
+            raise TypeError(f"Container must be a Feature, CompoundLocation, or FeatureLocation, not {type(other)}")
         return locations_overlap(self.location, location)
 
     def is_contained_by(self, other: Union["Feature", Location]) -> bool:
@@ -181,7 +183,7 @@ class Feature:
             return location_contains_other(other.location, self.location)
         if isinstance(other, (CompoundLocation, FeatureLocation)):
             return location_contains_other(other, self.location)
-        raise TypeError("Container must be a Feature, CompoundLocation or FeatureLocation, not %s" % type(other))
+        raise TypeError(f"Container must be a Feature, CompoundLocation or FeatureLocation, not {type(other)}")
 
     def to_biopython(self, qualifiers: Dict[str, Any] = None) -> List[SeqFeature]:
         """ Converts this feature into one or more SeqFeature instances.
@@ -231,7 +233,7 @@ class Feature:
         return repr(self)
 
     def __repr__(self) -> str:
-        return "%s(%s)" % (self.type, self.location)
+        return f"{self.type}({self.location})"
 
     @classmethod
     def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,

--- a/antismash/common/secmet/features/gene.py
+++ b/antismash/common/secmet/features/gene.py
@@ -61,7 +61,7 @@ class Gene(Feature):
         locus = pop_locus_qualifier(leftovers, allow_missing=True, default=None)
         name = leftovers.pop("gene", [""])[0] or None
         if not (locus or name):
-            name = "gene%s_%s" % (bio_feature.location.start, bio_feature.location.end)
+            name = f"gene{bio_feature.location.start}_{bio_feature.location.end}"
         feature = cls(bio_feature.location, locus_tag=locus, gene_name=name)
         super().from_biopython(bio_feature, feature=feature, leftovers=leftovers, record=record)
         return feature

--- a/antismash/common/secmet/features/module.py
+++ b/antismash/common/secmet/features/module.py
@@ -32,7 +32,7 @@ class ModuleType(Enum):
         for value in ModuleType:
             if str(value) == label:
                 return value
-        raise ValueError("unknown module type: %s" % label)
+        raise ValueError(f"unknown module type: {label}")
 
 
 class Module(Feature):
@@ -69,7 +69,7 @@ class Module(Feature):
         super().__init__(location, self.FEATURE_TYPE, created_by_antismash=True)
 
         if not isinstance(module_type, ModuleType):
-            raise TypeError("module_type must be a ModuleType instance, not %s" % type(module_type))
+            raise TypeError(f"module_type must be a ModuleType instance, not {type(module_type)}")
 
         # parent CDS name order should match that of the domains provided
         self._parent_cds_names: List[str] = []
@@ -183,7 +183,7 @@ class Module(Feature):
             new["iterative"] = None
 
         if self._substrate_monomer_pairs:
-            new["monomer_pairings"] = ["%s -> %s" % (sub, mon) for sub, mon in self._substrate_monomer_pairs]
+            new["monomer_pairings"] = [f"{sub} -> {mon}" for sub, mon in self._substrate_monomer_pairs]
 
         new.update(qualifiers or {})
 
@@ -199,13 +199,13 @@ class Module(Feature):
             domain_names = leftovers.pop("domains")
             module_type = ModuleType.from_string(leftovers.pop("type")[0])
         except KeyError as err:
-            raise ValueError("module at %s missing expected qualifier: %s" % (bio_feature.location, err))
+            raise ValueError(f"module at {bio_feature.location} missing expected qualifier: {err}")
         except ValueError as err:
-            raise ValueError("module at %s %s" % (bio_feature.location, err))
+            raise ValueError(f"module at {bio_feature.location}: {err}")
 
         complete = "complete" in leftovers
         if not complete and "incomplete" not in leftovers:
-            raise ValueError("module at %s missing one of: complete, incomplete" % bio_feature.location)
+            raise ValueError(f"module at {bio_feature.location} missing one of: complete, incomplete")
         leftovers.pop("complete", "")
         leftovers.pop("incomplete", "")
 
@@ -218,8 +218,7 @@ class Module(Feature):
         try:
             domains = [record.get_domain_by_name(domain) for domain in domain_names]
         except KeyError as err:
-            raise ValueError("record does not contain domain referenced by module at %s: %s" % (
-                             bio_feature.location, err))
+            raise ValueError(f"record does not contain domain referenced by module at {bio_feature.location}: {err}")
 
         starter = "starter_module" in leftovers
         if starter:
@@ -238,14 +237,14 @@ class Module(Feature):
             try:
                 substrate, monomer = raw.split(" -> ")
             except ValueError:
-                raise ValueError("module at %s has invalid monomer pairing: %r" % (bio_feature.location, raw))
+                raise ValueError(f"module at {bio_feature.location} has invalid monomer pairing: {raw!r}")
             substrate = substrate.strip()
             monomer = monomer.strip()
             if not substrate or not monomer:
-                raise ValueError("module at %s has invalid monomer pairing: %r" % (bio_feature.location, raw))
+                raise ValueError(f"module at {bio_feature.location} has invalid monomer pairing: {raw!r}")
             module.add_monomer(substrate, monomer)
 
         return module
 
     def __repr__(self) -> str:
-        return "Module(%s, %s: %s)" % (self.location, self.module_type, [dom.domain for dom in self.domains])
+        return f"Module(self.location, {self.module_type}: {[dom.domain for dom in self.domains]}"

--- a/antismash/common/secmet/features/pfam_domain.py
+++ b/antismash/common/secmet/features/pfam_domain.py
@@ -40,7 +40,7 @@ class PFAMDomain(Domain):
         super().__init__(location, self.FEATURE_TYPE, protein_location, locus_tag,
                          domain=domain, tool=tool)
         if not isinstance(description, str):
-            raise TypeError("PFAMDomain description must be a string, not %s" % type(description))
+            raise TypeError(f"PFAMDomain description must be a string, not {type(description)}")
         if not description:
             raise ValueError("PFAMDomain description cannot be empty")
         self.description = description
@@ -51,7 +51,7 @@ class PFAMDomain(Domain):
             identifier, version = identifier.split(".", maxsplit=1)
             self.version = int(version)
         if not (len(identifier) == 7 and identifier.startswith('PF') and identifier[2:].isdecimal()):
-            raise ValueError("invalid Pfam identifier: %s" % identifier)
+            raise ValueError(f"invalid Pfam identifier: {identifier}")
         self.identifier = str(identifier)
         self.gene_ontologies: Optional[GOQualifier] = None
 
@@ -62,7 +62,7 @@ class PFAMDomain(Domain):
         """
         if not self.version:
             return self.identifier
-        return "%s.%d" % (self.identifier, self.version)
+        return f"{self.identifier}.{self.version}"
 
     def to_biopython(self, qualifiers: Dict[str, List[str]] = None) -> List[SeqFeature]:
         mine: Dict[str, List[str]] = OrderedDict()

--- a/antismash/common/secmet/features/prepeptide.py
+++ b/antismash/common/secmet/features/prepeptide.py
@@ -130,8 +130,8 @@ class Prepeptide(CDSMotif):  # pylint: disable=too-many-instance-attributes
             leader_qualifiers = {
                 "prepeptide": ["leader"],
                 "note": [
-                    "peptide class: %s" % self.peptide_class,
-                    "predicted sequence: %s" % self.leader,
+                    "peptide class: {self.peptide_class}",
+                    f"predicted sequence: {self.leader}",
                 ],
                 "locus_tag": [self.locus_tag],
                 "aSTool": [self.tool],
@@ -153,9 +153,9 @@ class Prepeptide(CDSMotif):  # pylint: disable=too-many-instance-attributes
             "locus_tag": [self.locus_tag],
             "peptide": [self.peptide_class],
             "predicted_class": [self.peptide_subclass],
-            "score": ["{:.2f}".format(self.score)],
-            "molecular_weight": ["{:.1f}".format(self.molecular_weight)],
-            "monoisotopic_mass": ["{:.1f}".format(self.monoisotopic_mass)],
+            "score": [f"{self.score:.2f}"],
+            "molecular_weight": [f"{self.molecular_weight:.1f}"],
+            "monoisotopic_mass": [f"{self.monoisotopic_mass:.1f}"],
             "core_sequence": [self._core],
             "aSTool": [self.tool],
             "tool": ["antismash"],
@@ -171,7 +171,7 @@ class Prepeptide(CDSMotif):  # pylint: disable=too-many-instance-attributes
                 "tail_location": [str(tail_location)],
             })
         if self.alternative_weights:
-            weights = map(lambda x: "%0.1f" % x, self.alternative_weights)
+            weights = map(lambda x: f"{x:0.1f}", self.alternative_weights)
             core.qualifiers['alternative_weights'] = list(weights)
 
         features.append(core)
@@ -196,7 +196,7 @@ class Prepeptide(CDSMotif):  # pylint: disable=too-many-instance-attributes
 
         section = leftovers.pop("prepeptide", [""])[0]
         if not section:
-            raise SecmetInvalidInputError("cannot reconstruct Prepeptide from biopython feature %s" % bio_feature)
+            raise SecmetInvalidInputError(f"cannot reconstruct Prepeptide from biopython feature {bio_feature}")
         if section != "core":
             raise SecmetInvalidInputError("Prepeptide can only be reconstructed from core feature")
         alt_weights = [float(weight) for weight in leftovers.pop("alternative_weights", [])]

--- a/antismash/common/secmet/features/protocluster.py
+++ b/antismash/common/secmet/features/protocluster.py
@@ -39,7 +39,7 @@ class Protocluster(CDSCollection):
         # cluster-wide
         self.detection_rule = detection_rule
         if not product.replace("-", "").replace("_", "").isalnum() or product[0] in "-_" or product[-1] in "-_":
-            raise ValueError("invalid protocluster product: %s" % product)
+            raise ValueError(f"invalid protocluster product: {product}")
         self.product = product
         self.product_category = product_category
         self.tool = tool
@@ -56,7 +56,7 @@ class Protocluster(CDSCollection):
         self.t2pks: Optional[T2PKSQualifier] = None
 
     def __str__(self) -> str:
-        return "Protocluster(%s, product=%s)" % (self.location, self.product)
+        return f"Protocluster({self.location}, product={self.product})"
 
     def get_protocluster_number(self) -> int:
         """ Returns the protoclusters's numeric ID, only guaranteed to be consistent
@@ -155,7 +155,7 @@ class Protocluster(CDSCollection):
 
         # grab optional parent qualifiers
         updated = super().from_biopython(bio_feature, feature, leftovers, record=record)
-        assert updated is feature, "feature changed: %s -> %s" % (feature, updated)
+        assert updated is feature, f"feature changed: {feature} -> {updated}"
         assert isinstance(updated, Protocluster)
         return updated
 
@@ -184,7 +184,7 @@ class SideloadedProtocluster(Protocluster):
     def to_biopython(self, qualifiers: Optional[Dict[str, List[str]]] = None) -> List[SeqFeature]:
         features = super().to_biopython(qualifiers)
         for feature in features:
-            feature.qualifiers["aStool"] = ["externally annotated by: %s" % self.tool]
+            feature.qualifiers["aStool"] = [f"externally annotated by: {self.tool}"]
             if self.extra_qualifiers:
                 feature.qualifiers["external_qualifier_ids"] = list(self.extra_qualifiers)
                 feature.qualifiers.update(self.extra_qualifiers)

--- a/antismash/common/secmet/features/region.py
+++ b/antismash/common/secmet/features/region.py
@@ -164,7 +164,7 @@ class Region(CDSCollection):
             within the Region.
         """
         if not filename:
-            filename = "%s.region%03d.gbk" % (self.parent_record.id, self.get_region_number())
+            filename = f"{self.parent_record.id}.region{self.get_region_number():03d}.gbk"
         if directory:
             filename = os.path.join(directory, filename)
 
@@ -188,11 +188,9 @@ class Region(CDSCollection):
         # update the antiSMASH annotation to include some cluster details
         comment_end_marker = "##antiSMASH-Data-END"
         cluster_comment = ("NOTE: This is a single region extracted from a larger record!\n"
-                           "Orig. start  :: {start}\n"
-                           "Orig. end    :: {end}\n"
-                           "{end_marker}").format(start=self.location.start,
-                                                  end=self.location.end,
-                                                  end_marker=comment_end_marker)
+                           "Orig. start  :: {self.location.start}\n"
+                           "Orig. end    :: {self.location.end}\n"
+                           "{comment_end_marker}")
         original = cluster_record.annotations["comment"]
         cluster_record.annotations["comment"] = original.replace(comment_end_marker, cluster_comment)
 

--- a/antismash/common/secmet/features/subregion.py
+++ b/antismash/common/secmet/features/subregion.py
@@ -89,7 +89,7 @@ class SideloadedSubRegion(SubRegion):
     def to_biopython(self, qualifiers: Optional[Dict[str, List[str]]] = None) -> List[SeqFeature]:
         features = super().to_biopython(qualifiers)
         for feature in features:
-            feature.qualifiers["aStool"] = ["externally annotated by: %s" % self.tool]
+            feature.qualifiers["aStool"] = [f"externally annotated by: {self.tool}"]
             if self.extra_qualifiers:
                 feature.qualifiers["external_qualifier_ids"] = list(self.extra_qualifiers)
                 feature.qualifiers.update(self.extra_qualifiers)

--- a/antismash/common/secmet/features/test/test_cds_feature.py
+++ b/antismash/common/secmet/features/test/test_cds_feature.py
@@ -215,7 +215,7 @@ class TestCDSProteinLocation(unittest.TestCase):
         print(list(map(str, self.cds.location.parts)))
         print(list(map(str, new.parts)))
         assert len(new) == len(self.cds.location)
-        assert new == self.location, "%s != %s" % (str(new), str(self.location))
+        assert new == self.location, f"{new} != {self.location}"
         extracted = new.extract(self.magic_split)
         assert extracted == self.magic
         assert extracted.translate() == self.translation[0:5]

--- a/antismash/common/secmet/features/test/test_cdscollection.py
+++ b/antismash/common/secmet/features/test/test_cdscollection.py
@@ -53,7 +53,7 @@ class TestCDSCollection(unittest.TestCase):
 
         # without a record, this breaks
         with self.assertRaisesRegex(ValueError, "Cannot determine"):
-            outer.contig_edge
+            outer.contig_edge  # pylint: disable=pointless-statement
 
         # add the record, ensure for testing that everything starts not on the edge
         record = DummyRecord(seq="A"*70)

--- a/antismash/common/secmet/features/test/test_feature.py
+++ b/antismash/common/secmet/features/test/test_feature.py
@@ -96,10 +96,10 @@ class TestFeature(unittest.TestCase):
             for start, end in [(1, 5), (3, 8), (10, 15)]:
                 feature = Feature(FeatureLocation(start, end, strand=1),
                                   feature_type=feature_type)
-                assert str(feature) == "%s([%d:%d](+))" % (feature_type, start, end)
+                assert str(feature) == f"{feature_type}([{start}:{end}](+))"
                 feature = Feature(FeatureLocation(start, end, strand=-1),
                                   feature_type=feature_type)
-                assert str(feature) == "%s([%d:%d](-))" % (feature_type, start, end)
+                assert str(feature) == f"{feature_type}([{start}:{end}](-))"
 
     def test_bridging_fails(self):
         parts = [FeatureLocation(9, 12, strand=1), FeatureLocation(0, 3, strand=1)]

--- a/antismash/common/secmet/features/test/test_module.py
+++ b/antismash/common/secmet/features/test/test_module.py
@@ -158,7 +158,7 @@ class TestModule(unittest.TestCase):
     def test_cross_gene_ordering(self):
         domains = [DummyAntismashDomain(locus_tag="A"), DummyAntismashDomain(locus_tag="B")]
         for doms in [domains, domains[::-1]]:
-            assert Module(doms).parent_cds_names == tuple([dom.locus_tag for dom in doms])
+            assert Module(doms).parent_cds_names == tuple(dom.locus_tag for dom in doms)
 
     def test_type(self):
         assert create_module().module_type == ModuleType.UNKNOWN

--- a/antismash/common/secmet/features/test/test_module.py
+++ b/antismash/common/secmet/features/test/test_module.py
@@ -99,7 +99,7 @@ class TestModule(unittest.TestCase):
         for removed_key in ["domains", "incomplete"]:
             bio = module.to_biopython()[0]
             bio.qualifiers.pop(removed_key)
-            with self.assertRaisesRegex(ValueError, "missing .* '?%s" % removed_key):
+            with self.assertRaisesRegex(ValueError, f"missing .* '?{removed_key}"):
                 Module.from_biopython(bio, record=record)
 
         bio = module.to_biopython()[0]

--- a/antismash/common/secmet/features/test/test_protocluster.py
+++ b/antismash/common/secmet/features/test/test_protocluster.py
@@ -121,7 +121,7 @@ class TestDefinitionCDS(unittest.TestCase):
         assert not self.cluster.definition_cdses
 
     def add_core_function(self, cds, cluster_product=True):
-        product = self.cluster.product if cluster_product else "not%s" % self.cluster.product
+        product = self.cluster.product if cluster_product else f"not{self.cluster.product}"
         cds.gene_functions.add(GeneFunction.CORE, "test", "dummy", product)
 
     def test_no_secmet_qual_inside(self):

--- a/antismash/common/secmet/features/test/test_protocluster.py
+++ b/antismash/common/secmet/features/test/test_protocluster.py
@@ -81,7 +81,6 @@ class TestProtocluster(unittest.TestCase):
         assert cluster.contig_edge is True
 
 
-
 class TestSideloaded(unittest.TestCase):
     def test_conversion(self):
         core = FeatureLocation(8, 71, strand=1)

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -34,7 +34,7 @@ def convert_protein_position_to_dna(start: int, end: int, location: Location) ->
             an int representing the calculated DNA location
     """
     if not 0 <= start < end <= len(location) // 3:
-        raise ValueError("Protein positions %d and %d must be contained by %s" % (start, end, location))
+        raise ValueError(f"Protein positions {start} and {end} must be contained by {location}")
     if location.strand == -1:
         dna_start = location.start + len(location) - end * 3
         dna_end = location.start + len(location) - start * 3
@@ -45,8 +45,10 @@ def convert_protein_position_to_dna(start: int, end: int, location: Location) ->
     # only CompoundLocations are complicated
     if not isinstance(location, CompoundLocation):
         if not location.start <= dna_start < dna_end <= location.end:
-            raise ValueError(("Converted coordinates %d..%d "
-                              "out of bounds for location %s") % (dna_start, dna_end, location))
+            raise ValueError(
+                f"Converted coordinates {dna_start}..{dna_end} "
+                f"out of bounds for location {location}"
+            )
         return dna_start, dna_end
 
     parts = sorted(location.parts, key=lambda x: x.start)
@@ -71,8 +73,10 @@ def convert_protein_position_to_dna(start: int, end: int, location: Location) ->
     assert end_found
 
     if not location.start <= dna_start < dna_end <= location.end:
-        raise ValueError(("Converted coordinates %d..%d "
-                          "out of bounds for location %s") % (dna_start, dna_end, location))
+        raise ValueError(
+            f"Converted coordinates {dna_start}..{dna_end} "
+            f"out of bounds for location {location}"
+        )
     return dna_start, dna_end
 
 
@@ -202,10 +206,10 @@ def split_origin_bridging_location(location: CompoundLocation) -> Tuple[
         raise ValueError("Cannot separate bridged location without a valid strand")
 
     if not (lower and upper):
-        raise ValueError("Location does not bridge origin: %s" % location)
+        raise ValueError(f"Location does not bridge origin: {location}")
 
     if not _is_valid_split(lower, upper, location.strand):
-        raise ValueError("cannot determine correct ordering of bridged location: %s" % str(location))
+        raise ValueError(f"cannot determine correct ordering of bridged location: {location}")
 
     return lower, upper
 
@@ -274,11 +278,11 @@ def location_from_string(data: str) -> Location:
         elif '(' not in string:
             strand = None
         else:
-            raise ValueError("Cannot identify strand in location: %s" % string)
+            raise ValueError(f"Cannot identify strand in location: {string}")
 
         return FeatureLocation(start, end, strand=strand)
 
-    assert isinstance(data, str), "%s, %r" % (type(data), data)
+    assert isinstance(data, str), f"{type(data)}, {data!r}"
 
     if '{' not in data:
         return parse_single_location(data)
@@ -335,7 +339,7 @@ def location_contains_overlapping_exons(location: Location) -> bool:
     if isinstance(location, FeatureLocation):
         return False
     if not isinstance(location, CompoundLocation):
-        raise TypeError("expected CompoundLocation, not %s" % type(location))
+        raise TypeError(f"expected CompoundLocation, not {type(location)}")
 
     return len(set(part.end for part in location.parts)) != len(location.parts)
 
@@ -365,10 +369,10 @@ def ensure_valid_locations(features: List[SeqFeature], can_be_circular: bool, se
             raise ValueError("one or more features with missing or invalid locations")
         # features outside the sequence cause problems with motifs and translations
         if feature.location.end > sequence_length:
-            raise ValueError("feature outside record sequence: %s" % feature.location)
+            raise ValueError("feature outside record sequence: {feature.location}")
         # features with overlapping exons cause translation problems
         if location_contains_overlapping_exons(feature.location):
-            raise ValueError("location contains overlapping exons: %s" % feature.location)
+            raise ValueError(f"location contains overlapping exons: {feature.location}")
 
     # non-circular records with compound locations need to have the right part ordering
     # for translations, only really relevant for reverse strand features
@@ -397,7 +401,7 @@ def ensure_valid_locations(features: List[SeqFeature], can_be_circular: bool, se
             if not feature.location.strand:
                 continue
             if location_bridges_origin(feature.location, allow_reversing=True):
-                raise ValueError("cannot determine correct exon ordering for location: %s" % feature.location)
+                raise ValueError(f"cannot determine correct exon ordering for location: {feature.location}")
 
 
 def _adjust_location_by_offset(location: Location, offset: int) -> Location:
@@ -409,7 +413,7 @@ def _adjust_location_by_offset(location: Location, offset: int) -> Location:
     if offset == 0:
         return location
 
-    assert -2 <= offset <= 2, "invalid offset %d" % offset
+    assert -2 <= offset <= 2, f"invalid offset {offset}"
 
     def adjust_single_location(part: FeatureLocation) -> FeatureLocation:
         """ only functions on FeatureLocation """
@@ -458,7 +462,7 @@ def frameshift_location_by_qualifier(location: Location, raw_start: Union[str, i
         codon_start = raw_start - 1
 
     if not 0 <= codon_start <= 2:
-        raise SecmetInvalidInputError("invalid codon_start qualifier: %d" % (codon_start + 1))
+        raise SecmetInvalidInputError(f"invalid codon_start qualifier: {codon_start + 1}")
 
     if location.strand == -1:
         codon_start *= -1

--- a/antismash/common/secmet/qualifiers/gene_functions.py
+++ b/antismash/common/secmet/qualifiers/gene_functions.py
@@ -39,7 +39,7 @@ class GeneFunction(Enum):
         for value in GeneFunction:
             if str(value) == label:
                 return value
-        raise ValueError("Unknown gene function label: %s" % label)
+        raise ValueError(f"Unknown gene function label: {label}")
 
 
 class _GeneFunctionAnnotation:  # pylint: disable=too-few-public-methods
@@ -48,7 +48,7 @@ class _GeneFunctionAnnotation:  # pylint: disable=too-few-public-methods
 
     def __init__(self, function: GeneFunction, tool: str, description: str,
                  product: Optional[str]) -> None:
-        assert isinstance(function, GeneFunction), "wrong type: %s" % type(function)
+        assert isinstance(function, GeneFunction), f"wrong type: {type(function)}"
         assert tool and len(tool.split()) == 1, tool  # no whitespace allowed in tool name
         assert description
         if function == GeneFunction.CORE and not product:
@@ -60,8 +60,8 @@ class _GeneFunctionAnnotation:  # pylint: disable=too-few-public-methods
 
     def __str__(self) -> str:
         if not self.product:
-            return "%s (%s) %s" % (self.function, self.tool, self.description)
-        return "%s (%s) %s: %s" % (self.function, self.tool, self.product, self.description)
+            return f"{self.function} ({self.tool}) {self.description}"
+        return f"{self.function} ({self.tool}) {self.product}: {self.description}"
 
     def __repr__(self) -> str:
         fmt = "GeneFunctionAnnotation(function=%r, tool='%s', product='%s', '%s')"
@@ -83,10 +83,10 @@ class _GeneFunctionAnnotation:  # pylint: disable=too-few-public-methods
             try:
                 parts = _parse_format("{} ({}) {}", text)
             except ValueError:
-                raise ValueError("cannot parse GeneFunctionAnnotation from %s" % text)
+                raise ValueError("cannot parse GeneFunctionAnnotation from {text!r}")
 
         if len(parts) not in [3, 4]:
-            raise ValueError("cannot parse GeneFunctionAnnotation from %s" % text)
+            raise ValueError(f"cannot parse GeneFunctionAnnotation from {text!r}")
 
         if len(parts) == 4:
             function, tool, product, description = parts

--- a/antismash/common/secmet/qualifiers/go.py
+++ b/antismash/common/secmet/qualifiers/go.py
@@ -18,7 +18,7 @@ class GOQualifier:
 
     def to_biopython(self) -> List[str]:
         """Convert GOQualifier to BioPython-style qualifier."""
-        return ["{}: {}".format(go_id, go_description) for go_id, go_description in sorted(self.go_entries.items())]
+        return [f"{go_id}: {go_description}" for go_id, go_description in sorted(self.go_entries.items())]
 
     @staticmethod
     def from_biopython(qualifier: List[str]) -> "GOQualifier":
@@ -35,7 +35,7 @@ class GOQualifier:
         for go_string in qualifier:
             go_id, separator, go_description = go_string.partition(": ")
             if not separator:
-                raise ValueError("Cannot parse qualifier: %s" % qualifier)
+                raise ValueError(f"Cannot parse qualifier: {qualifier}")
             go_entries[go_id] = go_description
         result = GOQualifier(go_entries)
         return result

--- a/antismash/common/secmet/qualifiers/nrps_pks.py
+++ b/antismash/common/secmet/qualifiers/nrps_pks.py
@@ -59,8 +59,7 @@ class NRPSPKSQualifier:
             return (self.start, self.end) < (other.start, other.end)
 
         def __repr__(self) -> str:
-            return "NRPSPKSQualifier.Domain(%s, label=%s, start=%d, end=%d)" % (
-                        self.full_type, self.label, self.start, self.end)
+            return f"NRPSPKSQualifier.Domain({self.full_type}, label={self.label}, start={self.start}, end={self.end})"
 
         def get_predictions(self) -> Dict[str, str]:
             """ Returns a dictionary mapping prediction method to prediction """
@@ -81,7 +80,7 @@ class NRPSPKSQualifier:
     def __init__(self, strand: int) -> None:
         super().__init__()
         if strand not in [1, -1]:
-            raise ValueError("strand must be 1 or -1, not %s" % strand)
+            raise ValueError(f"strand must be 1 or -1, not {strand}")
         self.strand = strand
         self.type = "uninitialised"
         self._domains: List["NRPSPKSQualifier.Domain"] = []
@@ -129,22 +128,22 @@ class NRPSPKSQualifier:
         assert not isinstance(domain, str)
         if domain.hit_id == "PKS_AT":
             self.at_counter += 1
-            suffix = "_AT%d" % self.at_counter
+            suffix = f"_AT{self.at_counter}"
         elif domain.hit_id == "PKS_KR":
             self.kr_counter += 1
-            suffix = "_KR%d" % self.kr_counter
+            suffix = f"_KR{self.kr_counter}"
         elif domain.hit_id == "CAL_domain":
             self.cal_counter += 1
-            suffix = "_CAL%d" % self.cal_counter
+            suffix = f"_CAL{self.cal_counter}"
         elif domain.hit_id in ["AMP-binding", "A-OX"]:
             self.a_counter += 1
-            suffix = "_A%d" % self.a_counter
+            suffix = f"_A{self.a_counter}"
         elif domain.hit_id == "PKS_KS":
             self.ks_counter += 1
-            suffix = "_KS%d" % self.ks_counter
+            suffix = f"_KS{self.ks_counter}"
         else:
             self.other_counter += 1
-            suffix = "_OTHER%d" % self.other_counter
+            suffix = f"_OTHER{self.other_counter}"
 
         new = NRPSPKSQualifier.Domain(domain.hit_id, suffix,
                                       domain.query_start, domain.query_end,
@@ -173,4 +172,4 @@ class NRPSPKSQualifier:
             elif qualifier.startswith("type: "):
                 self.type = _parse_format(_TYPE_FORMAT, qualifier)[0]
             else:
-                raise ValueError("unknown NRPS/PKS qualifier: %s" % qualifier)
+                raise ValueError(f"unknown NRPS/PKS qualifier: {qualifier}")

--- a/antismash/common/secmet/qualifiers/prepeptide_qualifiers.py
+++ b/antismash/common/secmet/qualifiers/prepeptide_qualifiers.py
@@ -13,7 +13,7 @@ class RiPPQualifier:
 
     def __init__(self, rodeo_score: int = 0) -> None:
         if not isinstance(rodeo_score, int):
-            raise TypeError("RODEO score must be an int, not %s" % type(rodeo_score))
+            raise TypeError(f"RODEO score must be an int, not {type(rodeo_score)}")
         self.rodeo_score = rodeo_score
 
     def to_biopython_qualifiers(self) -> Dict[str, List[str]]:
@@ -167,5 +167,5 @@ def rebuild_qualifier(data: Dict[str, List[str]], kind: str) -> Optional[RiPPQua
         "lassopeptide": LassoQualifier,
     }
     if kind not in classes:
-        raise ValueError("no known qualifier builder for prepeptide kind: %s" % kind)
+        raise ValueError(f"no known qualifier builder for prepeptide kind: {kind}")
     return classes[kind].from_biopython_qualifiers(data)

--- a/antismash/common/secmet/qualifiers/secmet.py
+++ b/antismash/common/secmet/qualifiers/secmet.py
@@ -37,18 +37,18 @@ def _parse_format(fmt: str, data: str) -> Sequence[str]:
     # step 3: replace all unescaped brace pairs with a capture group
     # first do an integer-only pass
     fragment = re.escape(":d")
-    sub_search = r"(?<!\\)({%s})" % fragment
-    safe = safe.replace("{%s}" % fragment, r"([0-9]+)")
+    sub_search = fr"(?<!\\)({{{fragment}}})"
+    safe = safe.replace(f"{{{fragment}}}", r"([0-9]+)")
     # then a generic step
     sub_search = r"(?<!\\)({.*?(?<!\\)})"
     # core    "({.*?})" any brace pair and its contents
     # special "(?<!\\)" disallows any core starting or ending with an escaped brace
     # this combo allows capturing the nested parts correctly
-    regex = "^{}$".format(re.sub(sub_search, r"(.+?)", safe))
+    regex = f"^{re.sub(sub_search, r'(.+?)', safe)}$"
 
     res = re.search(regex, data)
     if res is None:
-        raise ValueError("could not match format %r to input %r" % (fmt, data))
+        raise ValueError(f"could not match format {fmt!r} to input {data!r}")
     # don't return matches, since that includes the braces, just use the groups
     return res.groups()
 

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -758,7 +758,8 @@ class Record:
             name_modified = False
 
             # prefilter some NCBI Pfam hits locations that are generated poorly
-            if can_be_circular and feature.type == "misc_feature" and location_bridges_origin(feature.location, allow_reversing=False):
+            if all([can_be_circular, feature.type == "misc_feature",
+                    location_bridges_origin(feature.location, allow_reversing=False)]):
                 feature.location = remove_redundant_exons(feature.location)
 
             if can_be_circular and location_bridges_origin(feature.location, allow_reversing=False):

--- a/antismash/common/secmet/test/helpers.py
+++ b/antismash/common/secmet/test/helpers.py
@@ -33,7 +33,7 @@ class DummyAntismashDomain(AntismashDomain):
         if protein_location is None:
             protein_location = FeatureLocation(protein_start, protein_end)
         if not domain_id:
-            domain_id = "test_asDom_%d" % DummyAntismashDomain.counter
+            domain_id = f"test_asDom_{DummyAntismashDomain.counter}"
             DummyAntismashDomain.counter += 1
         super().__init__(location, tool, protein_location, locus_tag, domain=domain)
         self.domain_id = domain_id
@@ -46,7 +46,7 @@ class DummyCDS(CDSFeature):
         if not translation:
             translation = "A"*(abs(start-end))
         if not locus_tag:
-            locus_tag = "dummy_locus_tag_%d" % DummyCDS.counter
+            locus_tag = f"dummy_locus_tag_{DummyCDS.counter}"
             DummyCDS.counter += 1
         super().__init__(FeatureLocation(start, end, strand), translation=translation,
                          locus_tag=locus_tag)
@@ -71,7 +71,7 @@ class DummyCDSMotif(CDSMotif):
             protein_location = FeatureLocation(protein_start, protein_end)
         super().__init__(FeatureLocation(start, end, strand), locus_tag, protein_location, tool)
         if not domain_id:
-            domain_id = "dummy_domain%d_%d_%d" % (DummyCDSMotif.counter, start, end)
+            domain_id = f"dummy_domain{DummyCDSMotif.counter}_{start}_{end}"
             DummyCDSMotif.counter += 1
         self.domain_id = domain_id
 
@@ -111,7 +111,7 @@ class DummyPFAMDomain(PFAMDomain):
         if protein_location is None:
             protein_location = FeatureLocation(protein_start, protein_end)
         super().__init__(location, description, protein_location, identifier, tool, locus_tag, domain=domain)
-        self.domain_id = domain_id or "dummy_pfam_%d" % DummyPFAMDomain.counter
+        self.domain_id = domain_id or f"dummy_pfam_{DummyPFAMDomain.counter}"
         DummyPFAMDomain.counter += 1
 
 

--- a/antismash/common/secmet/test/helpers.py
+++ b/antismash/common/secmet/test/helpers.py
@@ -4,7 +4,7 @@
 """ Simple constructors for complicated features to simplify testing """
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=protected-access,missing-docstring
 
 from ..features import (
     AntismashDomain,

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -392,7 +392,7 @@ class TestRecord(unittest.TestCase):
         motifs = rec.get_cds_motifs()
         assert len(motifs) == 2
         for i, motif in enumerate(motifs):
-            assert motif.domain_id == "non_aS_motif_0_6_%s" % (i + 1)
+            assert motif.domain_id == f"non_aS_motif_0_6_{i + 1}"
 
     def test_seq_types(self):
         first = Record("A" * 20)

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -134,7 +134,8 @@ class TestConversion(unittest.TestCase):
                 SeqFeature(FeatureLocation(100, 160, 1), type=CDSFeature.FEATURE_TYPE),  # valid/non-antismash
             ]
             # without the discard flag, this needs to raise an error
-            with self.assertRaisesRegex(SecmetInvalidInputError, "(missing expected qualifier: '[^'])|(requires at least one)"):
+            with self.assertRaisesRegex(SecmetInvalidInputError,
+                                        "(missing expected qualifier: '[^'])|(requires at least one)"):
                 Record.from_biopython(bio, taxon="bacteria")
             # with the discard flag, the bad antismash-specific feature should just disappear
             rec = Record.from_biopython(bio, taxon="bacteria", discard_antismash_features=True)
@@ -862,8 +863,10 @@ class TestCDSUniqueness(unittest.TestCase):
         gene = Gene(FeatureLocation(20, 42, 1), locus_tag="test_gene")
         record.add_gene(gene)
 
-        splice1 = CDSFeature(FeatureLocation(20, 26, 1), locus_tag="test_gene", protein_id="splice1", translation="MA")
-        splice2 = CDSFeature(FeatureLocation(27, 33, 1), locus_tag="test_gene", protein_id="splice2", translation="MA")
+        splice1 = CDSFeature(FeatureLocation(20, 26, 1), locus_tag="test_gene",
+                             protein_id="splice1", translation="MA")
+        splice2 = CDSFeature(FeatureLocation(27, 33, 1), locus_tag="test_gene",
+                             protein_id="splice2", translation="MA")
         record.add_cds_feature(splice1)
         record.add_cds_feature(splice2)
 
@@ -871,11 +874,13 @@ class TestCDSUniqueness(unittest.TestCase):
         assert splice2.locus_tag == "test_gene_7e364f92"
 
         with self.assertRaisesRegex(ValueError, "same location"):
-            splice1 = CDSFeature(FeatureLocation(20, 26, 1), locus_tag="test_gene", protein_id="splice1", translation="MA")
+            splice1 = CDSFeature(FeatureLocation(20, 26, 1), locus_tag="test_gene",
+                                 protein_id="splice1", translation="MA")
             record.add_cds_feature(splice1)
 
         with self.assertRaisesRegex(ValueError, "same location"):
-            splice2 = CDSFeature(FeatureLocation(27, 33, 1), locus_tag="test_gene", protein_id="splice2", translation="MA")
+            splice2 = CDSFeature(FeatureLocation(27, 33, 1), locus_tag="test_gene",
+                                 protein_id="splice2", translation="MA")
             record.add_cds_feature(splice2)
 
         splice3 = CDSFeature(FeatureLocation(36, 42, 1), locus_tag="test_gene", protein_id="splice2", translation="MA")

--- a/antismash/common/serialiser.py
+++ b/antismash/common/serialiser.py
@@ -52,7 +52,7 @@ class AntismashResults:
             in a file
         """
         if isinstance(handle, str):
-            handle = open(handle, "r")  # pylint: disable=consider-using-with
+            handle = open(handle, "r", encoding="utf-8")  # pylint: disable=consider-using-with
         try:
             data = json.loads(handle.read())
         except json.JSONDecodeError:
@@ -96,7 +96,7 @@ class AntismashResults:
             logging.error(message)
             raise TypeError(message) from error
         if isinstance(handle, str):
-            handle = open(handle, "w")  # pylint: disable=consider-using-with
+            handle = open(handle, "w", encoding="utf-8")  # pylint: disable=consider-using-with
         handle.write(converted)
 
 
@@ -147,7 +147,7 @@ def dump_records(records: List[SeqRecord], results: List[Dict[str, Union[Dict[st
         logging.error("Error converting json data: %s", data)
         raise
     if isinstance(handle, str):
-        handle = open(handle, "w")  # pylint: disable=consider-using-with
+        handle = open(handle, "w", encoding="utf-8")  # pylint: disable=consider-using-with
     handle.write(new_contents)
     return data
 

--- a/antismash/common/serialiser.py
+++ b/antismash/common/serialiser.py
@@ -61,8 +61,10 @@ class AntismashResults:
         schema = data.get("schema", 1)
         current = AntismashResults.SCHEMA_VERSION
         if schema != current and schema not in AntismashResults.COMPATIBLE_SCHEMAS[current]:
-            raise ValueError("schema mismatch in previous results: expected %s, found %s" % (
-                                AntismashResults.SCHEMA_VERSION, data.get("schema")))
+            raise ValueError(
+                f"schema mismatch in previous results: expected {AntismashResults.SCHEMA_VERSION}"
+                f", found {data.get('schema')}"
+            )
         version = data["version"]
         input_file = data["input_file"]
         taxon = data.get("taxon", "bacteria")
@@ -90,7 +92,7 @@ class AntismashResults:
         try:
             converted = json.dumps(self.to_json())
         except TypeError as error:
-            message = "Failed to convert JSON results: %s" % str(error)
+            message = f"Failed to convert JSON results: {error}"
             logging.error(message)
             raise TypeError(message) from error
         if isinstance(handle, str):
@@ -131,7 +133,7 @@ def dump_records(records: List[SeqRecord], results: List[Dict[str, Union[Dict[st
             if isinstance(m_results, ModuleResults):
                 modules[module] = m_results.to_json()
             else:
-                raise TypeError("Module results for module %s are of invalid type: %s" % (module, type(m_results)))
+                raise TypeError(f"Module results for module {module} are of invalid type: {type(m_results)}")
         json_record["modules"] = modules
         data.append(json_record)
 

--- a/antismash/common/signature.py
+++ b/antismash/common/signature.py
@@ -41,7 +41,7 @@ def get_signature_profiles(detail_file: str) -> List[HmmSignature]:
     """
     bad_lines = []
     profiles = []
-    with open(detail_file, "r") as data:
+    with open(detail_file, "r", encoding="utf-8") as data:
         for line in data.read().split("\n"):
             if line.startswith("#") or not line.strip():
                 continue

--- a/antismash/common/signature.py
+++ b/antismash/common/signature.py
@@ -23,7 +23,7 @@ class HmmSignature(Signature):
     def __init__(self, name: str, description: str, cutoff: int, hmm_path: str) -> None:
         self.hmm_file = hmm_path
         if cutoff < 0:
-            raise ValueError("Signature cutoffs cannot be negative: %s" % cutoff)
+            raise ValueError(f"Signature cutoffs cannot be negative: {cutoff}")
         super().__init__(name, 'model', description, cutoff, self.hmm_file)
 
 

--- a/antismash/common/subprocessing/base.py
+++ b/antismash/common/subprocessing/base.py
@@ -95,8 +95,7 @@ def execute(commands: List[str], stdin: Optional[str] = None, stdout: Union[int,
         except TimeoutExpired:
             proc.kill()
             assert isinstance(timeout, int)
-            raise RuntimeError("Child process '%s' timed out after %d seconds" % (
-                    commands, timeout))
+            raise RuntimeError(f"Child process {commands} timed out after {timeout} seconds")
 
         return RunResult(commands, out, err, proc.returncode, stdout == PIPE,
                          stderr == PIPE)
@@ -187,8 +186,7 @@ def parallel_execute(commands: List[List[str]], cpus: Optional[int] = None,
         except multiprocessing.TimeoutError:
             pool.terminate()
             assert isinstance(timeout, int)
-            raise RuntimeError("One of %d child processes timed out after %d seconds" % (
-                    cpus, timeout))
+            raise RuntimeError(f"One of {cpus} child processes timed out after {timeout} seconds")
 
         except KeyboardInterrupt:
             logging.error("Interrupted by user")

--- a/antismash/common/subprocessing/blast.py
+++ b/antismash/common/subprocessing/blast.py
@@ -46,7 +46,7 @@ def run_blastp(target_blastp_database: str, query_sequence: str,
         command.extend(opts)
 
     if results_file is not None:
-        handle: IO[Any] = open(results_file)  # pylint: disable=consider-using-with
+        handle: IO[Any] = open(results_file, encoding="utf-8")  # pylint: disable=consider-using-with
     else:
         handle = NamedTemporaryFile()  # pylint: disable=consider-using-with
 
@@ -56,7 +56,7 @@ def run_blastp(target_blastp_database: str, query_sequence: str,
                            result.return_code, result.stderr.replace("\n", ""),
                            query_sequence[:100]))
     filename = results_file or handle.name
-    with open(filename) as read_handle:
+    with open(filename, encoding="utf-8") as read_handle:
         parsed = list(SearchIO.parse(read_handle, 'blast-tab'))
     handle.close()
     return parsed

--- a/antismash/common/subprocessing/diamond.py
+++ b/antismash/common/subprocessing/diamond.py
@@ -117,7 +117,7 @@ def check_diamond_db_compatible(database_file: str) -> bool:
     with TemporaryDirectory(change=True):
         dummy_fasta = "dummy.fa"
         dummy_db = "dummy.dmnd"
-        with open(dummy_fasta, "w") as handle:
+        with open(dummy_fasta, "w", encoding="utf-8") as handle:
             handle.write(">test\nM\n")
         run_diamond_makedb(dummy_db, dummy_fasta)
         compatible_format = _extract_db_format(dummy_db)
@@ -145,7 +145,7 @@ def _extract_db_format(database_file: str) -> int:
         Returns:
             The database version as an integer
     """
-    with open(database_file, 'rb') as handle:
+    with open(database_file, "rb") as handle:
         chunk = handle.read(16)
 
     if len(chunk) != 16:

--- a/antismash/common/subprocessing/diamond.py
+++ b/antismash/common/subprocessing/diamond.py
@@ -42,7 +42,7 @@ def run_diamond(subcommand: str,
 
         result = execute(params)
         if not result.successful():
-            raise RuntimeError("diamond failed to run: %s -> %s" % (subcommand, result.stderr[-100:]))
+            raise RuntimeError(f"diamond failed to run: {subcommand} -> {result.stderr[-100:]}")
     return result
 
 
@@ -176,12 +176,12 @@ def check_diamond_files(definition_file: str, fasta_file: str, db_file: str,
     failure_messages: List[str] = []
 
     if path.locate_file(definition_file) is None:
-        failure_messages.append("Failed to locate cluster definition file: {!r}".format(definition_file))
+        failure_messages.append(f"Failed to locate cluster definition file: {definition_file!r}")
 
     regen_message = ""
 
     if path.locate_file(fasta_file) is None:
-        failure_messages.append("Failed to locate cluster proteins: {!r}".format(fasta_file))
+        failure_messages.append(f"Failed to locate cluster proteins: {fasta_file!r}")
         if not logging_only:
             raise FileNotFoundError(failure_messages[-1])
     elif path.locate_file(db_file) is None:
@@ -198,7 +198,7 @@ def check_diamond_files(definition_file: str, fasta_file: str, db_file: str,
         except RuntimeError:
             if not logging_only:
                 raise
-            failure_messages.append("Failed to regenerate diamond database %r" % db_file)
+            failure_messages.append(f"Failed to regenerate diamond database {db_file!r}")
 
     if failure_messages:
         failure_messages.append(f"with diamond executable: {get_config().executables.diamond}")

--- a/antismash/common/subprocessing/hmmpfam.py
+++ b/antismash/common/subprocessing/hmmpfam.py
@@ -46,7 +46,7 @@ def run_hmmpfam2(query_hmmfile: str, target_sequence: str, extra_args: List[str]
     if not result.successful():
         logging.debug('hmmpfam2 returned %d: %r while searching %r', result.return_code,
                       result.stderr, query_hmmfile)
-        raise RuntimeError("hmmpfam2 problem while running %s: %s" % (command, result.stderr))
+        raise RuntimeError(f"hmmpfam2 problem while running {command}: {result.stderr}")
     res_stream = StringIO(result.stdout)
     return list(SearchIO.parse(res_stream, 'hmmer2-text'))
 
@@ -61,8 +61,7 @@ def run_hmmpfam2_help() -> str:
 
     help_text = execute(command).stdout
     if not help_text.startswith("hmmpfam"):
-        msg = "unexpected output from hmmpfam2: %s, check path"
-        raise RuntimeError(msg % hmmpfam2)
+        raise RuntimeError(f"unexpected output from hmmpfam2: {hmmpfam2!r}, check path")
 
     return help_text
 

--- a/antismash/common/subprocessing/hmmscan.py
+++ b/antismash/common/subprocessing/hmmscan.py
@@ -45,7 +45,7 @@ def run_hmmscan(target_hmmfile: str, query_sequence: str, opts: List[str] = None
             f"while scanning {query_sequence[:100]!r}",
         ]))
     if results_file is not None:
-        with open(results_file, 'w') as handle:
+        with open(results_file, "w", encoding="utf-8") as handle:
             handle.write(result.stdout)
 
     return list(SearchIO.parse(StringIO(result.stdout), 'hmmer3-text'))

--- a/antismash/common/subprocessing/hmmscan.py
+++ b/antismash/common/subprocessing/hmmscan.py
@@ -39,9 +39,11 @@ def run_hmmscan(target_hmmfile: str, query_sequence: str, opts: List[str] = None
     command.extend([target_hmmfile, '-'])
     result = execute(command, stdin=query_sequence)
     if not result.successful():
-        raise RuntimeError('hmmscan returned %d: %r while scanning %r' % (
-                           result.return_code, (result.stderr or result.stdout).splitlines()[0],
-                           query_sequence[:100]))
+        raise RuntimeError("".join([
+            f"hmmscan returned {result.return_code}:",
+            (result.stderr or result.stdout).splitlines()[0],
+            f"while scanning {query_sequence[:100]!r}",
+        ]))
     if results_file is not None:
         with open(results_file, 'w') as handle:
             handle.write(result.stdout)
@@ -64,8 +66,7 @@ def run_hmmscan_help() -> str:
 
     help_text = execute(command).stdout
     if not help_text.startswith("# hmmscan"):
-        msg = "unexpected output from hmmscan: %s, check path"
-        raise RuntimeError(msg % hmmscan)
+        raise RuntimeError(f"unexpected output from hmmscan: {hmmscan}, check path")
 
     setattr(run_hmmscan_help, 'help_text', help_text)
     return help_text

--- a/antismash/common/subprocessing/hmmsearch.py
+++ b/antismash/common/subprocessing/hmmsearch.py
@@ -40,7 +40,7 @@ def run_hmmsearch(query_hmmfile: str, target_sequence: str, use_tempfile: bool =
     with TemporaryDirectory(change=True):
         try:
             if use_tempfile:
-                with open("input.fa", 'w') as handle:
+                with open("input.fa", "w", encoding="utf-8") as handle:
                     handle.write(target_sequence)
                 command.append("input.fa")
                 run_result = execute(command)

--- a/antismash/common/subprocessing/memesuite.py
+++ b/antismash/common/subprocessing/memesuite.py
@@ -24,7 +24,7 @@ def run_fimo_simple(query_motif_file: str, target_sequence: str) -> str:
     if not result.successful():
         logging.debug('FIMO returned %d: %r while searching %r', result.return_code,
                       result.stderr, query_motif_file)
-        raise RuntimeError("FIMO problem while running %s... %s" % (command, result.stderr[-100:]))
+        raise RuntimeError(f"FIMO problem while running {command}... {result.stderr[-100:]}")
     return result.stdout
 
 
@@ -38,8 +38,7 @@ def run_fimo_version() -> str:
 
     version_string = execute(command).stdout.strip()
     if not version_string:
-        msg = "unexpected output from fimo: %s, check path"
-        raise RuntimeError(msg % fimo)
+        raise RuntimeError(f"unexpected output from fimo: {fimo}, check path")
     return version_string
 
 

--- a/antismash/common/subprocessing/test/test_diamond.py
+++ b/antismash/common/subprocessing/test/test_diamond.py
@@ -26,8 +26,7 @@ def test_diamond_version(mock_run_diamond):
 @patch("antismash.common.subprocessing.diamond.run_diamond", return_value=DummyResult("lots of useless text"))
 def test_diamond_makedb(mock_run_diamond):
     subprocessing.run_diamond_makedb("fake.dmnd", "fake.fasta")
-    mock_run_diamond.assert_called_once_with("makedb",
-        ["--db", "fake.dmnd", "--in", "fake.fasta"])
+    mock_run_diamond.assert_called_once_with("makedb", ["--db", "fake.dmnd", "--in", "fake.fasta"])
 
 
 class TestDiamondDatabaseChecks(unittest.TestCase):

--- a/antismash/common/test/helpers.py
+++ b/antismash/common/test/helpers.py
@@ -62,7 +62,7 @@ class FakeHSPHit:
         self.seeds = seeds
 
     def __repr__(self):
-        return "FakeHSP({})".format(str(vars(self)))
+        return f"FakeHSP({vars(self)})"
 
 
 class DummyHMMResult(HMMResult):

--- a/antismash/common/test/helpers.py
+++ b/antismash/common/test/helpers.py
@@ -6,7 +6,7 @@
 """
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=protected-access,missing-docstring
 
 # and some extra silencing because most of these classes are simple stubs
 # pylint: disable=too-few-public-methods

--- a/antismash/common/test/helpers.py
+++ b/antismash/common/test/helpers.py
@@ -118,7 +118,7 @@ def run_and_regenerate_results_for_module(input_file, module, options,
         assert not os.path.exists(json_filename)
         try:
             antismash.main.run_antismash(input_file, options)
-        except:
+        except Exception:
             update_config({"output_dir": orig_output})
             raise
         update_config({"output_dir": orig_output})

--- a/antismash/common/test/test_all_orfs.py
+++ b/antismash/common/test/test_all_orfs.py
@@ -14,9 +14,9 @@ from antismash.common.all_orfs import (
     get_trimmed_orf,
     scan_orfs,
 )
+from antismash.common.secmet.test.helpers import DummySubRegion
 
 from .helpers import DummyCDS, DummyRecord
-from antismash.common.secmet.test.helpers import DummySubRegion
 
 
 class TestOrfCounts(unittest.TestCase):

--- a/antismash/common/test/test_all_orfs.py
+++ b/antismash/common/test/test_all_orfs.py
@@ -47,7 +47,7 @@ class TestOrfCounts(unittest.TestCase):
         expected = [FeatureLocation(ExactPosition(0), ExactPosition(66), strand=1)]
         for start in ('ATG', 'GTG', 'TTG'):
             for stop in ('TAA', 'TAG', 'TGA'):
-                seq = "{}{}{}".format(start, "N"*60, stop)
+                seq = f"{start}{'N'*60}{stop}"
                 self.run_both_dirs(expected, seq)
 
     def test_single_contained(self):

--- a/antismash/common/test/test_gff_parser.py
+++ b/antismash/common/test/test_gff_parser.py
@@ -52,7 +52,7 @@ class GffParserTest(TestCase):
 
     def test_features_from_file(self):
         filename = path.get_full_path(__file__, 'data', 'fumigatus.cluster1.gff')
-        features = gff_parser.get_features_from_file(open(filename))["cluster0"]
+        features = gff_parser.get_features_from_file(open(filename, encoding="utf-8"))["cluster0"]
         assert len(features) == 11
         for feature in features:
             assert feature.type == 'CDS'

--- a/antismash/common/test/test_html_renderer.py
+++ b/antismash/common/test/test_html_renderer.py
@@ -127,7 +127,7 @@ class TestSequences(unittest.TestCase):
         assert result == f"{a_chunk}{b_chunk}{c_chunk}{d_chunk}"
 
     def test_invalid(self):
-        for char in "<> ?!+": # indicative, not exhaustive
+        for char in "<> ?!+":  # indicative, not exhaustive
             with self.assertRaisesRegex(ValueError, "invalid character in HTML class"):
                 renderer.spanned_sequence("A", {"A": f"a{char}b"})
 

--- a/antismash/common/test/test_html_renderer.py
+++ b/antismash/common/test/test_html_renderer.py
@@ -24,14 +24,14 @@ def _verify_html_tags_match(html):
             continue
         print(closing, tag)
         if closing:
-            assert stack and stack[-1] == tag, "extra </%s>" % tag
+            assert stack and stack[-1] == tag, f"extra </{tag}>"
             print("closed", stack[-1])
             stack.pop()
         else:
             stack.append(tag)
             print("opened", stack[-1])
     print(stack)
-    assert not stack, "unclosed: %s" % ", ".join(stack)
+    assert not stack, f'unclosed: {", ".join(stack)}'
 
 
 class TestHTMLMatcher(unittest.TestCase):
@@ -69,7 +69,7 @@ class TestCollapser(unittest.TestCase):
             html = str(renderer.collapser_start("dummy", level)) + str(renderer.collapser_end())
             _verify_html_tags_match(html)
             assert "collapser-target-dummy" in html
-            assert "collapser-level-%s" % level in html
+            assert f"collapser-level-{level}" in html
 
     def test_safe_classes(self):
         html = str(renderer.collapser_start("some:name.3", "all")) + str(renderer.collapser_end())
@@ -89,7 +89,7 @@ class TestDocsLink(unittest.TestCase):
     def test_no_subtarget(self):
         result = renderer.docs_link("label")
         assert isinstance(result, renderer.Markup)
-        expected = "<a class='external-link' href='%s' target='_blank'>label</a>" % self.url
+        expected = f"<a class='external-link' href='{self.url}' target='_blank'>label</a>"
         assert str(result) == expected
 
     def test_subtarget(self):
@@ -97,7 +97,7 @@ class TestDocsLink(unittest.TestCase):
         result = renderer.docs_link("label", target)
         assert isinstance(result, renderer.Markup)
         url = self.url + target
-        expected = "<a class='external-link' href='%s' target='_blank'>label</a>" % url
+        expected = f"<a class='external-link' href='{url}' target='_blank'>label</a>"
         assert str(result) == expected
 
 

--- a/antismash/common/test/test_logs.py
+++ b/antismash/common/test/test_logs.py
@@ -68,7 +68,7 @@ class LogTest(unittest.TestCase):
                 logging.debug("during")
             logging.debug("after")
 
-            with open(logfile.name) as handle:
+            with open(logfile.name, encoding="utf-8") as handle:
                 content = handle.read()
             assert "during" in content
             assert "after" not in content
@@ -80,7 +80,7 @@ class LogTest(unittest.TestCase):
                 logging.debug("debug")
             logging.info("after")
 
-            with open(logfile.name) as handle:
+            with open(logfile.name, encoding="utf-8") as handle:
                 content = handle.read()
             assert "during" in content
             assert "debug" not in content
@@ -93,7 +93,7 @@ class LogTest(unittest.TestCase):
                 logging.debug("debug")
             logging.warning("after")
 
-            with open(logfile.name) as handle:
+            with open(logfile.name, encoding="utf-8") as handle:
                 content = handle.read()
             assert "during" in content
             assert "debug" not in content
@@ -105,7 +105,7 @@ class LogTest(unittest.TestCase):
                 logging.debug("during")
             logging.debug("after")
 
-            with open(logfile.name) as handle:
+            with open(logfile.name, encoding="utf-8") as handle:
                 content = handle.read()
             assert "during" in content
             assert "after" not in content

--- a/antismash/common/test/test_pfamdb.py
+++ b/antismash/common/test/test_pfamdb.py
@@ -34,7 +34,7 @@ class TestPFAMs(unittest.TestCase):
 
             if create_file:
                 path = os.path.join(path, "Pfam-A.hmm")
-                with open(path, "w") as handle:
+                with open(path, "w", encoding="utf-8"):
                     pass
 
         with tempfile.TemporaryDirectory(prefix="aS.pfamdbtest") as temp_db_layout:

--- a/antismash/common/test/test_pfamdb.py
+++ b/antismash/common/test/test_pfamdb.py
@@ -46,7 +46,7 @@ class TestPFAMs(unittest.TestCase):
             with self.assertRaisesRegex(Exception, f"No matching database in location {temp_db_layout}"):
                 pfamdb.find_latest_database_version(temp_db_layout)
 
-            with open(os.path.join(bad, "Pfam-A.hmm"), "w") as handle:
+            with open(os.path.join(bad, "Pfam-A.hmm"), "w", encoding="utf-8") as handle:
                 handle.write("dummy text")
 
             with self.assertRaisesRegex(Exception, f"Incompatible database .* {temp_db_layout}"):

--- a/antismash/common/test/test_record_processing.py
+++ b/antismash/common/test/test_record_processing.py
@@ -360,7 +360,7 @@ class TestUniqueID(unittest.TestCase):
                 record_processing.generate_unique_id("pref", {}, 1, bad_max)
 
     def test_generation(self):
-        existing = {"a_%d" % i for i in range(15)}
+        existing = {f"a_{i}" for i in range(15)}
         new, counter = record_processing.generate_unique_id("a", existing)
         assert len(existing) == 15 and new not in existing
         assert new == "a_15" and counter == 15
@@ -374,7 +374,7 @@ class TestUniqueID(unittest.TestCase):
         assert new == "b_0" and counter == 0
 
     def test_overlong(self):
-        existing = {"a_%d" % i for i in range(150)}
+        existing = {f"a_{i}" for i in range(150)}
         # prefix itself too long
         with self.assertRaisesRegex(RuntimeError, "Could not generate .*"):
             record_processing.generate_unique_id("aaa", existing, start=0, max_length=3)

--- a/antismash/common/test/test_serialiser.py
+++ b/antismash/common/test/test_serialiser.py
@@ -69,7 +69,7 @@ class TestResultsJSON(unittest.TestCase):
             for oldline, newline in zip(oldvalue.split('\n'), newvalue.split('\n')):
                 assert oldline == newline
 
-    def test_results_from_invalid_file_raises_error(self):
+    def test_invalid_file_raises_error(self):
         filename = get_path_to_nisin_genbank()
         self.assertRaisesRegex(ValueError, "Cannot load results to reuse",
                                serialiser.AntismashResults.from_file, filename)

--- a/antismash/common/test/test_serialiser.py
+++ b/antismash/common/test/test_serialiser.py
@@ -44,7 +44,7 @@ class TestResultsJSON(unittest.TestCase):
 
     def test_record_to_json_and_back(self):
         filename = get_path_to_nisin_genbank()
-        records = list(seqio.parse(open(filename), "genbank"))
+        records = list(seqio.parse(open(filename, encoding="utf-8"), "genbank"))
         records = [Record.from_biopython(rec, taxon="bacteria") for rec in records]
         rec_results = [{}, {}, {}]
         results = serialiser.AntismashResults(filename, records, rec_results, "dummy", taxon="dummytaxon")
@@ -64,8 +64,8 @@ class TestResultsJSON(unittest.TestCase):
         oldvalue = original.getvalue()
         newvalue = new.getvalue()
         with TemporaryDirectory(change=True):
-            open("old.json", "w").write(oldvalue)
-            open("new.json", "w").write(newvalue)
+            open("old.json", "w", encoding="utf-8").write(oldvalue)
+            open("new.json", "w", encoding="utf-8").write(newvalue)
             for oldline, newline in zip(oldvalue.split('\n'), newvalue.split('\n')):
                 assert oldline == newline
 

--- a/antismash/common/utils.py
+++ b/antismash/common/utils.py
@@ -125,7 +125,7 @@ def get_hmm_lengths(hmm_file: str) -> Dict[str, int]:
             a dictionary mapping each NAME field in the file to it's LENG field
     """
     lengths = {}
-    with open(hmm_file, "r") as handle:
+    with open(hmm_file, "r", encoding="utf-8") as handle:
         contents = handle.read()
     contents = contents.replace("\r", "")
     hmms = contents.split("//")[:-1]

--- a/antismash/config/__init__.py
+++ b/antismash/config/__init__.py
@@ -52,7 +52,7 @@ class Config:  # since it's a glorified namespace, pylint: disable=too-few-publi
         def __getattr__(self, attr: str) -> Any:
             if attr in self.__dict__:
                 return self.__dict__[attr]
-            raise AttributeError("Config has no attribute: %s" % attr)
+            raise AttributeError(f"Config has no attribute: {attr}")
 
         def __setattr__(self, attr: str, value: Any) -> None:
             # special exceptions for those arguments we must update after
@@ -141,7 +141,7 @@ def build_config(args: List[str], parser: Optional[AntismashParser] = None, isol
     with_files = []
     for filename in (_USER_FILE_NAME, _INSTANCE_FILE_NAME):
         if os.path.exists(filename):
-            with_files.append("@%s" % filename)
+            with_files.append(f"@{filename}")
     with_files.extend(args)
     result = parser.parse_args(with_files)
 

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -71,8 +71,9 @@ class AntismashParser(argparse.ArgumentParser):
         if basic:
             self._basic_help_groups.add(title)
         return super().add_argument_group(title, description, **kwargs)
+# pylint: enable=arguments-differ
 
-    def print_help(self, file_handle: IO = None, show_all: bool = False
+    def print_help(self, file: IO = None, show_all: bool = False
                    ) -> None:
         """ Overrides parent print_help() to be able to pass through whether all
             help should be shown or not.
@@ -85,8 +86,7 @@ class AntismashParser(argparse.ArgumentParser):
                 None
         """
         self._show_all = show_all
-        super().print_help(file_handle)
-# pylint: enable=arguments-differ
+        super().print_help(file)
 
     def write_to_config_file(self, filename: str, values: Dict[str, Any] = None) -> None:
         """ Write the default options to file in a form that can be parsed again
@@ -151,7 +151,6 @@ class AntismashParser(argparse.ArgumentParser):
         if not values:
             values = {}
 
-        outfile = open(filename, "w", encoding="utf-8")
         dests: Set[str] = set()  # set of processed destinations
         titles: Dict[str, Dict[str, List[str]]] = defaultdict(lambda: defaultdict(list))
         for parent in sorted(self.parents, key=lambda group: group.title):
@@ -161,14 +160,14 @@ class AntismashParser(argparse.ArgumentParser):
         for arg in self._actions:
             titles["Core options"]["core"].extend(construct_arg_text(arg, dests, values))
 
-        for title, prefixes in titles.items():
-            banner = "#"*10 + "\n"
-            outfile.writelines([banner, f"#\t{title}\n", banner, "\n"])
-            for lines in prefixes.values():
-                outfile.write("\n".join(lines))
-                outfile.write("\n")
-            outfile.write("\n\n")
-        outfile.close()
+        with open(filename, "w", encoding="utf-8") as outfile:
+            for title, prefixes in titles.items():
+                banner = "#"*10 + "\n"
+                outfile.writelines([banner, f"#\t{title}\n", banner, "\n"])
+                for lines in prefixes.values():
+                    outfile.write("\n".join(lines))
+                    outfile.write("\n")
+                outfile.write("\n\n")
 
     def format_help(self) -> str:
         """Custom help formatter"""

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -151,7 +151,7 @@ class AntismashParser(argparse.ArgumentParser):
         if not values:
             values = {}
 
-        outfile = open(filename, 'w')
+        outfile = open(filename, "w", encoding="utf-8")
         dests: Set[str] = set()  # set of processed destinations
         titles: Dict[str, Dict[str, List[str]]] = defaultdict(lambda: defaultdict(list))
         for parent in sorted(self.parents, key=lambda group: group.title):

--- a/antismash/config/executables.py
+++ b/antismash/config/executables.py
@@ -80,24 +80,24 @@ def get_executable_paths(binaries_arg: str) -> Dict[str, str]:
             continue
         subparts = part.split("=")
         if not len(subparts) == 2:
-            raise ValueError("invalid alternate executable format: %s" % part)
+            raise ValueError(f"invalid alternate executable format: {part}")
         name, path = subparts
         if not name or not path:
-            raise ValueError("invalid alternate executable format: %s" % part)
+            raise ValueError(f"invalid alternate executable format: {part}")
         if name not in _ALTERNATE_EXECUTABLE_NAMES:
-            raise ValueError("unrecognised executable name: %s" % name)
+            raise ValueError(f"unrecognised executable name: {name}")
         if os.sep in path:
             path = os.path.abspath(path)
         if os.path.isabs(path):
             if not os.path.exists(path):
-                raise ValueError("no such file: %s" % path)
+                raise ValueError(f"no such file: {path!r}")
             full_path = path
         else:
             full_path = find_executable_path(path)
             if not full_path:
-                raise ValueError("cannot find executable: %s" % path)
+                raise ValueError(f"cannot find executable: {path}")
         if full_path != binaries.get(name, full_path):
-            raise ValueError("multiple paths specified for executable: %s" % name)
+            raise ValueError(f"multiple paths specified for executable: {name}")
         assert full_path
         binaries[name] = full_path
     return binaries

--- a/antismash/config/loader.py
+++ b/antismash/config/loader.py
@@ -25,7 +25,7 @@ def load_config_from_file() -> Namespace:
     default_file = os.path.join(_BASEDIR, _DEFAULT_NAME)
     # load generic configuration settins
     config = configparser.ConfigParser()
-    with open(default_file, 'r') as handle:
+    with open(default_file, "r", encoding="utf-8") as handle:
         config.read_file(handle)
 
     for section in config.sections():

--- a/antismash/config/test/test_args.py
+++ b/antismash/config/test/test_args.py
@@ -89,7 +89,7 @@ class TestConfig(unittest.TestCase):
 
     def test_paths(self):
         with TemporaryDirectory(change=True) as temp_dir:
-            with open("local", "w"):
+            with open("local", "w", encoding="utf-8"):
                 pass  # just create the file, no need for content
             options = self.core_parser.parse_args(["--reuse-results", "local"])
             without_symlinks = os.path.realpath(os.path.join(temp_dir, "local"))

--- a/antismash/detection/cassis/__init__.py
+++ b/antismash/detection/cassis/__init__.py
@@ -386,25 +386,25 @@ def create_subregions(anchor: str, cluster_preds: List[ClusterPrediction],
             "aStool": ["cassis"],
             "label": [anchor],
             "abundance": [cluster.start.abundance + cluster.end.abundance],
-            "motif_score": ["{:.1e}".format(cluster.start.score + cluster.end.score)],
+            "motif_score": [f"{cluster.start.score + cluster.end.score:.1e}"],
             "gene_left": [cluster.start.gene],
             "promoter_left": [cluster.start.promoter],
             "abundance_left": [cluster.start.abundance],
             "motif_left": [cluster.start.pairing_string],
-            "motif_score_left": ["{:.1e}".format(cluster.start.score)],
+            "motif_score_left": [f"{cluster.start.score:.1e}"],
             "gene_right": [cluster.end.gene],
             "promoter_right": [cluster.end.promoter],
             "abundance_right": [cluster.end.abundance],
             "motif_right": [cluster.end.pairing_string],
-            "motif_score_right": ["{:.1e}".format(cluster.end.score)],
+            "motif_score_right": [f"{cluster.end.score:.1e}"],
             "genes": [cluster.genes],
             "promoters": [cluster.promoters],
         }
 
         if i == 0:
-            new_feature.qualifiers["note"] = ["best prediction (most abundant) for anchor gene {}".format(anchor)]
+            new_feature.qualifiers["note"] = [f"best prediction (most abundant) for anchor gene {anchor}"]
         else:
-            new_feature.qualifiers["note"] = ["alternative prediction ({}) for anchor gene {}".format(i, anchor)]
+            new_feature.qualifiers["note"] = [f"alternative prediction ({i}) for anchor gene {anchor}"]
 
         new_feature = SubRegion.from_biopython(new_feature)
         subregions.append(new_feature)

--- a/antismash/detection/cassis/cluster_prediction.py
+++ b/antismash/detection/cassis/cluster_prediction.py
@@ -43,11 +43,10 @@ class ClusterMarker(Pairing):
             self.minus = int(motif.minus)
 
     def __str__(self) -> str:
-        return "gene %s; abundance %s; motif %s; score %s" % (
-                  self.gene, self.abundance, self.pairing_string, self.score)
+        return f"gene {self.gene}; abundance {self.abundance}; motif {self.pairing_string}; score {self.score}"
 
     def __repr__(self) -> str:
-        return "ClusterMarker(%s, promoter=%s)" % (str(self), self.promoter)
+        return f"ClusterMarker({self}, promoter={self.promoter})"
 
     def __eq__(self, other: Any) -> bool:
         return (isinstance(other, ClusterMarker)
@@ -65,8 +64,10 @@ class ClusterPrediction:
         self.promoters = 0
 
     def __repr__(self) -> str:
-        return "ClusterPrediction(start=%s, end=%s, gene_count=%d, promoter_count=%d)" % (
-                        self.start, self.end, self.genes, self.promoters)
+        return (
+            f"ClusterPrediction(start={self.start}, end={self.end},"
+            f" gene_count={self.genes}, promoter_count={self.promoters})"
+        )
 
     def __eq__(self, other: Any) -> bool:
         return (isinstance(other, ClusterPrediction)

--- a/antismash/detection/cassis/islands.py
+++ b/antismash/detection/cassis/islands.py
@@ -28,7 +28,7 @@ class Island:
                 and self.motif == other.motif)
 
     def __repr__(self) -> str:
-        return "Island(start=%s, end=%s, motif=%s)" % (self.start, self.end, self.motif)
+        return f"Island(start={self.start}, end={self.end}, motif={self.motif})"
 
 
 def get_islands(anchor_promoter: int, motifs: List[Motif], promoters: List[Promoter]) -> List[Island]:

--- a/antismash/detection/cassis/motifs.py
+++ b/antismash/detection/cassis/motifs.py
@@ -91,7 +91,7 @@ def generate_motifs(meme_dir: str, anchor_promoter: int, promoters: List[Promote
                     os.makedirs(pm_dir)
 
                 # write promoter sequences to fasta file, in respective "plus-minus" subdir
-                with open(os.path.join(pm_dir, "promoters.fasta"), "w") as pm_handle:
+                with open(os.path.join(pm_dir, "promoters.fasta"), "w", encoding="utf-8") as pm_handle:
                     for i in range(start_index, end_index + 1):
                         seq = SeqRecord(promoters[i].seq,
                                         id=promoters[i].get_id(),
@@ -150,8 +150,8 @@ def filter_meme_results(meme_dir: str, promoter_sets: List[Motif], anchor: str) 
                                           site.findall("site/letter_ref")))
                               for site in contributing_sites]
                 # write sites to fasta file
-                with open(os.path.join(meme_dir, str(motif),
-                                       "binding_sites.fasta"), "w") as handle:
+                with open(os.path.join(meme_dir, str(motif), "binding_sites.fasta"),
+                          "w", encoding="utf-8") as handle:
                     handle.write(f">{anchor}__{motif}\n")
                     handle.write("\n".join(motif.seqs))
                 if VERBOSE_DEBUG:
@@ -175,7 +175,7 @@ def filter_fimo_results(motifs: List[Motif], fimo_dir: str, promoters: List[Prom
 
     for motif in motifs:
         assert isinstance(motif, Motif), type(motif)
-        with open(os.path.join(fimo_dir, str(motif), "fimo.txt"), "r") as handle:
+        with open(os.path.join(fimo_dir, str(motif), "fimo.txt"), "r", encoding="utf-8") as handle:
             table_reader = csv.reader(handle, delimiter="\t")
             for row in table_reader:
                 # skip comment lines
@@ -185,7 +185,7 @@ def filter_fimo_results(motifs: List[Motif], fimo_dir: str, promoters: List[Prom
                 motif.hits[seq_id] += 1
 
         # write binding sites per promoter to file
-        with open(os.path.join(fimo_dir, str(motif), "bs_per_promoter.csv"), "w") as handle:
+        with open(os.path.join(fimo_dir, str(motif), "bs_per_promoter.csv"), "w", encoding="utf-8") as handle:
             table_writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
             table_writer.writerow(["#", "promoter", "binding sites"])  # table head
             for i, promoter in enumerate(promoters):

--- a/antismash/detection/cassis/motifs.py
+++ b/antismash/detection/cassis/motifs.py
@@ -52,7 +52,7 @@ class Motif(Pairing):
                 and self.hits == other.hits)
 
     def __repr__(self) -> str:
-        return "Motif(%s, score=%s, hits=%s)" % (self.pairing_string, self.score, self.hits)
+        return f"Motif({self.pairing_string}, score={self.score}, hits={self.hits})"
 
 
 def generate_motifs(meme_dir: str, anchor_promoter: int, promoters: List[Promoter]) -> List[Motif]:
@@ -95,7 +95,7 @@ def generate_motifs(meme_dir: str, anchor_promoter: int, promoters: List[Promote
                     for i in range(start_index, end_index + 1):
                         seq = SeqRecord(promoters[i].seq,
                                         id=promoters[i].get_id(),
-                                        description="length={}bp".format(len(promoters[i].seq)))
+                                        description=f"length={len(promoters[i].seq)}bp")
                         if i == anchor_promoter:  # mark anchor gene
                             seq.id += "__ANCHOR"  # must be part of id, otherwise MEME woun't recognize it
                         SeqIO.write(seq, pm_handle, "fasta")
@@ -152,7 +152,7 @@ def filter_meme_results(meme_dir: str, promoter_sets: List[Motif], anchor: str) 
                 # write sites to fasta file
                 with open(os.path.join(meme_dir, str(motif),
                                        "binding_sites.fasta"), "w") as handle:
-                    handle.write(">{}__{}\n".format(anchor, str(motif)))
+                    handle.write(f">{anchor}__{motif}\n")
                     handle.write("\n".join(motif.seqs))
                 if VERBOSE_DEBUG:
                     logging.debug("MEME: motif %s; e-value = %s", motif, motif.score)

--- a/antismash/detection/cassis/pairings.py
+++ b/antismash/detection/cassis/pairings.py
@@ -16,7 +16,7 @@ class Pairing:
     @property
     def pairing_string(self) -> str:
         """ A string representing the range of this pairing. """
-        return "+{:02d}_-{:02d}".format(self.plus, self.minus)
+        return f"+{self.plus:02d}_-{self.minus:02d}"
 
     def __str__(self) -> str:
         return self.pairing_string

--- a/antismash/detection/cassis/promoters.py
+++ b/antismash/detection/cassis/promoters.py
@@ -40,7 +40,7 @@ class Promoter:
         return len(self.seq)
 
     def __str__(self) -> str:
-        return "Promoter(%r, %d, %d)" % (self.get_id(), self.start, self.end)
+        return f"Promoter({self.get_id()!r}, {self.start}, {self.end})"
 
     def __repr__(self) -> str:
         return str(self)
@@ -70,7 +70,7 @@ class CombinedPromoter(Promoter):
         self.second_gene = str(second_gene)
 
     def get_id(self) -> str:
-        return "{}+{}".format(self.gene_name, self.second_gene)
+        return f"{self.gene_name}+{self.second_gene}"
 
     def get_gene_names(self) -> List[str]:
         return super().get_gene_names() + [self.second_gene]
@@ -119,7 +119,7 @@ def get_promoters(record: Record, genes: List[Gene],
 
         downstream_inside_gene = gene_last > gene_first + downstream_tss
         if gene.location.strand not in [1, -1]:
-            raise ValueError("Gene %s has unknown strand: %s" % (gene.get_name(), gene.location.strand))
+            raise ValueError(f"Gene {gene.get_name()} has unknown strand: {gene.location.strand}")
 
         is_special_case = (gene.location.strand == -1 and len(genes) > i + 1 and genes[i+1].location.strand == 1
                            and gene_last + upstream_tss >= genes[i+1].location.start - upstream_tss)
@@ -316,7 +316,7 @@ def write_promoters_to_file(output_dir: str, prefix: str, promoters: List[Promot
 
         # write promoter sequences to file
         SeqIO.write(SeqRecord(promoter.seq, id=promoter.get_id(),
-                    description="length={}bp".format(len(promoter))),
+                    description=f"length={len(promoter)}bp"),
                     seq_handle,
                     "fasta")
     pos_handle.close()
@@ -330,4 +330,4 @@ def get_anchor_promoter_index(anchor: str, promoters: List[Promoter]) -> int:
         if anchor in promoter.get_gene_names():
             return i
 
-    raise ValueError("No promoter exists for the given anchor: %s" % anchor)
+    raise ValueError(f"No promoter exists for the given anchor: {anchor}")

--- a/antismash/detection/cassis/promoters.py
+++ b/antismash/detection/cassis/promoters.py
@@ -302,10 +302,10 @@ def write_promoters_to_file(output_dir: str, prefix: str, promoters: List[Promot
     """
     # pylint: disable=consider-using-with
     # positions file
-    pos_handle = open(os.path.join(output_dir, prefix + "_promoter_positions.csv"), "w")
+    pos_handle = open(os.path.join(output_dir, prefix + "_promoter_positions.csv"), "w", encoding="utf-8")
     pos_handle.write("\t".join(["#", "promoter", "start", "end", "length"]) + "\n")
     # sequences file
-    seq_handle = open(os.path.join(output_dir, prefix + "_promoter_sequences.fasta"), "w")
+    seq_handle = open(os.path.join(output_dir, prefix + "_promoter_sequences.fasta"), "w", encoding="utf-8")
     # pylint: enable=consider-using-with
 
     for i, promoter in enumerate(promoters):

--- a/antismash/detection/cassis/test/test_cassis.py
+++ b/antismash/detection/cassis/test/test_cassis.py
@@ -103,23 +103,27 @@ class TestCassisMethods(CassisTestCore):
         cassis.write_promoters_to_file(self.options.output_dir, seq_record.name, promoters)
         # read expected files and save to string variable
         expected_sequences_file = ""
-        with open(path.get_full_path(__file__, "data", "expected_promoter_sequences.fasta")) as handle:
+        with open(path.get_full_path(__file__, "data", "expected_promoter_sequences.fasta"),
+                  encoding="utf-8") as handle:
             expected_sequences_file = handle.read()
         expected_sequences_file = convert_newline(expected_sequences_file.rstrip())
 
         expected_positions_file = ""
-        with open(path.get_full_path(__file__, "data", "expected_promoter_positions.csv")) as handle:
+        with open(path.get_full_path(__file__, "data", "expected_promoter_positions.csv"),
+                  encoding="utf-8") as handle:
             expected_positions_file = handle.read()
         expected_positions_file = convert_newline(expected_positions_file.rstrip())
 
         # read test files and save to string variable
         sequences_file = ""
-        with open(os.path.join(self.options.output_dir, seq_record.name + "_promoter_sequences.fasta")) as handle:
+        with open(os.path.join(self.options.output_dir, seq_record.name + "_promoter_sequences.fasta"),
+                  encoding="utf-8") as handle:
             sequences_file = handle.read()
         sequences_file = convert_newline(sequences_file.rstrip())
 
         positions_file = ""
-        with open(os.path.join(self.options.output_dir, seq_record.name + "_promoter_positions.csv")) as handle:
+        with open(os.path.join(self.options.output_dir, seq_record.name + "_promoter_positions.csv"),
+                  encoding="utf-8") as handle:
             positions_file = handle.read()
         positions_file = convert_newline(positions_file.rstrip())
 

--- a/antismash/detection/cassis/test/test_islands.py
+++ b/antismash/detection/cassis/test/test_islands.py
@@ -19,7 +19,7 @@ class TestPairings(unittest.TestCase):
         anchor_promoter = 1
         promoters = []
         for i in range(1, 7):
-            promoters.append(Promoter("gene%d" % i, i * 10, i * 10 + 4))
+            promoters.append(Promoter(f"gene{i}", i * 10, i * 10 + 4))
         # resulting in 2 different islands (this example)
         # promoter (pos): 1 2 3 4 5 6
         # binding sites:  1 2 0 0 0 0

--- a/antismash/detection/cassis/test/test_motifs.py
+++ b/antismash/detection/cassis/test/test_motifs.py
@@ -74,7 +74,7 @@ class TestMotifs(CassisTestCore):
         anchor_promoter = 1
         promoters = []
         for i in range(1, 16):
-            promoters.append(Promoter("gene%d" % i, i * 10, i * 10 + 4))
+            promoters.append(Promoter(f"gene{i}", i * 10, i * 10 + 4))
         # need certain amount of promoters, otherwise the proportion of
         # promoters with a motif (motif frequency) will be too high --> error
         expected_motifs = [Motif(0, 3, hits={"gene1": 1, "gene2": 2})]

--- a/antismash/detection/cassis/test/test_runners.py
+++ b/antismash/detection/cassis/test/test_runners.py
@@ -16,12 +16,12 @@ from .test_cassis import create_fake_record, convert_newline, CassisTestCore
 def read_generated_expected_file(generated_file, expected_file):
     """Read generated and expected files and save to string variables"""
     generated_string = ""
-    with open(generated_file) as handle:
+    with open(generated_file, encoding="utf-8") as handle:
         generated_string = handle.read()
     generated_string = convert_newline(generated_string.rstrip())
 
     expected_string = ""
-    with open(path.get_full_path(__file__, "data", expected_file)) as handle:
+    with open(path.get_full_path(__file__, "data", expected_file), encoding="utf-8") as handle:
         expected_string = handle.read()
     expected_string = convert_newline(expected_string.rstrip())
 

--- a/antismash/detection/cluster_hmmer/__init__.py
+++ b/antismash/detection/cluster_hmmer/__init__.py
@@ -47,7 +47,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
     failure_messages = []
     for binary_name in ['hmmscan']:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate executable: %r" % binary_name)
+            failure_messages.append(f"Failed to locate executable: {binary_name!r}")
 
     data_dir = options.database_dir
 

--- a/antismash/detection/cluster_hmmer/test/test_clusterhmmer.py
+++ b/antismash/detection/cluster_hmmer/test/test_clusterhmmer.py
@@ -48,7 +48,7 @@ class TestClusterhmmer(unittest.TestCase):
 
     def test_check_prereqs_missing_file(self, patched_locate, _patched_run):
         patched_locate.side_effect = [None] + EXPECTED_FILES[1:]
-        expected = ["Failed to locate file: 'Pfam-A.hmm' in %s/pfam/%s" % (self.config.database_dir, self.latest_pfam)]
+        expected = [f"Failed to locate file: 'Pfam-A.hmm' in {self.config.database_dir}/pfam/{self.latest_pfam}"]
         returned = cluster_hmmer.check_prereqs(self.config)
 
         self.assertListEqual(expected, returned)

--- a/antismash/detection/full_hmmer/__init__.py
+++ b/antismash/detection/full_hmmer/__init__.py
@@ -56,7 +56,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
     failure_messages = []
     for binary_name in ['hmmscan']:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate executable: %r" % binary_name)
+            failure_messages.append(f"Failed to locate executable: {binary_name!r}")
 
     data_dir = options.database_dir
 

--- a/antismash/detection/full_hmmer/test/test_fullhmmer.py
+++ b/antismash/detection/full_hmmer/test/test_fullhmmer.py
@@ -48,7 +48,7 @@ class TestFullhmmer(unittest.TestCase):
 
     def test_check_prereqs_missing_file(self, patched_locate, _patched_run):
         patched_locate.side_effect = [None] + EXPECTED_FILES[1:]
-        expected = ["Failed to locate file: 'Pfam-A.hmm' in %s/pfam/%s" % (self.config.database_dir, self.latest_pfam)]
+        expected = [f"Failed to locate file: 'Pfam-A.hmm' in {self.config.database_dir}/pfam/{self.latest_pfam}"]
         returned = full_hmmer.check_prereqs(self.config)
 
         self.assertListEqual(expected, returned)

--- a/antismash/detection/genefunctions/__init__.py
+++ b/antismash/detection/genefunctions/__init__.py
@@ -34,7 +34,7 @@ class AllFunctionResults(module_results.DetectionResults):
         """ Add results for a tool, tool name must be unique and user-friendly """
         assert isinstance(results, FunctionResults), type(results)
         if results.tool in self._tools:
-            raise ValueError("Gene function results already exist for tool: %s" % results.tool)
+            raise ValueError(f"Gene function results already exist for tool: {results.tool}")
         self._tools[results.tool] = results
 
     def add_to_record(self, record: Record) -> None:
@@ -109,11 +109,11 @@ def check_prereqs(options: ConfigType) -> List[str]:
 
     for binary_name in ['hmmscan', 'hmmpress']:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate file: %r" % binary_name)
+            failure_messages.append(f"Failed to locate file: {binary_name!r}")
 
     database = os.path.join(options.database_dir, 'resfam', 'Resfams.hmm')
     if "mounted_at_runtime" not in database and path.locate_file(database) is None:
-        failure_messages.append('Failed to locate Resfam database in %s' % database)
+        failure_messages.append(f"Failed to locate Resfam database in {database!r}")
 
     failure_messages.extend(prepare_data(logging_only=True))
 

--- a/antismash/detection/genefunctions/core.py
+++ b/antismash/detection/genefunctions/core.py
@@ -31,8 +31,8 @@ class FunctionResults(DetectionResults):
         for feature_name, result in self.best_hits.items():
             function = self.function_mapping[feature_name]
             feature = record.get_cds_by_name(feature_name)
-            feature.gene_functions.add(function, self.tool, "%s (Score: %g; E-value: %g)" % (
-                                            result.hit_id, result.bitscore, result.evalue))
+            feature.gene_functions.add(function, self.tool,
+                                       f"{result.hit_id} (Score: {result.bitscore:G}; E-value: {result.evalue})")
 
     @staticmethod
     def from_json(json: Dict[str, Any], record: Record) -> Optional["FunctionResults"]:

--- a/antismash/detection/genefunctions/smcogs.py
+++ b/antismash/detection/genefunctions/smcogs.py
@@ -51,7 +51,7 @@ def build_function_mapping() -> Dict[str, GeneFunction]:
         'R': GeneFunction.REGULATORY,  # 'regulatory',
     }
     annotations = {}
-    with open(path.get_full_path(__file__, 'data', 'cog_annotations.txt'), 'r') as handle:
+    with open(path.get_full_path(__file__, "data", "cog_annotations.txt"), "r", encoding="utf-8") as handle:
         lines = handle.readlines()
     for line in lines:
         cog, _desc, key = line.strip().split('\t', 3)

--- a/antismash/detection/genefunctions/test/integration_smcogs.py
+++ b/antismash/detection/genefunctions/test/integration_smcogs.py
@@ -37,7 +37,7 @@ class TestSMCOGs(unittest.TestCase):
 
     def build_record(self, genbank):
         # construct a working record
-        with open(genbank) as handle:
+        with open(genbank, encoding="utf-8") as handle:
             seq_record = seqio.read(handle, "genbank")
         record = secmet.Record.from_biopython(seq_record, taxon="bacteria")
         assert record.get_protoclusters()

--- a/antismash/detection/genefunctions/test/test_smcogs.py
+++ b/antismash/detection/genefunctions/test/test_smcogs.py
@@ -18,7 +18,7 @@ class TestSMCOGLoad(unittest.TestCase):
         mapping = smcogs.build_function_mapping()
         assert len(mapping) == 301
         for key, function in mapping.items():
-            assert isinstance(function, GeneFunction), "cog annotation %s has bad type" % key
+            assert isinstance(function, GeneFunction), f"cog annotation {key} has bad type"
 
 
 class TestAddingToRecord(unittest.TestCase):

--- a/antismash/detection/hmm_detection/__init__.py
+++ b/antismash/detection/hmm_detection/__init__.py
@@ -108,7 +108,7 @@ def _get_rules(strictness: str, category: Optional[str] = None) -> List[rule_par
     rules: List[rule_parser.DetectionRule] = []
     aliases: Dict[str, List[rule_parser.Token]] = {}
     for rule_file in _get_rule_files_for_strictness(strictness):
-        with open(rule_file) as rulefile:
+        with open(rule_file, encoding="utf-8") as rulefile:
             rules = rule_parser.Parser("".join(rulefile.readlines()), signature_names,
                                        category_names, rules, aliases).rules
     if category is not None:
@@ -259,9 +259,9 @@ def prepare_data(logging_only: bool = False) -> List[str]:
     if outdated:
         # try to generate file from all specified profiles in hmmdetails
         try:
-            with open(seeds_hmm, 'w') as all_hmms_handle:
+            with open(seeds_hmm, "w", encoding="utf-8") as all_hmms_handle:
                 for hmm_file in hmm_files:
-                    with open(path.get_full_path(__file__, hmm_file), 'r') as handle:
+                    with open(path.get_full_path(__file__, hmm_file), "r", encoding="utf-8") as handle:
                         all_hmms_handle.write(handle.read())
         except OSError:
             if not logging_only:

--- a/antismash/detection/hmm_detection/__init__.py
+++ b/antismash/detection/hmm_detection/__init__.py
@@ -60,7 +60,7 @@ def _get_rule_files_for_strictness(strictness: str) -> List[str]:
     assert strictness in _STRICTNESS_LEVELS, strictness
     files = []
     for level in _STRICTNESS_LEVELS[:_STRICTNESS_LEVELS.index(strictness) + 1]:
-        files.append(path.get_full_path(__file__, "cluster_rules", "%s.txt" % level))
+        files.append(path.get_full_path(__file__, "cluster_rules", f"{level}.txt"))
     return files
 
 
@@ -74,7 +74,7 @@ class HMMDetectionResults(DetectionResults):
         self.rule_results = rule_results
         self.enabled_types = enabled_types
         if strictness not in _STRICTNESS_LEVELS:
-            raise ValueError("unknown strictness level: %s" % strictness)
+            raise ValueError(f"unknown strictness level: {strictness}")
         self.strictness = strictness
 
     def to_json(self) -> Dict[str, Any]:
@@ -266,7 +266,7 @@ def prepare_data(logging_only: bool = False) -> List[str]:
         except OSError:
             if not logging_only:
                 raise
-            failure_messages.append('Failed to generate file {!r}'.format(seeds_hmm))
+            failure_messages.append(f"Failed to generate file {seeds_hmm!r}")
 
     # if regeneration failed, don't try to run hmmpress
     if failure_messages:
@@ -284,7 +284,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
     failure_messages = []
     for binary_name in ["hmmsearch", "hmmpress"]:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate executable for %r" % binary_name)
+            failure_messages.append(f"Failed to locate executable for {binary_name!r}")
 
     # no point checking the data if we can't use it
     if failure_messages:

--- a/antismash/detection/hmm_detection/categories.py
+++ b/antismash/detection/hmm_detection/categories.py
@@ -50,7 +50,7 @@ def get_rule_categories() -> List[RuleCategory]:
     # not cached, generate
     categories: List[RuleCategory] = []
 
-    with open(path.get_full_path(__file__, "data", "categories.json"), 'r') as handle:
+    with open(path.get_full_path(__file__, "data", "categories.json"), "r", encoding="utf-8") as handle:
         category_json = json.load(handle)
         for name, metadata in category_json.items():
             categories.append(RuleCategory.from_json(name, metadata))

--- a/antismash/detection/hmm_detection/data/extract_details.py
+++ b/antismash/detection/hmm_detection/data/extract_details.py
@@ -12,7 +12,7 @@ import os
 from typing import IO
 
 
-def main() -> None:
+def _main() -> None:
     parser = ArgumentParser()
     parser.add_argument("profile", type=FileType('r', encoding="utf-8"),
                         help="HMM file to extract info from")
@@ -28,10 +28,23 @@ def main() -> None:
 
 
 def run(profile: IO, name: str = "", description: str = "", cutoff: int = -1) -> str:
+    """ Extracts name, description, and cutoff from an HMM profile and returns
+        a string with the information that is compatible with the format used in
+        'hmmdetails.txt'.
+
+        Arguments:
+            profile: an open handle to the profile content
+            name: a name to use instead of any found in the profile
+            description: a description to use instead of any found in the profile
+            cutoff: a cutoff to use instead of any used in the profile
+
+        Returns:
+            a 'hmmdetails.txt'-compatible line of text
+    """
     filename = os.path.basename(profile.name)
 
     line = profile.readline().strip()
-    while line and line != '//' and not (name and description and (cutoff > -1) ):
+    while line and line != '//' and not (name and description and (cutoff > -1)):
         line = profile.readline().strip()
         if not name and line.startswith("NAME"):
             name = line.split(" ", 1)[-1].strip()
@@ -52,4 +65,4 @@ def run(profile: IO, name: str = "", description: str = "", cutoff: int = -1) ->
 
 
 if __name__ == "__main__":
-    main()
+    _main()

--- a/antismash/detection/hmm_detection/test/test_extract_details.py
+++ b/antismash/detection/hmm_detection/test/test_extract_details.py
@@ -29,6 +29,7 @@ TC    {cutoff} 12.34;
 //
 """
 
+
 def create_profile(name: str, description: str, cutoff: float = -1.0) -> StringIO:
     """Create a fake HMM profile handle"""
     if cutoff >= 0:
@@ -40,6 +41,7 @@ def create_profile(name: str, description: str, cutoff: float = -1.0) -> StringI
     handle.name = "path/to/fake.hmm"
 
     return handle
+
 
 class ExtractDetailsTest(unittest.TestCase):
     def test_all_defaults(self):

--- a/antismash/detection/hmm_detection/test/test_extract_details.py
+++ b/antismash/detection/hmm_detection/test/test_extract_details.py
@@ -5,7 +5,6 @@
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,consider-using-with
 
 from io import StringIO
-import profile
 import unittest
 
 import antismash.detection.hmm_detection.data.extract_details as core

--- a/antismash/detection/hmm_detection/test/test_hmm_detection.py
+++ b/antismash/detection/hmm_detection/test/test_hmm_detection.py
@@ -167,7 +167,7 @@ class HmmDetectionTest(unittest.TestCase):
         aliases = {}
         rules = hmm_detection.create_rules(self.rules_file, self.signature_names,
                                            self.valid_categories, aliases)
-        assert len(rules) == open(self.rules_file).read().count("\nRULE")
+        assert len(rules) == open(self.rules_file, encoding="utf-8").read().count("\nRULE")
         t1pks_rules = [rule for rule in rules if rule.name == "T1PKS"]
         assert len(t1pks_rules) == 1
         rule = t1pks_rules[0]
@@ -188,7 +188,7 @@ class HmmDetectionTest(unittest.TestCase):
                                            self.valid_categories, aliases, rules)
         profiles_used = set()
 
-        with open(self.filter_file, 'r') as handle:
+        with open(self.filter_file, "r", encoding="utf-8") as handle:
             filter_lines = handle.readlines()
         for line in filter_lines:
             for sig in line.split(','):
@@ -269,7 +269,7 @@ class HmmDetectionTest(unittest.TestCase):
     def test_equivalence_groups(self):
         group_file = path.get_full_path(os.path.dirname(__file__), "filterhmmdetails.txt")
         sets = []
-        with open(group_file) as group_lines:
+        with open(group_file, encoding="utf-8") as group_lines:
             sets = [set(line.strip().split(',')) for line in group_lines]
 
         # ensure they have at least two elements

--- a/antismash/detection/hmm_detection/test/test_hmm_detection.py
+++ b/antismash/detection/hmm_detection/test/test_hmm_detection.py
@@ -70,13 +70,13 @@ class HmmDetectionTest(unittest.TestCase):
         self.categories = {"Cat"}
 
         self.rules = rule_parser.Parser("\n".join([
-                "RULE MetaboliteA CATEGORY Cat CUTOFF 10 NEIGHBOURHOOD 5 CONDITIONS modelA",
-                "RULE MetaboliteB CATEGORY Cat CUTOFF 10 NEIGHBOURHOOD 5 CONDITIONS cds(modelA and modelB)",
-                "RULE MetaboliteC CATEGORY Cat CUTOFF 10 NEIGHBOURHOOD 5 CONDITIONS (modelA and modelB)",
-                "RULE MetaboliteD CATEGORY Cat CUTOFF 20 NEIGHBOURHOOD 5 CONDITIONS minimum(2,[modelC,modelB]) and modelA",
-                "RULE Metabolite0 CATEGORY Cat CUTOFF 1 NEIGHBOURHOOD 3 CONDITIONS modelF",
-                "RULE Metabolite1 CATEGORY Cat CUTOFF 1 NEIGHBOURHOOD 3 CONDITIONS modelG"]),
-                self.test_names, self.categories).rules
+            "RULE MetaboliteA CATEGORY Cat CUTOFF 10 NEIGHBOURHOOD 5 CONDITIONS modelA",
+            "RULE MetaboliteB CATEGORY Cat CUTOFF 10 NEIGHBOURHOOD 5 CONDITIONS cds(modelA and modelB)",
+            "RULE MetaboliteC CATEGORY Cat CUTOFF 10 NEIGHBOURHOOD 5 CONDITIONS (modelA and modelB)",
+            "RULE MetaboliteD CATEGORY Cat CUTOFF 20 NEIGHBOURHOOD 5 CONDITIONS minimum(2,[modelC,modelB]) and modelA",
+            "RULE Metabolite0 CATEGORY Cat CUTOFF 1 NEIGHBOURHOOD 3 CONDITIONS modelF",
+            "RULE Metabolite1 CATEGORY Cat CUTOFF 1 NEIGHBOURHOOD 3 CONDITIONS modelG"]),
+            self.test_names, self.categories).rules
         self.record = Record()
         self.record._record.seq = Seq("A"*150000)
         for feature in self.feature_by_id.values():

--- a/antismash/detection/hmm_detection/test/test_hmm_detection.py
+++ b/antismash/detection/hmm_detection/test/test_hmm_detection.py
@@ -147,7 +147,7 @@ class HmmDetectionTest(unittest.TestCase):
             self.record.add_protocluster(cluster)
         assert len(self.record.get_protoclusters()) == 7
         cluster_products = sorted([cluster.product for cluster in self.record.get_protoclusters()])
-        assert cluster_products == sorted(["Metabolite%s" % i for i in "01AABCD"])
+        assert cluster_products == sorted([f"Metabolite{i}" for i in "01AABCD"])
         self.record.create_candidate_clusters()
         assert len(self.record.get_candidate_clusters()) == 3
         self.record.create_regions()

--- a/antismash/detection/nrps_pks_domains/__init__.py
+++ b/antismash/detection/nrps_pks_domains/__init__.py
@@ -94,8 +94,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
     failure_messages = []
     for binary_name in ['hmmscan', 'hmmpress']:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate executable for %r" %
-                                    binary_name)
+            failure_messages.append(f"Failed to locate executable for {binary_name!r}")
 
     # skip trying to press files if there's missing binaries
     if failure_messages:

--- a/antismash/detection/nrps_pks_domains/__init__.py
+++ b/antismash/detection/nrps_pks_domains/__init__.py
@@ -83,8 +83,7 @@ def prepare_data(logging_only: bool = False) -> List[str]:
             if logging_only:
                 failure_messages.append(str(err))
                 continue
-            else:
-                raise
+            raise
         failure_messages.extend(hmmer.ensure_database_pressed(full_path, return_not_raise=logging_only))
     return failure_messages
 

--- a/antismash/detection/nrps_pks_domains/domain_drawing.py
+++ b/antismash/detection/nrps_pks_domains/domain_drawing.py
@@ -248,7 +248,7 @@ def domains_have_predictions(region: Union[Region, RegionLayer]) -> bool:
 
 
 def generate_html(region_layer: RegionLayer, _results: ModuleResults,
-                  record_layer: RecordLayer, options_layer: OptionsLayer
+                  record_layer: RecordLayer, _options_layer: OptionsLayer
                   ) -> HTMLSections:
     """ Generate the details section of NRPS/PKS domains in the main HTML output """
     template = FileTemplate(path.get_full_path(__file__, 'templates', 'details.html'))

--- a/antismash/detection/nrps_pks_domains/domain_drawing.py
+++ b/antismash/detection/nrps_pks_domains/domain_drawing.py
@@ -121,7 +121,7 @@ def _get_domain_class(abbreviation: str, domain_name: str) -> str:
         res = _CLASS_BY_ABBREVIATION.get(abbreviation, "other")
     else:
         res = _CLASS_BY_NAME.get(domain_name, "other")
-    return "jsdomain-%s" % res
+    return f"jsdomain-{res}"
 
 
 def get_css_class_and_abbreviation(domain_name: str) -> Tuple[str, str]:

--- a/antismash/detection/nrps_pks_domains/domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/domain_identification.py
@@ -445,7 +445,7 @@ def generate_domain_features(gene: CDSFeature, domains: List[HMMResult]) -> Dict
         new_feature.translation = gene.translation[domain.query_start:domain.query_end]
 
         domain_counts[domain.hit_id] += 1  # 1-indexed, so increment before use
-        domain_name = "{}_{}.{}".format(gene.get_name(), domain.hit_id, domain_counts[domain.hit_id])
+        domain_name = f"{gene.get_name()}_{domain.hit_id}.{domain_counts[domain.hit_id]}"
 
         new_feature.domain_id = "nrpspksdomains_" + domain_name
         new_feature.label = domain_name
@@ -469,7 +469,7 @@ def generate_motif_features(feature: CDSFeature, motifs: List[HMMResult]) -> Lis
         prot_loc = FeatureLocation(motif.query_start, motif.query_end)
         new_motif = CDSMotif(loc, feature.get_name(), prot_loc, tool="nrps_pks_domains")
         new_motif.label = motif.hit_id
-        new_motif.domain_id = 'nrpspksmotif_{}_{:04d}'.format(locus_tag, i)
+        new_motif.domain_id = f"nrpspksmotif_{locus_tag}_{i:04d}"
         new_motif.evalue = motif.evalue
         new_motif.score = motif.bitscore
         new_motif.detection = "hmmscan"

--- a/antismash/detection/nrps_pks_domains/modular_domain.py
+++ b/antismash/detection/nrps_pks_domains/modular_domain.py
@@ -25,7 +25,7 @@ TOOL = "nrps_pks_domains"
 
 class ModularDomain(AntismashDomain):
     """ A class to represent a Domain with extra specificities and type information """
-    __slots__ = ["specificity", "subtypes"]
+    __slots__ = ["subtypes"]
     FEATURE_TYPE = "aSDomain"
 
     def __init__(self, location: Location, protein_location: FeatureLocation, locus_tag: str) -> None:

--- a/antismash/detection/nrps_pks_domains/module_identification.py
+++ b/antismash/detection/nrps_pks_domains/module_identification.py
@@ -585,11 +585,12 @@ def combine_modules(current: CDSModuleInfo, previous: CDSModuleInfo) -> Optional
     if not current.modules:
         return module
 
-    next = current.modules[0]
+    next_module = current.modules[0]
     # is it a KR following a split trans_AT module?
     # e.g. AM746336 (in both kirAII and kirAV) and AF484556.1 (in LnmJ)
-    if module.is_trans_at() and len(next.components) == 1 and next.components[0].domain.hit_id == "PKS_KR":
-        module.add_component(next.components[0], [])
+    if module.is_trans_at() and len(next_module.components) == 1 \
+            and next_module.components[0].domain.hit_id == "PKS_KR":
+        module.add_component(next_module.components[0], [])
         current.modules.pop(0)
 
     return module

--- a/antismash/detection/nrps_pks_domains/module_identification.py
+++ b/antismash/detection/nrps_pks_domains/module_identification.py
@@ -332,7 +332,7 @@ class Module:
             try:
                 self.ensure_suitable(component, lookahead)
             except IncompatibleComponentError as err:
-                raise IncompatibleComponentError("cannot add %s to %s: %s" % (component, self, str(err)))
+                raise IncompatibleComponentError(f"cannot add {component} to {self}: {err}")
         if component.is_starter() and not self._starter:
             assert not self._starter, self
             self._starter = component
@@ -398,7 +398,8 @@ class Module:
         return not self._components
 
     def __str__(self) -> str:
-        return "[%s]" % (",".join(str(component) for component in self._components))
+        core = ",".join(str(component) for component in self._components)
+        return f"[{core}]"
 
     def __iter__(self) -> Iterator[Component]:
         for component in self._components:
@@ -482,7 +483,7 @@ def classify(profile_name: str) -> str:
     for key, val in CLASSIFICATIONS.items():
         if profile_name in val:
             return key
-    raise ValueError("could not classify domain: %s" % profile_name)
+    raise ValueError(f"could not classify domain: {profile_name}")
 
 
 def build_modules_for_cds(domains: List[HMMResult], cds_name: str) -> List[Module]:
@@ -499,7 +500,7 @@ def build_modules_for_cds(domains: List[HMMResult], cds_name: str) -> List[Modul
     modules = [Module(first_in_cds=True)]
     components = [Component(domain, cds_name) for domain in domains]
     for i, component in enumerate(components):
-        assert component.classification, "missing classification for %s" % component.domain.hit_id
+        assert component.classification, f"missing classification for {component.domain.hit_id}"
         component = Component(component.domain, cds_name)
         # start a new module if we have an explicit starter
         if component.is_starter() and not component.is_loader() and not modules[-1].is_empty():

--- a/antismash/detection/nrps_pks_domains/test/integration_domains.py
+++ b/antismash/detection/nrps_pks_domains/test/integration_domains.py
@@ -53,9 +53,12 @@ class TestAnalyses(unittest.TestCase):
                                         }],
                            "ks_subtypes": [],
                            }
-        one_domain_json = {'domain_hmms': [{'bitscore': 76.9, 'query_end': 382, 'evalue': 3.9e-24, 'hit_id': 'ECH', 'query_start': 170}],
-                           'motif_hmms': [{'query_start': 18, 'evalue': 4.7e-05, 'query_end': 30, 'bitscore': 16.1, 'hit_id': 'C1_dual_004-017'},
-                                          {'query_start': 38, 'evalue': 1.4e-19, 'query_end': 78, 'bitscore': 62.4, 'hit_id': 'C2_DCL_024-062'}],
+        one_domain_json = {'domain_hmms': [{'bitscore': 76.9, 'query_end': 382, 'evalue': 3.9e-24,
+                                            'hit_id': 'ECH', 'query_start': 170}],
+                           'motif_hmms': [{'query_start': 18, 'evalue': 4.7e-05, 'query_end': 30,
+                                           'bitscore': 16.1, 'hit_id': 'C1_dual_004-017'},
+                                          {'query_start': 38, 'evalue': 1.4e-19, 'query_end': 78,
+                                           'bitscore': 62.4, 'hit_id': 'C2_DCL_024-062'}],
                            "modules": [],  # arbitrarily none
                            "ks_subtypes": [],
                            }

--- a/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
@@ -97,7 +97,7 @@ class TestKSCounter(unittest.TestCase):
                 if key == var_name:
                     assert val == 2
                 else:
-                    assert val == 1, "%s %s" % (ks_name, vars(counter))
+                    assert val == 1, f"{ks_name} {vars(counter)}"
             assert counter.modular_is_greatest() == (ks_name == "Modular-KS")
             assert counter.ene_is_greatest() == (ks_name == "Enediyne-KS")
             assert counter.iterative_is_greatest() == (ks_name == "Iterative-KS")

--- a/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
@@ -239,7 +239,7 @@ class TestDatabases(unittest.TestCase):
 
     def test_caching(self):
         root = "/some/dummy/root"
-        options = update_config(get_simple_options(None, ['--databases', root]))
+        update_config(get_simple_options(None, ['--databases', root]))
         assert not domain_identification.DATABASE_PATHS
         with patch.object(path, "find_latest_database_version",
                           return_value="1.0") as patched:

--- a/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/test/test_domain_identification.py
@@ -91,7 +91,7 @@ class TestKSCounter(unittest.TestCase):
 
     def test_specific(self):
         for var_name, ks_name in zip(["trans_at", "modular", "enediyne", "iterative"],
-                            ["Trans-AT-KS", "Modular-KS", "Enediyne-KS", "Iterative-KS"]):
+                                     ["Trans-AT-KS", "Modular-KS", "Enediyne-KS", "Iterative-KS"]):
             counter = self.counter(self.one_each + [ks_name])
             for key, val in vars(counter).items():
                 if key == var_name:
@@ -122,6 +122,7 @@ class TestSubtypeFinding(unittest.TestCase):
                 DummyHMMResult("c", start=5, end=8),
             ]
         }
+
     def find(self, target, existing=None, callback=None):
         if existing is None:
             existing = self.existing_hits

--- a/antismash/detection/nrps_pks_domains/test/test_modules.py
+++ b/antismash/detection/nrps_pks_domains/test/test_modules.py
@@ -74,7 +74,8 @@ class TestClassify(unittest.TestCase):
 
     def test_all_domains_classified(self):
         domain_names = []
-        with open(path.get_full_path(nrps_pks_domains.__file__, "data", "nrpspksdomains.hmm")) as handle:
+        with open(path.get_full_path(nrps_pks_domains.__file__, "data", "nrpspksdomains.hmm"),
+                  encoding="utf-8") as handle:
             for line in handle:
                 if line.startswith("NAME"):
                     domain_names.append(line.strip().split()[1])

--- a/antismash/detection/nrps_pks_domains/test/test_modules.py
+++ b/antismash/detection/nrps_pks_domains/test/test_modules.py
@@ -237,7 +237,7 @@ class TestModule(unittest.TestCase):
     def test_monomer_trans_at_default(self):
         trans_at = build_module([PKS_START, CP], [TRANS_AT_SUBTYPE])
         assert trans_at._starter.subtype == TRANS_AT_SUBTYPE
-        assert trans_at._loader == None
+        assert trans_at._loader is None
         assert trans_at.is_trans_at()
         assert trans_at.get_monomer("") == "mal"
 
@@ -410,12 +410,12 @@ class TestBuildModules(unittest.TestCase):
             assert len(build_modules_for_cds(domains, ["Trans-AT-PKS"])) == 3
 
     def test_double_transporters_miss(self):
-         domains = [DummyHMMResult(i) for i in [PKS_START, CP, CP, NRPS_START]]
-         modules = build_modules_for_cds(domains, ["Trans-AT-PKS"])
-         # the two CP domains should be in separate modules, with the trailing NRPS a third
-         assert len(modules) == 3
-         assert len(modules[1].components) == 1
-         assert modules[1].components[0].domain.hit_id == CP
+        domains = [DummyHMMResult(i) for i in [PKS_START, CP, CP, NRPS_START]]
+        modules = build_modules_for_cds(domains, ["Trans-AT-PKS"])
+        # the two CP domains should be in separate modules, with the trailing NRPS a third
+        assert len(modules) == 3
+        assert len(modules[1].components) == 1
+        assert modules[1].components[0].domain.hit_id == CP
 
 
 class TestMerging(unittest.TestCase):

--- a/antismash/detection/sideloader/__init__.py
+++ b/antismash/detection/sideloader/__init__.py
@@ -101,7 +101,7 @@ def check_options(options: ConfigType) -> List[str]:
     errors = []
     for filename in options.sideload:
         if not os.path.exists(filename):
-            errors.append("Extra annotation JSON cannot be found at '%s'" % filename)
+            errors.append(f"Extra annotation JSON cannot be found at {filename!r}")
     if len(set(options.sideload)) != len(options.sideload):
         errors.append("Sideloaded filenames contain duplicates")
     if options.sideload_cds_padding < 0:

--- a/antismash/detection/sideloader/loader.py
+++ b/antismash/detection/sideloader/loader.py
@@ -43,7 +43,7 @@ def _ensure_valid(raw_json: Dict[str, Any], schema_file: str) -> Dict[str, Any]:
 
     # work around jsonschema breaking relative locations when subschemas reference each other
     schema_dir = os.path.dirname(schema_file)
-    resolver = jsonschema.RefResolver(base_uri='file://%s/subschemas/' % schema_dir, referrer=schema)
+    resolver = jsonschema.RefResolver(base_uri=f"file://{schema_dir}/subschemas/", referrer=schema)
 
     try:
         DefaultValidator(schema, resolver=resolver).validate(raw_json)

--- a/antismash/detection/sideloader/loader.py
+++ b/antismash/detection/sideloader/loader.py
@@ -38,7 +38,7 @@ DefaultValidator = _default_validator(jsonschema.Draft7Validator)
 
 def _ensure_valid(raw_json: Dict[str, Any], schema_file: str) -> Dict[str, Any]:
     """ Validate a python representation of JSON against a schema file """
-    with open(schema_file) as handle:
+    with open(schema_file, encoding="utf-8") as handle:
         schema = json.load(handle)
 
     # work around jsonschema breaking relative locations when subschemas reference each other
@@ -72,7 +72,7 @@ def load_validated_json(data_file: str, schema_file: str) -> Dict[str, Any]:
             A dictionary with the python representation of the JSON data
 
     """
-    with open(data_file) as handle:
+    with open(data_file, encoding="utf-8") as handle:
         try:
             raw = json.load(handle)
         except ValueError as err:

--- a/antismash/detection/sideloader/test/test_general.py
+++ b/antismash/detection/sideloader/test/test_general.py
@@ -49,7 +49,7 @@ class TestSimple(unittest.TestCase):
 
     def test_end_overflow(self):
         length = 50
-        features = [DummyCDS(start=10, end = 18)]
+        features = [DummyCDS(start=10, end=18)]
         record = DummyRecord(seq="A"*length, record_id="A", features=features)
         results = general.load_single_record_annotations([], record, _parse_arg(f"A:1-{length * 10}"))
         assert len(results.subregions) == 1

--- a/antismash/detection/sideloader/test/test_loading.py
+++ b/antismash/detection/sideloader/test/test_loading.py
@@ -11,7 +11,7 @@ from antismash.common import errors, path
 from antismash.detection.sideloader import general, loader
 
 GOOD_FILE = path.get_full_path(__file__, "data", "good.json")
-with open(GOOD_FILE) as _handle:
+with open(GOOD_FILE, encoding="utf-8") as _handle:
     GOOD_DATA = _handle.read()
 
 

--- a/antismash/detection/sideloader/test/test_structures.py
+++ b/antismash/detection/sideloader/test/test_structures.py
@@ -31,7 +31,7 @@ class TestSub(unittest.TestCase):
         sub = structures.SubRegionAnnotation(5, 50, "label", dummy_tool(), {"a": ["first"], "b": ["and", "second"]})
         as_json = json.loads(json.dumps(sub.to_json()))  # string conversion to match real use
         regenerated = structures.SubRegionAnnotation.from_json(as_json)
-        assert sub == regenerated, "%s != %s" % (vars(sub), vars(regenerated))
+        assert sub == regenerated, f"{vars(sub)} != {vars(regenerated)}"
 
         as_json["details"] = {"a": "first", "b": ["and", "second"]}
         regenerated = structures.SubRegionAnnotation.from_json(as_json)
@@ -39,7 +39,7 @@ class TestSub(unittest.TestCase):
 
         as_json.pop("tool")
         regenerated = structures.SubRegionAnnotation.from_schema_json(as_json, dummy_tool())
-        assert sub == regenerated, "%s != %s" % (vars(sub), vars(regenerated))
+        assert sub == regenerated, f"{vars(sub)} != {vars(regenerated)}"
 
     def test_secmet_conversion(self):
         source = structures.SubRegionAnnotation(5, 50, "label", dummy_tool(), {"a": ["first"], "b": ["second"]})

--- a/antismash/detection/tigrfam/tigr_domain.py
+++ b/antismash/detection/tigrfam/tigr_domain.py
@@ -43,7 +43,7 @@ class TIGRDomain(AntismashDomain):
         """
         super().__init__(location, TOOL, protein_location, locus_tag, domain=domain)
         if not isinstance(description, str):
-            raise TypeError("TIGRDomain description must be a string, not %s" % type(description))
+            raise TypeError(f"TIGRDomain description must be a string, not {type(description)}")
         if not description:
             raise ValueError("TIGRDomain description cannot be empty")
         self.description = description
@@ -52,7 +52,7 @@ class TIGRDomain(AntismashDomain):
             raise ValueError("TIGRFam identifier cannot be empty")
 
         if not (len(identifier) == 9 and identifier.startswith('TIGR') and identifier[4:].isdecimal()):
-            raise ValueError("invalid TIGRFam identifier: %s" % identifier)
+            raise ValueError(f"invalid TIGRFam identifier: {identifier}")
         self.identifier = identifier
 
     def to_biopython(self, qualifiers: Dict[str, List[str]] = None) -> List[SeqFeature]:

--- a/antismash/detection/tigrfam/tigr_results.py
+++ b/antismash/detection/tigrfam/tigr_results.py
@@ -32,7 +32,7 @@ class TIGRFamResults(HmmerResults):
                         "score", "translation"]:
                 setattr(tigr_feature, key, getattr(hit, key))
             tigr_feature.detection = "hmmscan"
-            tigr_feature.domain_id = "{}_{}_{:04d}".format(self.tool, tigr_feature.locus_tag, i + 1)
+            tigr_feature.domain_id = f"{self.tool}_{tigr_feature.locus_tag}_{i + 1:04d}"
             record.add_feature(tigr_feature)
 
     def refilter(self, max_evalue: float, min_score: float) -> "TIGRFamResults":

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -674,6 +674,10 @@ def run_antismash(sequence_file: Optional[str], options: ConfigType) -> int:
     return result
 
 
+def _get_all_enabled_modules(modules: list[AntismashModule], options: ConfigType) -> list[AntismashModule]:
+    return [module for module in modules if module.is_enabled(options)]
+
+
 def _run_antismash(sequence_file: Optional[str], options: ConfigType) -> int:
     """ The real run_antismash, assumes logging is set up around it """
     logging.info("antiSMASH version: %s", options.version)
@@ -684,7 +688,7 @@ def _run_antismash(sequence_file: Optional[str], options: ConfigType) -> int:
         return 0
 
     modules = get_all_modules()
-    options.all_enabled_modules = list(filter(lambda x: x.is_enabled(options), modules))
+    options.all_enabled_modules = _get_all_enabled_modules(modules, options)
 
     if options.check_prereqs_only:
         try:

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -252,6 +252,8 @@ def run_module(record: Record, module: AntismashModule, options: ConfigType,
         Returns:
             None
     """
+    if module not in options.all_enabled_modules:
+        return
     previous_results = module_results.pop(module.__name__, None)
     results = None
     if previous_results is not None:

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -371,7 +371,7 @@ def write_profiling_results(profiler: cProfile.Profile, target: str) -> None:
     stats.print_callers(.25)
     try:
         path_to_remove = os.path.dirname(os.path.realpath(__file__)) + os.path.sep
-        with open(target, "w") as handle:
+        with open(target, "w", encoding="utf-8") as handle:
             handle.write(stream.getvalue().replace(path_to_remove, ""))
         logging.info("Profiling report written to %s", target)
     except IOError:
@@ -547,7 +547,7 @@ def read_data(sequence_file: Optional[str], options: ConfigType) -> serialiser.A
         update_config({"input_file": os.path.splitext(results.input_file)[1]})
     else:
         logging.debug("Attempting to reuse previous results in: %s", options.reuse_results)
-        with open(options.reuse_results) as handle:
+        with open(options.reuse_results, encoding="utf-8") as handle:
             contents = handle.read()
             if not contents:
                 raise ValueError(f"No results contained in file: {options.reuse_results!r}")

--- a/antismash/modules/active_site_finder/__init__.py
+++ b/antismash/modules/active_site_finder/__init__.py
@@ -67,7 +67,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
 
     for binary_name in ['hmmpfam2', 'hmmscan', 'hmmpress']:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate file: %r" % binary_name)
+            failure_messages.append(f"Failed to locate file: {binary_name!r}")
 
     # Get all HMM profile names from XML file
     for profile in ["PKSI-KR.hmm2", "PKSI-KS_N.hmm2", "PKSI-KS_C.hmm2", "PKSI-AT.hmm2",
@@ -76,7 +76,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
         full_hmm_path = path.get_full_path(__file__, "data", profile)
 
         if path.locate_file(full_hmm_path) is None:
-            failure_messages.append("Failed to locate file: %s" % profile)
+            failure_messages.append(f"Failed to locate file: {profile!r}")
             continue
 
     return failure_messages

--- a/antismash/modules/active_site_finder/analysis.py
+++ b/antismash/modules/active_site_finder/analysis.py
@@ -113,7 +113,7 @@ def asp_ks_c(record: secmet.Record) -> List[SinglePairing]:
 
     for alignment in analyser.get_alignments():
         value = alignment.get_signature([49, 111])  # emissions [0.95, 1.]
-        results.append((alignment.domain, "found active site histidines: %s" % (value == "HH")))
+        results.append((alignment.domain, f"found active site histidines: {value == 'HH'}"))
 
     return results
 
@@ -195,7 +195,7 @@ def asp_acp(record: secmet.Record) -> List[SinglePairing]:
 
     for alignment in analyser.get_alignments():
         value = alignment.get_signature([31])  # emission 0.98
-        results.append((alignment.domain, "found active site serine: %s" % (value == "S")))
+        results.append((alignment.domain, f"found active site serine: {value == 'S'}"))
 
     return results
 
@@ -223,7 +223,7 @@ def asp_pksi_dh(record: secmet.Record) -> List[SinglePairing]:
             continue
         value = alignment.get_signature([5, 39, 44])
         found = value == "HGP"  # emissions 1., 0.62, 097
-        results.append((alignment.domain, "catalytic triad H,G,P found: %s" % found))
+        results.append((alignment.domain, f"catalytic triad H,G,P found: {found}"))
 
     return results
 
@@ -255,7 +255,7 @@ def asp_pksi_kr(record: secmet.Record) -> List[SinglePairing]:
             continue
         value = alignment.get_signature([149, 162, 166])
         found = value == "SYN"
-        results.append((alignment.domain, "catalytic triad S,Y,N found: %s" % found))
+        results.append((alignment.domain, f"catalytic triad S,Y,N found: {found}"))
 
     return results
 
@@ -282,7 +282,7 @@ def asp_thioesterase(record: secmet.Record) -> List[SinglePairing]:
             continue
         value = alignment.get_signature([81])
         found = value == "S"
-        results.append((alignment.domain, "active site serine present: %s" % found))
+        results.append((alignment.domain, f"active site serine present: {found}"))
 
     return results
 
@@ -379,5 +379,5 @@ def asp_p450_oxy(record: secmet.Record) -> List[SinglePairing]:
             continue
         value = alignment.get_signature([407])
         found = value == "C"
-        results.append((alignment.domain, "active site cysteine present: %s" % found))
+        results.append((alignment.domain, f"active site cysteine present: {found}"))
     return results

--- a/antismash/modules/active_site_finder/common.py
+++ b/antismash/modules/active_site_finder/common.py
@@ -40,7 +40,7 @@ class ActiveSiteAnalysis:
         self.target_domain = str(target_domain)
         self.database = path.get_full_path(__file__, 'data', database)
         if not os.path.exists(self.database):
-            raise ValueError("No database file located for: %s" % self.database)
+            raise ValueError(f"No database file located for: {self.database!r}")
         self.positions = list(map(int, positions))
         self.expected_values = list(map(str, expected_values))
         if len(expected_values) != len(positions):
@@ -54,7 +54,7 @@ class ActiveSiteAnalysis:
         self.domains_of_interest: List[secmet.features.Domain] = []
         for candidate in candidates:
             if not isinstance(candidate, secmet.features.Domain):
-                raise TypeError("Candidates must be Domains, not %s" % type(candidate))
+                raise TypeError(f"Candidates must be Domains, not {type(candidate)}")
             if candidate.domain == self.target_domain:
                 self.domains_of_interest.append(candidate)
 

--- a/antismash/modules/active_site_finder/test/integration_analysis.py
+++ b/antismash/modules/active_site_finder/test/integration_analysis.py
@@ -18,8 +18,8 @@ class TestAnalyses(unittest.TestCase):
     def setUp(self):
         # skipping clusterhmmer and the p450 potential hits for speed
         self.options = build_config(["--asf", "--minimal", "--enable-html"],
-                            isolated=True,
-                            modules=antismash.get_all_modules())
+                                    isolated=True,
+                                    modules=antismash.get_all_modules())
 
     def test_regeneration(self):
         datafile = helpers.get_path_to_balhymicin_genbank()

--- a/antismash/modules/active_site_finder/test/test_analysis.py
+++ b/antismash/modules/active_site_finder/test/test_analysis.py
@@ -193,7 +193,7 @@ class TestSynthetic(unittest.TestCase):
         for values in ["GGP", "HPP", "HGG", "NNN", "HGP"]:
             mocked_get.return_value = [DummyAlignment(values, {5: values[0], 39: values[1], 44: values[2]})]
             pairings = analysis.asp_pksi_dh(self.record)
-            assert pairings == [(values, "catalytic triad H,G,P found: %s" % (values == "HGP"))]
+            assert pairings == [(values, f"catalytic triad H,G,P found: {values == 'HGP'}")]
         # and an inconclusive
         mocked_match.return_value = False
         # values here don't matter
@@ -208,7 +208,7 @@ class TestSynthetic(unittest.TestCase):
         for char in string.ascii_uppercase:
             mocked_get.return_value = [DummyAlignment(char, {81: char})]
             pairings = analysis.asp_thioesterase(self.record)
-            assert pairings == [(char, "active site serine present: %s" % (char == "S"))]
+            assert pairings == [(char, f"active site serine present: {char == 'S'}")]
         # and an inconclusive
         mocked_match.return_value = False
         # values here don't matter
@@ -261,7 +261,7 @@ class TestSynthetic(unittest.TestCase):
         for char in string.ascii_uppercase:
             mocked_get.return_value = [DummyAlignment(char, {407: char})]
             pairings = analysis.asp_p450_oxy(self.record)
-            assert pairings == [(char, "active site cysteine present: %s" % (char == "C"))]
+            assert pairings == [(char, f"active site cysteine present: {char == 'C'}")]
         # and an inconclusive
         mocked_match.return_value = False
         # values here don't matter

--- a/antismash/modules/active_site_finder/test/test_analysis.py
+++ b/antismash/modules/active_site_finder/test/test_analysis.py
@@ -19,7 +19,7 @@ from antismash.modules.active_site_finder import analysis
 
 
 def parse_hmmpfam_results(filename):
-    with open(path.get_full_path(__file__, 'data', filename)) as handle:
+    with open(path.get_full_path(__file__, 'data', filename), encoding="utf-8") as handle:
         return list(SearchIO.parse(handle, "hmmer2-text"))
 
 

--- a/antismash/modules/active_site_finder/test/test_common.py
+++ b/antismash/modules/active_site_finder/test/test_common.py
@@ -94,7 +94,8 @@ class TestAnalysisCore(unittest.TestCase):
             ActiveSiteAnalysis("not-p450", ("not a Domain",), "PKSI-KR.hmm2", [5, 6], ["C", "S"])
 
     def test_alignment_generation(self):
-        pregenerated = list(SearchIO.parse(open(path.get_full_path(__file__, 'data', 'KS_N.output')),
+        pregenerated = list(SearchIO.parse(open(path.get_full_path(__file__, 'data', 'KS_N.output'),
+                                                encoding="utf-8"),
                                            "hmmer2-text"))
         domains = self.generate_domains()
         analysis = ActiveSiteAnalysis("PKS_KS", domains, "PKSI-KS_N.hmm2",
@@ -106,7 +107,8 @@ class TestAnalysisCore(unittest.TestCase):
         assert [align.domain for align in alignments[:4]] == domains[:4]
 
     def test_alignment_generation_no_hits(self):
-        no_hits = list(SearchIO.parse(open(path.get_full_path(__file__, 'data', 'no_hits.output')),
+        no_hits = list(SearchIO.parse(open(path.get_full_path(__file__, 'data', 'no_hits.output'),
+                                           encoding="utf-8"),
                                       "hmmer2-text"))
         for result in no_hits:
             assert not result.hsps, "hits shouldn't exist"

--- a/antismash/modules/cluster_compare/__init__.py
+++ b/antismash/modules/cluster_compare/__init__.py
@@ -75,11 +75,11 @@ def check_options(options: ConfigType) -> List[str]:
             a list of strings describing any errors, if they exist
     """
     errors = []
-    with open(path.get_full_path(__file__, "data", "schema.json")) as handle:
+    with open(path.get_full_path(__file__, "data", "schema.json"), encoding="utf-8") as handle:
         schema = json.load(handle)
     for db in options.cc_custom_dbs:
         try:
-            with open(db) as handle:
+            with open(db, encoding="utf-8") as handle:
                 setup = json.load(handle)
                 try:
                     jsonschema.validate(instance=setup, schema=schema)

--- a/antismash/modules/cluster_compare/__init__.py
+++ b/antismash/modules/cluster_compare/__init__.py
@@ -130,7 +130,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
     failure_messages = []
     for binary_name in ["diamond"]:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate file: %r" % binary_name)
+            failure_messages.append(f"Failed to locate file: {binary_name!r}")
 
     if "diamond" not in get_config().executables:
         failure_messages.append("cannot check cluster_compare databases, no diamond executable present")

--- a/antismash/modules/cluster_compare/analysis.py
+++ b/antismash/modules/cluster_compare/analysis.py
@@ -210,7 +210,8 @@ def score_as_region(label: str, region: Region, hits_by_reference: HitsByReferen
     """
     local_hits = filter_by_query_area(region, hits_by_reference)
     ranking = score_query_area(region, local_hits, query_components[region], mode)[:MAX_RESULTS]
-    region_ranking = sorted(((scorer.reference, scorer.final_score) for scorer in ranking), key=lambda x: x[1], reverse=True)
+    region_ranking = sorted(((scorer.reference, scorer.final_score) for scorer in ranking),
+                            key=lambda x: x[1], reverse=True)
     regions = {region for region, _ in region_ranking}
     best_hits = {ref: trim_to_best_hit(hits) for ref, hits in local_hits.items() if ref in regions}
     return VariantResults(label + str(mode), region_ranking, RegionToRegionScores(ranking), best_hits)

--- a/antismash/modules/cluster_compare/data_structures.py
+++ b/antismash/modules/cluster_compare/data_structures.py
@@ -143,7 +143,7 @@ class ReferenceCDS:
         }
 
     def __str__(self) -> str:
-        return "ReferenceCDS(%s, %s)" % (self.name, self.location)
+        return f"ReferenceCDS({self.name}, {self.location})"
 
     def get_minimal_json(self) -> Dict[str, Any]:
         """ Returns the minimum information required as JSON for the purposes of
@@ -188,7 +188,7 @@ class ReferenceArea:
     def set_component_data(self, data: Components) -> None:
         """ Sets the component data of the area to avoid (re)calculating when unnecessary """
         if not isinstance(data, Components):
-            raise TypeError("component data expected to be 'Components', but was '%s'" % type(data))
+            raise TypeError(f"component data expected to be 'Components', but was '{type(data)}'")
         self._components = data
 
     def to_json(self) -> Dict[str, Any]:
@@ -227,7 +227,7 @@ class ReferenceProtocluster(ReferenceArea):
         }
 
     def __str__(self) -> str:
-        return "ReferenceProtocluster(%s, %s, %s...)" % (self.start, self.end, self.product)
+        return f"ReferenceProtocluster({self.start}, {self.end}, {self.product})"
 
     def __repr__(self) -> str:
         return str(self)
@@ -270,7 +270,7 @@ class ReferenceRegion(ReferenceArea):
         return result
 
     def __repr__(self) -> str:
-        return "ReferenceRegion(%s, %s, %s, %s...)" % (self.accession, self.start, self.end, self.products)
+        return f"ReferenceRegion({self.accession}, {self.start}, {self.end}, {self.products})"
 
 
 class ReferenceRecord:
@@ -323,7 +323,7 @@ class ReferenceScorer:
         self.accession = reference.accession
         self.hits_by_gene = best_hits
         for hit in best_hits.values():
-            assert hit.reference_record == reference.accession, "%s != %s" % (hit.reference_record, reference.accession)
+            assert hit.reference_record == reference.accession, f"{hit.reference_record} != {reference.accession}"
         self.identity = identity
         self.order = order
         self.component = component
@@ -372,25 +372,19 @@ class ReferenceScorer:
         return str(self)
 
     def __str__(self) -> str:
-        return "ReferenceScorer(%s: raw_id=%.2f, order=%s, comp=%s)" % (
-            self.accession,
-            self.identity,
-            ("%.2f" % self.order) if len(self.hits_by_gene) > 1 else "N/A",
-            ("%.2f" % self.component) if self.component is not None else "N/A",
-        )
+        order = f"{self.order:.2f}" if len(self.hits_by_gene) > 1 else "N/A"
+        components = f"{self.component:.2f}" if self.component is not None else "N/A"
+        return f"ReferenceScorer({self.accession}: raw_id={self.identity:.2f}, order={order}, comp={components})"
 
     def table_string(self) -> str:
         """ Generates a string suitable for a tooltip of a particular result """
-        return "%.2f (id:%.2f, order:%s, components:%s)" % (
-            self.final_score,
-            self.identity,
-            ("%.2f" % self.order) if len(self.hits_by_gene) > 1 else "N/A",
-            ("%.2f" % self.component) if self.component is not None else "N/A",
-        )
+        order = f"{self.order:.2f}" if len(self.hits_by_gene) > 1 else "N/A"
+        components = f"{self.component:.2f}" if self.component is not None else "N/A"
+        return f"{self.final_score:.2f} (id:{self.identity:.2f}, order:{order}, components:{components})"
 
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, ReferenceScorer):
-            raise TypeError("cannot compare ReferenceScorer to %s" % type(other))
+            raise TypeError(f"cannot compare ReferenceScorer to {type(other)}")
         return self.final_score < other.final_score
 
 

--- a/antismash/modules/cluster_compare/data_structures.py
+++ b/antismash/modules/cluster_compare/data_structures.py
@@ -63,7 +63,7 @@ class DBConfig:
         """ Constructs a DBConfig instance from a file containing JSON.
             Requires the current config database directory to handle replacments.
         """
-        with open(filename) as handle:
+        with open(filename, encoding="utf-8") as handle:
             raw = json.load(handle)
         return cls.from_json(raw, database_dir)
 
@@ -306,7 +306,7 @@ def load_data(filename: str) -> Dict[str, ReferenceRecord]:
 
     """
     if filename not in _LOADED_DATA:
-        with open(filename) as handle:
+        with open(filename, encoding="utf-8") as handle:
             raw = json.loads(handle.read())
         result = {}
         for accession, record in raw.items():

--- a/antismash/modules/cluster_compare/test/integration_cc.py
+++ b/antismash/modules/cluster_compare/test/integration_cc.py
@@ -30,7 +30,7 @@ class TestFull(unittest.TestCase):
     def test_result_conversion(self):
         update_config({"cc_mibig": True})
         nisin = Record.from_genbank(helpers.get_path_to_nisin_with_detection())[0]
-        with open(path.get_full_path(__file__, "data", "nisin.out")) as handle:
+        with open(path.get_full_path(__file__, "data", "nisin.out"), encoding="utf-8") as handle:
             trimmed_output = handle.read()
         with patch.object(subprocessing, "run_diamond_search", return_value=trimmed_output):
             results = cluster_compare.run_on_record(nisin, None, self.options)

--- a/antismash/modules/cluster_compare/test/test_order.py
+++ b/antismash/modules/cluster_compare/test/test_order.py
@@ -62,7 +62,8 @@ class TestOrdering(unittest.TestCase):
             "4": generate_hit(self.cdses[2], "4"),
         }
         segments = self.find(hits)
-        assert score(segments, len(self.cdses), len(self.refs)) == ordering.calculate_order_score(self.cdses, hits, self.refs)
+        expected = ordering.calculate_order_score(self.cdses, hits, self.refs)
+        assert score(segments, len(self.cdses), len(self.refs)) == expected
 
     def test_empty(self):
         assert ordering.calculate_order_score([], {}, None) == 0.
@@ -78,7 +79,7 @@ class TestSegmentScoring(unittest.TestCase):
     def test_single(self):
         for segments in [[[(1, 2, True)]],
                          [[(1, 2, True), (2, 3, True)]],
-                        ]:
+                         ]:
             assert score(segments, len(segments[0]), len(segments[0])) == 1.
 
     def test_comparitive(self):

--- a/antismash/modules/clusterblast/__init__.py
+++ b/antismash/modules/clusterblast/__init__.py
@@ -129,7 +129,7 @@ def prepare_data(logging_only: bool = False) -> List[str]:
     db_file = os.path.join(clusterblastdir, "proteins.dmnd")
 
     # check the DBv3 region info exists instead of single cluster numbers
-    with open(protein_seqs) as handle:
+    with open(protein_seqs, encoding="utf-8") as handle:
         sample = handle.readline()
     if "-" not in sample.split("|", 3)[1]:
         failure_messages.append("clusterblast database out of date, update with download-databases")

--- a/antismash/modules/clusterblast/__init__.py
+++ b/antismash/modules/clusterblast/__init__.py
@@ -54,7 +54,7 @@ def get_arguments() -> ModuleArgs:
                     type=int,
                     default=10,
                     help="Number of clusters from ClusterBlast to display,"
-                         " cannot be greater than %d. (default: %%(default)s)" % get_result_limit())
+                         f" cannot be greater than {get_result_limit()}. (default: %(default)s)")
     args.add_option('min-homology-scale',
                     dest='min_homology_scale',
                     metavar="LIMIT",
@@ -76,8 +76,7 @@ def is_enabled(options: ConfigType) -> bool:
 def check_options(options: ConfigType) -> List[str]:
     """ Checks that extra options are valid """
     if options.cb_nclusters > get_result_limit():
-        return ["nclusters of %d is over limit of %d" % (
-                    options.cb_nclusters, get_result_limit())]
+        return [f"nclusters of {options.cb_nclusters} is over limit of {get_result_limit()}"]
     return []
 
 
@@ -101,7 +100,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
     failure_messages = []
     for binary_name in _required_binaries:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate file: %r" % binary_name)
+            failure_messages.append(f"Failed to locate file: {binary_name!r}")
 
     if "diamond" not in get_config().executables:
         failure_messages.append("cannot check clusterblast databases, no diamond executable present")

--- a/antismash/modules/clusterblast/core.py
+++ b/antismash/modules/clusterblast/core.py
@@ -59,7 +59,7 @@ def run_blast(query: str, database: str) -> str:
                "-out", out_file]
     res = subprocessing.execute(command)
     if not res.successful():
-        raise RuntimeError("blastp run failed: %s..." % res.stderr[-200:])
+        raise RuntimeError(f"blastp run failed: ...{res.stderr[-200:]!r}")
     return out_file
 
 
@@ -209,8 +209,8 @@ def create_blast_inputs(region: secmet.Region) -> Tuple[List[str], List[str]]:
             strand = "+"
         else:
             strand = "-"
-        fullname = "|".join(["input", "c%d" % region.get_region_number(),
-                             "%d-%d" % (cds.location.start, cds.location.end),
+        fullname = "|".join(["input", f"c{region.get_region_number()}",
+                             f"{cds.location.start:d}-{cds.location.end:d}",
                              strand, cds.get_name(), cds.product])
         names.append(fullname)
         seqs.append(cds.translation)
@@ -285,7 +285,7 @@ def parse_subject(line_parts: List[str], seqlengths: Dict[str, int],
         locustag = subject_parts[6]
     else:
         locustag = ""
-    genecluster = "{}_{}".format(subject_parts[0], subject_parts[1])
+    genecluster = f"{subject_parts[0]}_{subject_parts[1]}"
     start, end = subject_parts[2].split("-")[:2]
     strand = subject_parts[3]
     annotation = subject_parts[5]
@@ -516,7 +516,7 @@ def write_raw_clusterblastoutput(output_dir: str, blast_output: str, prefix: str
         Returns:
             the name of the file written
     """
-    filename = "%soutput.txt" % prefix
+    filename = f"{prefix}output.txt"
     with open(os.path.join(output_dir, filename), "w") as handle:
         handle.write(blast_output)
     return filename

--- a/antismash/modules/clusterblast/core.py
+++ b/antismash/modules/clusterblast/core.py
@@ -12,7 +12,9 @@ from typing import Dict, Iterable, List, Set, Sequence, Tuple
 from helperlibs.wrappers.io import TemporaryDirectory
 
 from antismash.common import path, subprocessing, fasta, secmet
-from antismash.common.subprocessing.diamond import check_diamond_files as check_clusterblast_files
+from antismash.common.subprocessing.diamond import \
+    check_diamond_files as check_clusterblast_files  # used by other components # pylint: disable=unused-import
+
 from antismash.common.subprocessing.blast import run_makeblastdb as make_blastdb
 from antismash.config import get_config
 

--- a/antismash/modules/clusterblast/core.py
+++ b/antismash/modules/clusterblast/core.py
@@ -112,7 +112,7 @@ def load_reference_clusters(searchtype: str) -> Dict[str, ReferenceCluster]:
         data_dir = os.path.join(kcb_root, version)
 
     reference_cluster_file = os.path.join(data_dir, "clusters.txt")
-    with open(reference_cluster_file, "r") as handle:
+    with open(reference_cluster_file, "r", encoding="utf-8") as handle:
         filetext = handle.read()
     lines = [line for line in filetext.splitlines() if "\t" in line]
     clusters = {}
@@ -156,7 +156,7 @@ def load_reference_proteins(searchtype: str) -> Dict[str, Protein]:
 
     protein_file = os.path.join(data_dir, "proteins.fasta")
     proteins = {}
-    with open(protein_file, 'r') as handle:
+    with open(protein_file, "r", encoding="utf-8") as handle:
         for line in handle:
             line = line.rstrip("\n")
             if not line or line[0] != ">":
@@ -230,7 +230,7 @@ def run_internal_blastsearch(query_filename: str) -> str:
     """
     make_blastdb(query_filename, "internal_input.fasta")
     run_blast("internal_input.fasta", "internal_input.fasta")
-    with open("internal_input.out", "r") as handle:
+    with open("internal_input.out", "r", encoding="utf-8") as handle:
         blastoutput = handle.read()
     return blastoutput
 
@@ -517,7 +517,7 @@ def write_raw_clusterblastoutput(output_dir: str, blast_output: str, prefix: str
             the name of the file written
     """
     filename = f"{prefix}output.txt"
-    with open(os.path.join(output_dir, filename), "w") as handle:
+    with open(os.path.join(output_dir, filename), "w", encoding="utf-8") as handle:
         handle.write(blast_output)
     return filename
 

--- a/antismash/modules/clusterblast/data_structures.py
+++ b/antismash/modules/clusterblast/data_structures.py
@@ -26,7 +26,7 @@ class ReferenceCluster:
 
     def get_name(self) -> str:
         """ Returns the name of the cluster, including cluster number """
-        return "%s_%s" % (self.accession, self.cluster_label)
+        return f"{self.accession}_{self.cluster_label}"
 
 
 class Protein:
@@ -53,13 +53,12 @@ class Protein:
 
     def __str__(self) -> str:
         if len(self.location.split("-")) != 2:
-            raise ValueError("Invalid location in Protein: %s" % self.location)
+            raise ValueError(f"Invalid location in Protein: {self.location}")
         tag = self.locus_tag
         if tag == "no_locus_tag":
             tag = self.name
         locations = self.location.replace("-", "\t")
-        return "{}\t{}\t{}\t{}\t{}\n".format(tag, self.name, locations,
-                                             self.strand, self.annotations)
+        return f"{tag}\t{self.name}\t{locations}\t{self.strand}\t{self.annotations}\n"
 
 
 class Subject:

--- a/antismash/modules/clusterblast/html_output.py
+++ b/antismash/modules/clusterblast/html_output.py
@@ -62,6 +62,6 @@ def generate_div(region_layer: RegionLayer, record_layer: RecordLayer,
     """
     if additional is None:
         additional = {}
-    template = FileTemplate(path.get_full_path(__file__, "templates", "%s.html" % search_type))
+    template = FileTemplate(path.get_full_path(__file__, "templates", f"{search_type}.html"))
     return template.render(record=record_layer, region=region_layer, options=options_layer,
                            tooltip=tooltip, **additional)

--- a/antismash/modules/clusterblast/known.py
+++ b/antismash/modules/clusterblast/known.py
@@ -53,7 +53,7 @@ def check_known_prereqs(options: ConfigType) -> List[str]:
     failure_messages = []
     for binary_name in ['blastp', 'makeblastdb', 'diamond']:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate file: %r" % binary_name)
+            failure_messages.append(f"Failed to locate file: {binary_name!r})")
 
     return failure_messages
 

--- a/antismash/modules/clusterblast/results.py
+++ b/antismash/modules/clusterblast/results.py
@@ -162,13 +162,13 @@ class RegionResult:
         """
         region_num = self.region.get_region_number()
         record_index = self.region.parent_record.record_index
-        filename = "{}_r{}c{}_all.svg".format(prefix, record_index, region_num)
+        filename = f"{prefix}_r{record_index}c{region_num}_all.svg"
         with open(os.path.join(svg_dir, filename), "w") as handle:
             handle.write(self.svg_builder.get_overview_contents(width=800, height=50 + 50 * len(self.svg_builder.hits)))
 
         files = []
         for i in range(len(self.svg_builder.hits)):
-            filename = "{}_r{}c{}_{}.svg".format(prefix, record_index, region_num, i + 1)  # 1-index
+            filename = f"{prefix}_r{record_index}c{region_num}_{i + 1}.svg"  # 1-indexed
             with open(os.path.join(svg_dir, filename), "w") as handle:
                 handle.write(self.svg_builder.get_pairing_contents(i, width=800, height=230))
             files.append(filename)
@@ -261,8 +261,7 @@ class GeneralResults(ModuleResults):
         # so if there's a mismatch of version, but it's these two, let them through
         special_case = current == 2 and json["schema_version"] == 1
         if json["schema_version"] != current and not special_case:
-            raise ValueError("Incompatible results schema version, expected %d"
-                             % GeneralResults.schema_version)
+            raise ValueError(f"Incompatible results schema version, expected {GeneralResults.schema_version}")
         assert record.id == json["record_id"]
         data_version = json.get("data_version")
         result = GeneralResults(json["record_id"], search_type=json["search_type"],
@@ -309,8 +308,7 @@ class ClusterBlastResults(ModuleResults):
     @staticmethod
     def from_json(json: Dict[str, Any], record: Record) -> "ClusterBlastResults":
         if json["schema_version"] != ClusterBlastResults.schema_version:
-            raise ValueError("Incompatible results schema version, expected %d"
-                             % ClusterBlastResults.schema_version)
+            raise ValueError(f"Incompatible results schema version, expected {ClusterBlastResults.schema_version}")
         results = ClusterBlastResults(json["record_id"])
         for attr in ["general", "subcluster", "knowncluster"]:
             if attr in json:
@@ -349,7 +347,7 @@ def write_clusterblast_output(options: ConfigType, record: Record,
     assert isinstance(proteins, dict)
 
     region_number = cluster_result.region.get_region_number()
-    filename = "%s_c%d.txt" % (record.id, region_number)
+    filename = f"{record.id}_c{region_number}.txt"
 
     with changed_directory(_get_output_dir(options, searchtype)):
         _write_output(filename, record, cluster_result, proteins)
@@ -373,18 +371,18 @@ def _write_output(filename: str, record: Record, cluster_result: RegionResult,
     out_file.write("\n\nSignificant hits: \n")
     for i, cluster_and_score in enumerate(ranking):
         cluster = cluster_and_score[0]
-        out_file.write("{}. {}\t{}\n".format(i + 1, cluster.accession, cluster.description))
+        out_file.write(f"{i + 1}. {cluster.accession}\t{cluster.description}\n")
 
     out_file.write("\n\nDetails:")
     for i, cluster_and_score in enumerate(ranking):
         cluster, score = cluster_and_score
         nrhits = score.hits
         out_file.write("\n\n>>\n")
-        out_file.write("{}. {}\n".format(i + 1, cluster.accession))
-        out_file.write("Source: {}\n".format(cluster.description))
-        out_file.write("Type: {}\n".format(cluster.cluster_type))
-        out_file.write("Number of proteins with BLAST hits to this cluster: %d\n" % nrhits)
-        out_file.write("Cumulative BLAST score: %d\n\n" % score.blast_score)
+        out_file.write(f"{i + 1}. {cluster.accession}\n")
+        out_file.write(f"Source: {cluster.description}\n")
+        out_file.write(f"Type: {cluster.cluster_type}\n")
+        out_file.write(f"Number of proteins with BLAST hits to this cluster: {nrhits}\n")
+        out_file.write(f"Cumulative BLAST score: {score.blast_score}\n\n")
         out_file.write("Table of genes, locations, strands and annotations of subject cluster:\n")
         for protein_name in cluster.proteins:
             protein = proteins.get(protein_name)
@@ -394,7 +392,7 @@ def _write_output(filename: str, record: Record, cluster_result: RegionResult,
                        " %identity, blast score, %coverage, e-value):\n")
         if score.scored_pairings:
             for query, subject in score.scored_pairings:
-                out_file.write("{}\t{}\n".format(query.id, subject.get_table_string()))
+                out_file.write(f"{query.id}\t{subject.get_table_string()}\n")
         else:
             out_file.write("data not found\n")
         out_file.write("\n")
@@ -408,5 +406,5 @@ def _get_output_dir(options: ConfigType, searchtype: str) -> str:
     if not os.path.exists(output_dir):
         os.mkdir(output_dir)
     if not os.path.isdir(output_dir):
-        raise RuntimeError("%s exists as a file, but required as a directory" % output_dir)
+        raise RuntimeError(f"{output_dir} exists as a file, but must be a directory")
     return output_dir

--- a/antismash/modules/clusterblast/results.py
+++ b/antismash/modules/clusterblast/results.py
@@ -163,13 +163,13 @@ class RegionResult:
         region_num = self.region.get_region_number()
         record_index = self.region.parent_record.record_index
         filename = f"{prefix}_r{record_index}c{region_num}_all.svg"
-        with open(os.path.join(svg_dir, filename), "w") as handle:
+        with open(os.path.join(svg_dir, filename), "w", encoding="utf-8") as handle:
             handle.write(self.svg_builder.get_overview_contents(width=800, height=50 + 50 * len(self.svg_builder.hits)))
 
         files = []
         for i in range(len(self.svg_builder.hits)):
             filename = f"{prefix}_r{record_index}c{region_num}_{i + 1}.svg"  # 1-indexed
-            with open(os.path.join(svg_dir, filename), "w") as handle:
+            with open(os.path.join(svg_dir, filename), "w", encoding="utf-8") as handle:
                 handle.write(self.svg_builder.get_pairing_contents(i, width=800, height=230))
             files.append(filename)
         return files
@@ -358,7 +358,7 @@ def _write_output(filename: str, record: Record, cluster_result: RegionResult,
     ranking = cluster_result.ranking
     # Output for each hit: table of genes and locations of input cluster,
     # table of genes and locations of hit cluster, table of hits between the clusters
-    out_file = open(filename, "w")  # pylint: disable=consider-using-with
+    out_file = open(filename, "w", encoding="utf-8")  # pylint: disable=consider-using-with
     out_file.write("ClusterBlast scores for " + record.id + "\n")
     out_file.write("\nTable of genes, locations, strands and annotations of query cluster:\n")
     for i, cds in enumerate(cluster_result.region.cds_children):

--- a/antismash/modules/clusterblast/results.py
+++ b/antismash/modules/clusterblast/results.py
@@ -64,7 +64,7 @@ class RegionResult:
         if prefix != "subclusterblast":
             record_prefix = (region.parent_record.original_id or region.parent_record.id).split(".", 1)[0]
             display_ranking = list(filter(lambda pair: pair[0].accession != record_prefix, display_ranking))
-            if len(display_ranking) < display_limit and len(self.ranking) - 1 > display_limit:
+            if len(display_ranking) < display_limit < len(self.ranking) - 1:
                 display_ranking.append(self.ranking[display_limit])
         assert len(display_ranking) <= display_limit
         self.svg_builder = ClusterSVGBuilder(region, display_ranking, reference_proteins, prefix)

--- a/antismash/modules/clusterblast/sub.py
+++ b/antismash/modules/clusterblast/sub.py
@@ -50,11 +50,11 @@ def check_sub_prereqs(options: ConfigType) -> List[str]:
     failure_messages = []
     for binary_name in _required_binaries:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate file: %r" % binary_name)
+            failure_messages.append(f"Failed to locate file: {binary_name!r}")
 
     for file_name in _required_files:
         if path.locate_file(_get_datafile_path(file_name)) is None:
-            failure_messages.append("Failed to locate file: %r" % file_name)
+            failure_messages.append(f"Failed to locate file: {file_name!r}")
 
     return failure_messages
 
@@ -89,7 +89,7 @@ def _run_blast_helper(database: str, index: int) -> str:
         Returns:
             the name of the output file created by run_blast()
     """
-    return run_blast("input%d.fasta" % index, database)
+    return run_blast(f"input{index}.fasta", database)
 
 
 def run_clusterblast_processes(options: ConfigType) -> None:
@@ -129,7 +129,7 @@ def read_clusterblast_output(options: ConfigType) -> str:
 
     blastoutput = []
     for i in range(options.cpus):
-        with open("input%d.out" % i, "r") as handle:
+        with open(f"input{i}.out", "r", encoding="utf-8") as handle:
             output = handle.read()
         blastoutput.append(output)
     return "".join(blastoutput)

--- a/antismash/modules/clusterblast/sub.py
+++ b/antismash/modules/clusterblast/sub.py
@@ -124,7 +124,7 @@ def read_clusterblast_output(options: ConfigType) -> str:
             a string containing all blast run output
     """
     if options.cpus == 1:
-        with open("input.out") as handle:
+        with open("input.out", encoding="utf-8") as handle:
             return handle.read()
 
     blastoutput = []

--- a/antismash/modules/clusterblast/svg_builder.py
+++ b/antismash/modules/clusterblast/svg_builder.py
@@ -596,14 +596,14 @@ class ClusterSVGBuilder:
         scaling = (width - 20) / self.max_length  # -20 for margins
         offset = (self.max_length - len(self.query_cluster)) // 2
         for group in self.query_cluster.get_svg_groups(h_offset=offset, scaling=scaling,
-                                             colours=self.colour_lookup, overview=True,
-                                             prefix=self.prefix):
+                                                       colours=self.colour_lookup, overview=True,
+                                                       prefix=self.prefix):
             svg.addElement(group)
         for index, cluster in enumerate(self.hits):
             for group in cluster.get_svg_groups(v_offset=50 * (index + 1),
-                             h_offset=(self.max_length - len(cluster)) // 2,
-                             scaling=scaling, colours=self.colour_lookup, overview=True,
-                             prefix=self.prefix):
+                                                h_offset=(self.max_length - len(cluster)) // 2,
+                                                scaling=scaling, colours=self.colour_lookup, overview=True,
+                                                prefix=self.prefix):
                 svg.addElement(group)
         return svg.getXML()
 
@@ -626,7 +626,7 @@ class ClusterSVGBuilder:
         scaling = (width - 20) / max_length
         for i, cluster in enumerate([self.query_cluster, self.hits[index]]):
             for group in cluster.get_svg_groups(v_offset=50 * i,
-                    h_offset=(max_length - len(cluster)) // 2,
-                    scaling=scaling, colours=self.colour_lookup):
+                                                h_offset=(max_length - len(cluster)) // 2,
+                                                scaling=scaling, colours=self.colour_lookup):
                 svg.addElement(group)
         return svg.getXML()

--- a/antismash/modules/clusterblast/test/integration_clusterblast.py
+++ b/antismash/modules/clusterblast/test/integration_clusterblast.py
@@ -251,7 +251,7 @@ class TestDatabaseValidity(unittest.TestCase):
         proteins = core.load_reference_proteins(searchtype)
         for cluster in clusters.values():
             for protein in cluster.tags:
-                assert protein in proteins, "missing: %s" % protein
+                assert protein in proteins, f"missing: {protein}"
 
     def test_general(self):
         self._check_proteins_match_clusters("clusterblast")

--- a/antismash/modules/clusterblast/test/integration_clusterblast.py
+++ b/antismash/modules/clusterblast/test/integration_clusterblast.py
@@ -21,7 +21,7 @@ from antismash.modules import clusterblast
 from antismash.modules.clusterblast import core, known
 
 
-def known_dir(filename, *args):
+def known_dir(filename, *_args):
     return path.get_full_path(__file__, "data", "known", filename)
 
 

--- a/antismash/modules/clusterblast/test/test_clusterblast.py
+++ b/antismash/modules/clusterblast/test/test_clusterblast.py
@@ -38,7 +38,7 @@ class TestBlastParsing(unittest.TestCase):
                 return core.parse_subject(subject_line, seqlengths, seq_record)
 
     def read_sample_data(self, filename="data/diamond_output_sample.txt"):
-        with open(path.get_full_path(__file__, filename), "r") as handle:
+        with open(path.get_full_path(__file__, filename), "r", encoding="utf-8") as handle:
             return handle.read()
 
     def file_data_to_lists(self, data):
@@ -439,7 +439,7 @@ class TestInputGeneration(unittest.TestCase):
             assert files == ["test.fasta"]
             assert os.path.exists("test.fasta")
             expected = "".join(f">L{i}\nS{i}\n" for i in range(len(self.regions)*3))
-            with open("test.fasta") as handle:
+            with open("test.fasta", encoding="utf-8") as handle:
                 assert handle.read() == expected
 
     def test_single_partition(self):
@@ -449,7 +449,7 @@ class TestInputGeneration(unittest.TestCase):
             assert files == ["test.fasta"]
             assert os.path.exists("test.fasta")
             expected = "".join(f">L{i}\nS{i}\n" for i in range(len(self.regions)*3))
-            with open("test.fasta") as handle:
+            with open("test.fasta", encoding="utf-8") as handle:
                 assert handle.read() == expected
 
     def test_multiple_files(self):
@@ -462,7 +462,7 @@ class TestInputGeneration(unittest.TestCase):
                 assert files == [f"test{i}.fasta" for i in range(partitions)]
                 for index in range(partitions):
                     assert os.path.exists(files[index])
-                    with open(files[index]) as handle:
+                    with open(files[index], encoding="utf-8") as handle:
                         contents = handle.read()
                     assert contents.count(">") == chunk_size
                     positions = (i + index * chunk_size for i in range(chunk_size))

--- a/antismash/modules/clusterblast/test/test_clusterblast.py
+++ b/antismash/modules/clusterblast/test/test_clusterblast.py
@@ -410,8 +410,8 @@ class TestInputGeneration(unittest.TestCase):
         for _ in cluster.cds_children:
             index = self.index
             self.index += 1
-            names.append("L%d" % index)
-            seqs.append("S%d" % index)
+            names.append(f"L{index}")
+            seqs.append(f"S{index}")
         return names, seqs
 
     def add_cdses_to_region(self, cdses):
@@ -438,7 +438,7 @@ class TestInputGeneration(unittest.TestCase):
             files = core.write_fastas_with_all_genes(self.regions, "test.fasta")
             assert files == ["test.fasta"]
             assert os.path.exists("test.fasta")
-            expected = "".join(">L{0}\nS{0}\n".format(i) for i in range(len(self.regions)*3))
+            expected = "".join(f">L{i}\nS{i}\n" for i in range(len(self.regions)*3))
             with open("test.fasta") as handle:
                 assert handle.read() == expected
 
@@ -448,7 +448,7 @@ class TestInputGeneration(unittest.TestCase):
             files = core.write_fastas_with_all_genes(self.regions, "test.fasta", partitions=1)
             assert files == ["test.fasta"]
             assert os.path.exists("test.fasta")
-            expected = "".join(">L{0}\nS{0}\n".format(i) for i in range(len(self.regions)*3))
+            expected = "".join(f">L{i}\nS{i}\n" for i in range(len(self.regions)*3))
             with open("test.fasta") as handle:
                 assert handle.read() == expected
 
@@ -459,14 +459,14 @@ class TestInputGeneration(unittest.TestCase):
                 self.index = 0
                 chunk_size = (len(self.regions) * 3) // partitions
                 files = core.write_fastas_with_all_genes(self.regions, "test.fasta", partitions=partitions)
-                assert files == ["test%d.fasta" % i for i in range(partitions)]
+                assert files == [f"test{i}.fasta" for i in range(partitions)]
                 for index in range(partitions):
-                    assert os.path.exists("test%d.fasta" % index)
-                    print(index, chunk_size)
-                    with open("test%d.fasta" % index) as handle:
+                    assert os.path.exists(files[index])
+                    with open(files[index]) as handle:
                         contents = handle.read()
                     assert contents.count(">") == chunk_size
-                    expected = "".join(">L{0}\nS{0}\n".format(i + index * chunk_size) for i in range(chunk_size))
+                    positions = (i + index * chunk_size for i in range(chunk_size))
+                    expected = "".join(f">L{position}\nS{position}\n" for position in positions)
                     assert contents == expected
 
 

--- a/antismash/modules/clusterblast/test/test_clusterblast.py
+++ b/antismash/modules/clusterblast/test/test_clusterblast.py
@@ -106,8 +106,8 @@ class TestBlastParsing(unittest.TestCase):
     def test_parse_all_single_cluster(self, _mocked_record, _mocked_core):
         # single cluster to test the thresholds and content
         def parse_all_wrapper(coverage_threshold, ident_threshold):
-            clusters_by_number, queries_by_number = core.parse_all_clusters(self.sample_data,
-                                Record(), coverage_threshold, ident_threshold)
+            res = core.parse_all_clusters(self.sample_data, Record(), coverage_threshold, ident_threshold)
+            clusters_by_number, queries_by_number = res
             # make sure we only found one cluster number
             self.assertEqual(len(clusters_by_number), 1)
             self.assertEqual(list(clusters_by_number), [24])

--- a/antismash/modules/lanthipeptides/__init__.py
+++ b/antismash/modules/lanthipeptides/__init__.py
@@ -94,9 +94,8 @@ def check_prereqs(options: ConfigType) -> List[str]:
         if binary_name not in options.executables:
             present = False
             if not optional:
-                failure_messages.append("Failed to locate executable for %r" %
-                                        binary_name)
-        slot = '{}_present'.format(binary_name)
+                failure_messages.append(f"Failed to locate executable for {binary_name!r}")
+        slot = f"{binary_name}_present"
         conf = get_config()
         if hasattr(conf, slot):
             setattr(conf, slot, present)

--- a/antismash/modules/lanthipeptides/rodeo.py
+++ b/antismash/modules/lanthipeptides/rodeo.py
@@ -428,7 +428,7 @@ def lanscout(core: str) -> Tuple[int, List[int]]:
     """ define lanthionine ring with a c-terminal Cys """
     lanlower = 2
     lanupper = 6
-    lan = '(?=([T|S].{%d,%d}C))' % (lanlower, lanupper)
+    lan = f"(?=([T|S].{{{lanlower},{lanupper}}}C))"
     sizes = []
     totrings = re.compile(lan, re.I).findall(core)
     for ring in totrings:
@@ -460,7 +460,7 @@ def identify_lanthi_motifs(leader: str, core: str) -> Dict[int, float]:
     motifs_file = path.get_full_path(__file__, "data", "lanthi_motifs_meme.txt")
     with NamedTemporaryFile() as tempfile:
         with open(tempfile.name, "w") as out_file:
-            out_file.write(">query\n%s%s" % (leader, core))
+            out_file.write(f">query\n{leader}{core}")
         fimo_output = subprocessing.run_fimo_simple(motifs_file, tempfile.name)
     fimo_scores = {}
     for line in fimo_output.splitlines():

--- a/antismash/modules/lanthipeptides/rodeo.py
+++ b/antismash/modules/lanthipeptides/rodeo.py
@@ -285,14 +285,14 @@ def acquire_rodeo_heuristics(record: secmet.Record, query: secmet.CDSFeature,
     else:
         tabs.append(0)
     # Leader peptide has > 4 negatively charge motifs
-    if sum([leader.count(aa) for aa in "DE"]) > 4:
+    if sum(leader.count(aa) for aa in "DE") > 4:
         score += 1
         tabs.append(1)
     else:
         tabs.append(0)
     # Leader peptide has net negative charge
     charge_dict = {"E": -1, "D": -1, "K": 1, "R": 1}
-    if sum([charge_dict[aa] for aa in leader if aa in charge_dict]) < 0:
+    if sum(charge_dict.get(aa, 0) for aa in leader) < 0:
         score += 1
         tabs.append(1)
     else:
@@ -396,31 +396,20 @@ def generate_rodeo_svm_csv(leader: str, core: str, previously_gathered_tabs: Lis
         columns.append(fimo_scores.get(i, 0))
     # Number in leader of each amino acid
     columns += [leader.count(aa) for aa in "ARDNCQEGHILKMFPSTWYV"]
+    amino_groups = ["FWY", "DE", "RK", "RKDE", "GAVLMI", "ST"]
     # Number in leader of each amino acid type (aromatic, aliphatic, hydroxyl, basic, acidic)
-    columns.append(sum([leader.count(aa) for aa in "FWY"]))
-    columns.append(sum([leader.count(aa) for aa in "DE"]))
-    columns.append(sum([leader.count(aa) for aa in "RK"]))
-    columns.append(sum([leader.count(aa) for aa in "RKDE"]))
-    columns.append(sum([leader.count(aa) for aa in "GAVLMI"]))
-    columns.append(sum([leader.count(aa) for aa in "ST"]))
+    for group in amino_groups:
+        columns.append(sum(leader.count(aa) for aa in group))
     # Number in core of each amino acid
     columns += [core.count(aa) for aa in "ARDNCQEGHILKMFPSTWYV"]
     # Number in core of each amino acid type (aromatic, aliphatic, hydroxyl, basic, acidic)
-    columns.append(sum([core.count(aa) for aa in "FWY"]))
-    columns.append(sum([core.count(aa) for aa in "DE"]))
-    columns.append(sum([core.count(aa) for aa in "RK"]))
-    columns.append(sum([core.count(aa) for aa in "RKDE"]))
-    columns.append(sum([core.count(aa) for aa in "GAVLMI"]))
-    columns.append(sum([core.count(aa) for aa in "ST"]))
+    for group in amino_groups:
+        columns.append(sum(core.count(aa) for aa in group))
     # Number in entire precursor of each amino acid
     columns += [precursor.count(aa) for aa in "ARDNCQEGHILKMFPSTWYV"]
     # Number in entire precursor of each amino acid type (aromatic, aliphatic, hydroxyl, basic, acidic)
-    columns.append(sum([precursor.count(aa) for aa in "FWY"]))
-    columns.append(sum([precursor.count(aa) for aa in "DE"]))
-    columns.append(sum([precursor.count(aa) for aa in "RK"]))
-    columns.append(sum([precursor.count(aa) for aa in "RKDE"]))
-    columns.append(sum([precursor.count(aa) for aa in "GAVLMI"]))
-    columns.append(sum([precursor.count(aa) for aa in "ST"]))
+    for group in amino_groups:
+        columns.append(sum(precursor.count(aa) for aa in group))
     return columns
 
 

--- a/antismash/modules/lanthipeptides/rodeo.py
+++ b/antismash/modules/lanthipeptides/rodeo.py
@@ -459,7 +459,7 @@ def identify_lanthi_motifs(leader: str, core: str) -> Dict[int, float]:
     """Run FIMO to identify lanthipeptide-specific motifs"""
     motifs_file = path.get_full_path(__file__, "data", "lanthi_motifs_meme.txt")
     with NamedTemporaryFile() as tempfile:
-        with open(tempfile.name, "w") as out_file:
+        with open(tempfile.name, "w", encoding="utf-8") as out_file:
             out_file.write(f">query\n{leader}{core}")
         fimo_output = subprocessing.run_fimo_simple(motifs_file, tempfile.name)
     fimo_scores = {}

--- a/antismash/modules/lanthipeptides/specific_analysis.py
+++ b/antismash/modules/lanthipeptides/specific_analysis.py
@@ -413,7 +413,8 @@ def run_non_biosynthetic_phmms(fasta: str) -> Dict[str, List[str]]:
         Returns:
             a dictionary mapping the hit id to a list of matching query ids
     """
-    with open(path.get_full_path(__file__, "data", "non_biosyn_hmms", "hmmdetails.txt"), "r") as handle:
+    with open(path.get_full_path(__file__, "data", "non_biosyn_hmms", "hmmdetails.txt"),
+              "r", encoding="utf-8") as handle:
         hmmdetails = [line.strip().split("\t") for line in handle if line.count("\t") == 3]
     signature_profiles = [HmmSignature(details[0], details[1], int(details[2]), details[3]) for details in hmmdetails]
     non_biosynthetic_hmms_by_id: Dict[str, List[str]] = defaultdict(list)

--- a/antismash/modules/lanthipeptides/specific_analysis.py
+++ b/antismash/modules/lanthipeptides/specific_analysis.py
@@ -231,8 +231,7 @@ class CleavageSiteHit:  # pylint: disable=too-few-public-methods
         self.lantype = lantype
 
     def __repr__(self) -> str:
-        return ("CleavageSiteHit(end=%s, score=%s, lantype='%s')"
-                % (self.end, self.score, self.lantype))
+        return f"CleavageSiteHit(end={self.end}, score={self.score}, lantype={self.lantype!r})"
 
 
 class Lanthipeptide(PrepeptideBase):
@@ -517,7 +516,7 @@ def determine_precursor_peptide_candidate(record: Record, query: CDSFeature, dom
         return None
 
     # Create FASTA sequence for feature under study
-    lan_a_fasta = ">%s\n%s" % (query.get_name(), query.translation)
+    lan_a_fasta = f">{query.get_name()}\n{query.translation}"
 
     # Run sequence against pHMM; if positive, parse into a vector containing START, END and SCORE
     cleavage_result = run_cleavage_site_phmm(lan_a_fasta, hmmer_profile, THRESH_DICT[lant_class])
@@ -565,7 +564,7 @@ def run_lanthipred(record: Record, query: CDSFeature, lant_class: str,
 
     if lant_class in ("Class-II", "Class-III"):
         profile = path.get_full_path(__file__, hmmer_profiles[lant_class])
-        lan_a_fasta = ">%s\n%s" % (query.get_name(), query_sequence)
+        lan_a_fasta = f">{query.get_name()}\n{query_sequence}"
         cleavage_result = predict_cleavage_site(profile, lan_a_fasta)
 
         if cleavage_result is None:

--- a/antismash/modules/lanthipeptides/test/integration_lanthipeptides.py
+++ b/antismash/modules/lanthipeptides/test/integration_lanthipeptides.py
@@ -38,7 +38,7 @@ class IntegrationLanthipeptides(unittest.TestCase):
 
     def run_lanthi(self, genbank, html_snippet, expected_motifs=1):
         def callback(output_dir):
-            with open(os.path.join(output_dir, "index.html")) as handle:
+            with open(os.path.join(output_dir, "index.html"), encoding="utf-8") as handle:
                 content = handle.read()
                 assert html_snippet in content
 

--- a/antismash/modules/lanthipeptides/test/test_specific_analysis.py
+++ b/antismash/modules/lanthipeptides/test/test_specific_analysis.py
@@ -124,7 +124,7 @@ class TestSpecificAnalysis(unittest.TestCase):
         self.assertAlmostEqual(motif.molecular_weight, 3648.6, places=1)
         self.assertAlmostEqual(motif.monoisotopic_mass, 3646.3, places=1)
         for calc, expected in zip(motif.alternative_weights,
-                        [3666.6, 3684.6, 3702.7, 3720.7, 3738.7, 3756.7, 3774.7]):
+                                  [3666.6, 3684.6, 3702.7, 3720.7, 3738.7, 3756.7, 3774.7]):
             self.assertAlmostEqual(calc, expected, places=1)
         assert motif.core == seq
         assert motif.leader == vec.leader

--- a/antismash/modules/lanthipeptides/test/test_specific_analysis.py
+++ b/antismash/modules/lanthipeptides/test/test_specific_analysis.py
@@ -154,7 +154,7 @@ class TestNoCores(unittest.TestCase):
         cleavage_result = CleavageSiteHit(end=48, score=-6.8, lantype="Class-II")
         with patch.object(lanthi, "predict_cleavage_site", return_value=cleavage_result):
             for part in ["I", "II"]:
-                assert run_lanthipred(None, self.cds, "Class-%s" % part, self.domains) is None
+                assert run_lanthipred(None, self.cds, f"Class-{part}", self.domains) is None
 
     def test_prediction_with_core_class1(self, _patched_rodeo):
         # the cleavage result adjusted to leave at least one amino in core

--- a/antismash/modules/lassopeptides/__init__.py
+++ b/antismash/modules/lassopeptides/__init__.py
@@ -55,8 +55,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
         if binary_name not in options.executables:
             present = False
             if not optional:
-                failure_messages.append("Failed to locate executable for %r" %
-                                        binary_name)
+                failure_messages.append(f"Failed to locate executable for {binary_name}")
         if binary_name == "fimo":
             local_config().fimo_present = present
 

--- a/antismash/modules/lassopeptides/specific_analysis.py
+++ b/antismash/modules/lassopeptides/specific_analysis.py
@@ -448,7 +448,7 @@ def identify_lasso_motifs(leader: str, core: str) -> Tuple[List[int], int, Dict[
     """Run FIMO to identify lasso peptide-specific motifs"""
     motif_file = path.get_full_path(__file__, 'data', "lasso_motifs_meme.txt")
     with TemporaryFile() as tempfile:
-        with open(tempfile.name, "w") as out_file:
+        with open(tempfile.name, "w", encoding="utf-8") as out_file:
             out_file.write(f">query\n{leader}{core}")
         fimo_output = subprocessing.run_fimo_simple(motif_file, tempfile.name)
     fimo_motifs = [int(line.partition("\t")[0])

--- a/antismash/modules/lassopeptides/specific_analysis.py
+++ b/antismash/modules/lassopeptides/specific_analysis.py
@@ -158,10 +158,11 @@ class Lassopeptide:
         self._c_cut = str(ccut)
 
     def __repr__(self) -> str:
-        return "Lassopeptide(..%s, %s, %r, %r, %s, %s(%s), %s, %s)" % (
-                        self.end, self.score, self._lassotype,
-                        self._core, self.number_bridges, self._monoisotopic_weight,
-                        self._weight, self._macrolactam, self.c_cut)
+        return (
+            f"Lassopeptide(..{self.end}, {self.score}, {self._lassotype!r}, "
+            f"{self._core!r}, {self.number_bridges}, {self._monoisotopic_weight}({self._weight}), "
+            f"{self._macrolactam}, {self.c_cut})"
+        )
 
     def _calculate_weight(self, analysis: utils.RobustProteinAnalysis) -> float:
         """ Calculate the molecular weight/monoisotopic mass from the given input
@@ -448,7 +449,7 @@ def identify_lasso_motifs(leader: str, core: str) -> Tuple[List[int], int, Dict[
     motif_file = path.get_full_path(__file__, 'data', "lasso_motifs_meme.txt")
     with TemporaryFile() as tempfile:
         with open(tempfile.name, "w") as out_file:
-            out_file.write(">query\n%s%s" % (leader, core))
+            out_file.write(f">query\n{leader}{core}")
         fimo_output = subprocessing.run_fimo_simple(motif_file, tempfile.name)
     fimo_motifs = [int(line.partition("\t")[0])
                    for line in fimo_output.split("\n")
@@ -640,7 +641,7 @@ def determine_precursor_peptide_candidate(record: Record, cluster: Protocluster,
         return None
 
     # Create FASTA sequence for feature under study
-    lasso_a_fasta = ">%s\n%s" % (query.get_name(), query_sequence)
+    lasso_a_fasta = f">{query.get_name()}\n{query_sequence}"
 
     # Run sequence against pHMM to find the cleavage site position
     end, score = run_cleavage_site_phmm(lasso_a_fasta, 'precursor_2637.hmm', -20.00)
@@ -678,7 +679,7 @@ def run_lassopred(record: Record, cluster: Protocluster, query: CDSFeature) -> O
     thresh_c_hit = -7.5
 
     aux = result.core[(len(result.core) // 2):]
-    core_a_fasta = ">%s\n%s" % (query.get_name(), aux)
+    core_a_fasta = f">{query.get_name()}\n{aux}"
 
     profile = path.get_full_path(__file__, 'data', c_term_hmmer_profile)
     hmmer_res = subprocessing.run_hmmpfam2(profile, core_a_fasta)

--- a/antismash/modules/lassopeptides/specific_analysis.py
+++ b/antismash/modules/lassopeptides/specific_analysis.py
@@ -405,7 +405,7 @@ def acquire_rodeo_heuristics(record: Record, cluster: Protocluster, query: CDSFe
     else:
         tabs.append(0)
     # Core has at least 2 aromatic residues	+2
-    if sum([core.count(aa) for aa in list("FWY")]) >= 2:
+    if sum(core.count(aa) for aa in "FWY") >= 2:
         score += 2
         tabs.append(1)
     else:
@@ -518,62 +518,37 @@ def generate_rodeo_svm_csv(record: Record, query: CDSFeature, leader: str, core:
     columns.append(core[:9].count("P"))
     # Estimated core charge
     charge_dict = {"E": -1, "D": -1, "K": 1, "H": 1, "R": 1}
-    columns.append(sum([charge_dict[aa] for aa in core if aa in charge_dict]))
+    columns.append(sum(charge_dict.get(aa, 0) for aa in core))
     # Estimated leader charge
-    columns.append(sum([charge_dict[aa] for aa in leader if aa in charge_dict]))
+    columns.append(sum(charge_dict.get(aa, 0) for aa in leader))
     # Estimated precursor charge
-    columns.append(sum([charge_dict[aa] for aa in leader+core if aa in charge_dict]))
+    columns.append(sum(charge_dict.get(aa, 0) for aa in leader + core))
     # Absolute value of core charge
-    columns.append(abs(sum([charge_dict[aa] for aa in core if aa in charge_dict])))
+    columns.append(abs(sum(charge_dict.get(aa, 0) for aa in core)))
     # Absolute value of leader charge
-    columns.append(abs(sum([charge_dict[aa] for aa in leader if aa in charge_dict])))
+    columns.append(abs(sum(charge_dict.get(aa, 0) for aa in leader)))
     # Absolute value of precursor charge
-    columns.append(abs(sum([charge_dict[aa] for aa in leader+core if aa in charge_dict])))
+    columns.append(abs(sum(charge_dict.get(aa, 0) for aa in leader + core)))
     # Counts of AAs in leader
     columns += [leader.count(aa) for aa in "ARDNCQEGHILKMFPSTWYV"]
-    # Aromatics in leader
-    columns.append(sum([leader.count(aa) for aa in "FWY"]))
-    # Neg charged in leader
-    columns.append(sum([leader.count(aa) for aa in "DE"]))
-    # Pos charged in leader
-    columns.append(sum([leader.count(aa) for aa in "RK"]))
-    # Charged in leader
-    columns.append(sum([leader.count(aa) for aa in "RKDE"]))
-    # Aliphatic in leader
-    columns.append(sum([leader.count(aa) for aa in "GAVLMI"]))
-    # Hydroxyl in leader
-    columns.append(sum([leader.count(aa) for aa in "ST"]))
+    # groups for aromatics, neg charged, pos charged, aliphatic, and hydroxyl
+    groups = ["FWY", "DE", "RK", "RKDE", "GAVLMI", "ST"]
+    # leader groups
+    for group in groups:
+        columns.append(sum(leader.count(aa) for aa in group))
     # Counts of AAs in core
     columns += [core.count(aa) for aa in "ARDNCQEGHILKMFPSTWYV"]
-    # Aromatics in core
-    columns.append(sum([core.count(aa) for aa in "FWY"]))
-    # Neg charged in core
-    columns.append(sum([core.count(aa) for aa in "DE"]))
-    # Pos charged in core
-    columns.append(sum([core.count(aa) for aa in "RK"]))
-    # Charged in core
-    columns.append(sum([core.count(aa) for aa in "RKDE"]))
-    # Aliphatic in core
-    columns.append(sum([core.count(aa) for aa in "GAVLMI"]))
-    # Hydroxyl in core
-    columns.append(sum([core.count(aa) for aa in "ST"]))
+    # core groups
+    for group in groups:
+        columns.append(sum(core.count(aa) for aa in group))
     # Counts (0 or 1) of amino acids within first AA position of core sequence
     columns += [core[0].count(aa) for aa in "ARDNCQEGHILKMFPSTWYV"]
     # Counts of AAs in leader+core
     precursor = leader + core
     columns += [precursor.count(aa) for aa in "ARDNCQEGHILKMFPSTWYV"]  # Temp to work with current training CSV
-    # Aromatics in precursor
-    columns.append(sum([precursor.count(aa) for aa in "FWY"]))
-    # Neg charged in precursor
-    columns.append(sum([precursor.count(aa) for aa in "DE"]))
-    # Pos charged in precursor
-    columns.append(sum([precursor.count(aa) for aa in "RK"]))
-    # Charged in precursor
-    columns.append(sum([precursor.count(aa) for aa in "RKDE"]))
-    # Aliphatic in precursor
-    columns.append(sum([precursor.count(aa) for aa in "GAVLMI"]))
-    # Hydroxyl in precursor
-    columns.append(sum([precursor.count(aa) for aa in "ST"]))
+    # combined groups
+    for group in groups:
+        columns.append(sum(precursor.count(aa) for aa in group))
     # Motifs
     columns += [1 if motif in fimo_motifs else 0 for motif in range(1, 17)]
     # Total motifs hit
@@ -581,7 +556,7 @@ def generate_rodeo_svm_csv(record: Record, query: CDSFeature, leader: str, core:
     # Motif scores
     columns += [fimo_scores[motif] if motif in fimo_motifs else 0 for motif in range(1, 17)]
     # Sum of MEME scores
-    columns.append(sum([fimo_scores[motif] if motif in fimo_motifs else 0 for motif in range(1, 17)]))
+    columns.append(sum(fimo_scores[motif] if motif in fimo_motifs else 0 for motif in range(1, 17)))
     # No Motifs?
     if not fimo_motifs:
         columns.append(1)

--- a/antismash/modules/nrps_pks/__init__.py
+++ b/antismash/modules/nrps_pks/__init__.py
@@ -62,8 +62,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
     failure_messages = []
     for binary_name in ["hmmsearch", "java"]:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate executable for %r" %
-                                    binary_name)
+            failure_messages.append(f"Failed to locate executable for {binary_name!r}")
     failure_messages.extend(prepare_data(logging_only=True))
     failure_messages.extend(stach_check_prereqs(options))
     return failure_messages

--- a/antismash/modules/nrps_pks/at_analysis/at_analysis.py
+++ b/antismash/modules/nrps_pks/at_analysis/at_analysis.py
@@ -34,7 +34,7 @@ class ATResult:
         return str(self)
 
     def __str__(self) -> str:
-        return "ATResult(name=%s, signature=%s, score=%.1f)" % (self.name, self.signature, self.score)
+        return f"ATResult(name={self.name}, signature={self.signature}, score={self.score:.1f})"
 
     def to_json(self) -> Tuple[str, str, float]:
         """ Serialises the instance """
@@ -69,13 +69,13 @@ class ATPrediction(Prediction):
             return Markup("No matches above 50%")
         lines = []
         for monomer, pred in self.predictions[:3]:
-            lines.append("<dd>%s: %.1f%%</dd>\n" % (get_long_form(monomer), pred.score))
-        html = ((
+            lines.append(f"<dd>{get_long_form(monomer)}: {pred.score:.1f}%</dd>\n")
+        html = (
             "<dl>\n"
             " <dt>Top 3 matches:</dt>\n"
-            "%s"
+            f"{''.join(lines)}"
             "</dl>\n"
-        ) % "".join(lines))
+        )
         return Markup(html)
 
     def to_json(self) -> Dict[str, Any]:

--- a/antismash/modules/nrps_pks/at_analysis/at_analysis.py
+++ b/antismash/modules/nrps_pks/at_analysis/at_analysis.py
@@ -94,7 +94,7 @@ def get_at_positions(startpos: int = 7) -> List[int]:
     """ Reads a reference list of positions used in signature extraction
         from file.
     """
-    with open(_AT_POSITIONS_FILENAME, "r") as handle:
+    with open(_AT_POSITIONS_FILENAME, "r", encoding="utf-8") as handle:
         text = handle.read().strip().replace(' ', '_')
     positions = [int(pos) - startpos for pos in text.split("\t")]
     return positions

--- a/antismash/modules/nrps_pks/at_analysis/test/test_at_analysis.py
+++ b/antismash/modules/nrps_pks/at_analysis/test/test_at_analysis.py
@@ -11,7 +11,7 @@ from antismash.modules.nrps_pks.at_analysis import at_analysis
 
 class TestScoring(unittest.TestCase):
     def test_score_threshold(self):
-        ref_sigs = {"%s_%s" % (i, mon): i*24 for i, mon in zip("ABC", ["mal", "mmal", "emal"])}
+        ref_sigs = {f"{i}_{mon}": i*24 for i, mon in zip("ABC", ["mal", "mmal", "emal"])}
         query_sig = ["A"] * 24
         query_sig[3:7] = "B"
         query_sig[7:13] = "C"

--- a/antismash/modules/nrps_pks/data_structures.py
+++ b/antismash/modules/nrps_pks/data_structures.py
@@ -22,23 +22,22 @@ class Prediction:
             be made, an empty list is returned.
             The optional as_norine field forces the use of valid Norine names.
         """
-        raise NotImplementedError("Prediction subclass %s "
-                                  "did not implement get_classification()" % type(self))
+        raise NotImplementedError(f"Prediction subclass {type(self)} did not implement get_classification()")
 
     def as_html(self) -> Markup:
         """ Returns a jinja2.Markup object containing HTML to use when representing
             this prediction in the sidepanel output.
         """
-        raise NotImplementedError("Prediction subclass %s did not implement as_html()" % type(self))
+        raise NotImplementedError(f"Prediction subclass {type(self)} did not implement as_html()")
 
     def to_json(self) -> Dict[str, Any]:
         """ Creates a JSON representation of this prediction """
-        raise NotImplementedError("Prediction subclass %s did not implement to_json()" % type(self))
+        raise NotImplementedError(f"Prediction subclass {type(self)} did not implement to_json()")
 
     @classmethod
     def from_json(cls, json: Dict[str, Any]) -> "Prediction":
         """ Creates a Prediction from a JSON representation """
-        raise NotImplementedError("Prediction subclass %s did not implement from_json()" % cls)
+        raise NotImplementedError(f"Prediction subclass {cls} did not implement from_json()")
 
 
 class SimplePrediction(Prediction):
@@ -55,7 +54,7 @@ class SimplePrediction(Prediction):
         return [self.prediction]
 
     def as_html(self) -> Markup:
-        return Markup("%s: %s" % (self.method, self.prediction))
+        return Markup(f"{self.method}: {self.prediction}")
 
     def to_json(self) -> Dict[str, Any]:
         return {"class": "SimplePrediction",

--- a/antismash/modules/nrps_pks/minowa/base.py
+++ b/antismash/modules/nrps_pks/minowa/base.py
@@ -37,14 +37,14 @@ class MinowaPrediction(Prediction):
             " <dd>\n"
             "  <dl>\n"
         )
-        core = "\n".join("  <dd></dd><dt>%s: %.1f</dt>\n" % (name, score) for name, score in self.predictions)
+        core = "\n".join(f"  <dd></dd><dt>{name}: {score:.1f}</dt>\n" for name, score in self.predictions)
         raw_end = (
             "\n"
             "  </dl>\n"
             " </dd>\n"
             "</dl>\n"
         )
-        return Markup("%s%s%s" % (raw_start, core, raw_end))
+        return Markup(f"{raw_start}{core}{raw_end}")
 
     @staticmethod
     def from_json(json: Dict[str, Any]) -> "MinowaPrediction":
@@ -109,7 +109,7 @@ def run_minowa(sequence_info: Dict[str, str], startpos: int, muscle_ref: str, re
         # to use as input for hmm searches
         seq = utils.extract_by_reference_positions(aligned, ref_aligned, positions)
         assert seq
-        fasta_format = ">%s\n%s\n" % (query_id, seq.replace("-", "X"))
+        fasta_format = f">{query_id}\n{seq.replace('-', 'X')}\n"
 
         # then use list to extract positions from every sequence -> HMMs (one time, without any query sequence)
         hmm_scores = {}

--- a/antismash/modules/nrps_pks/minowa/base.py
+++ b/antismash/modules/nrps_pks/minowa/base.py
@@ -71,7 +71,7 @@ def hmmsearch(fasta_format: str, hmm: str) -> float:
 
 def get_positions(filename: str, startpos: int) -> List[int]:
     """ Reads the signature positions from the file provided """
-    with open(filename, "r") as handle:
+    with open(filename, "r", encoding="utf-8") as handle:
         text = handle.read().strip().replace(' ', '_')
     return [int(i) - startpos for i in text.split("\t")]
 

--- a/antismash/modules/nrps_pks/nrps_predictor.py
+++ b/antismash/modules/nrps_pks/nrps_predictor.py
@@ -120,38 +120,36 @@ class PredictorSVMResult(Prediction):
         elif self.stachelhaus_match_count > 7:
             qualifier = "moderate"
 
-        raw = ("\n"
-               "<dl><dt>SVM prediction details:</dt>\n"
-               " <dd>"
-               "  %s"
-               "  <dl>"
-               "   <dt>Predicted physicochemical class:</dt>\n"
-               "   <dd>%s</dd>\n"
-               "   <dt>Large clusters prediction:</dt>\n"
-               "   <dd>%s</dd>\n"
-               "   <dt>Small clusters prediction:</dt>\n"
-               "   <dd>%s</dd>\n"
-               "   <dt>Single AA prediction:</dt>\n"
-               "   <dd>%s</dd>\n"
-               "  </dl>\n"
-               " </dd>\n"
-               "</dl>\n"
-               "<dl><dt>Stachelhaus prediction details:</dt>\n"
-               " <dd>\n"
-               "  <dl>\n"
-               "   <dt>Stachelhaus sequence:</dt>\n"
-               "   <dd><span class=\"serif\">%s</span></dd>\n"
-               "   <dt>Nearest Stachelhaus code:</dt>\n"
-               "   <dd>%s</dd>\n"
-               "   <dt>Stachelhaus code match:</dt>\n"
-               "   <dd>%d%% (%s)</dd>\n"
-               "  </dl>\n"
-               " </dd>\n"
-               "</dl>\n" % (note, self.physicochemical_class, ", ".join(self.large_cluster_pred),
-                            ", ".join(self.small_cluster_pred), self.single_amino_pred,
-                            self.stachelhaus_seq, ", ".join(self.stachelhaus_predictions),
-                            self.stachelhaus_match_count * 10, qualifier))
-        return Markup(raw)
+        return Markup(
+            "\n"
+            "<dl><dt>SVM prediction details:</dt>\n"
+            " <dd>"
+            f"  {note}"
+            "  <dl>"
+            "   <dt>Predicted physicochemical class:</dt>\n"
+            f"   <dd>{self.physicochemical_class}</dd>\n"
+            "   <dt>Large clusters prediction:</dt>\n"
+            f"   <dd>{', '.join(self.large_cluster_pred)}</dd>\n"
+            "   <dt>Small clusters prediction:</dt>\n"
+            f"   <dd>{', '.join(self.small_cluster_pred)}</dd>\n"
+            "   <dt>Single AA prediction:</dt>\n"
+            f"   <dd>{self.single_amino_pred}</dd>\n"
+            "  </dl>\n"
+            " </dd>\n"
+            "</dl>\n"
+            "<dl><dt>Stachelhaus prediction details:</dt>\n"
+            " <dd>\n"
+            "  <dl>\n"
+            "   <dt>Stachelhaus sequence:</dt>\n"
+            f"   <dd><span class=\"serif\">{self.stachelhaus_seq}</span></dd>\n"
+            "   <dt>Nearest Stachelhaus code:</dt>\n"
+            f"   <dd>{', '.join(self.stachelhaus_predictions)}</dd>\n"
+            "   <dt>Stachelhaus code match:</dt>\n"
+            f"   <dd>{self.stachelhaus_match_count * 10}% ({qualifier})</dd>\n"
+            "  </dl>\n"
+            " </dd>\n"
+            "</dl>\n"
+        )
 
     @classmethod
     def from_line(cls, line: str) -> "PredictorSVMResult":
@@ -171,7 +169,7 @@ class PredictorSVMResult(Prediction):
         # 11: coords
         # 12: pfam-score
         if not len(parts) == 13:
-            raise ValueError("Invalid SVM result line: %s" % line)
+            raise ValueError(f"Invalid SVM result line: {line}")
         query_stach = parts[2]
         pred_from_stach = parts[7]
         best_stach_match = query_stach.lower()
@@ -253,7 +251,7 @@ def run_nrpspredictor(a_domains: List[ModularDomain], options: ConfigType) -> Di
             write_nrpspredictor_input(a_domains, signatures, handle)
         # Run NRPSPredictor2 SVM
         commands = ['java',
-                    '-Ddatadir=%s' % data_dir,
+                    f'-Ddatadir={data_dir}',
                     '-cp', classpath,
                     'org.roettig.NRPSpredictor2.NRPSpredictor2',
                     '-i', input_filename,
@@ -262,7 +260,7 @@ def run_nrpspredictor(a_domains: List[ModularDomain], options: ConfigType) -> Di
                     '-b', bacterial]
         result = subprocessing.execute(commands)
         if not result.successful():
-            raise RuntimeError("NRPSPredictor2 failed: %s" % result.stderr)
+            raise RuntimeError(f"NRPSPredictor2 failed: {result.stderr}")
 
         with open(output_filename, encoding="utf-8") as handle:
             lines = handle.read().splitlines()[1:]  # strip the header
@@ -276,7 +274,7 @@ def write_nrpspredictor_input(a_domains: list[ModularDomain], signatures: list[O
     for sig, domain in zip(signatures, a_domains):
         if not sig:
             continue
-        handle.write("%s\t%s\n" % (sig, domain.get_name()))
+        handle.write(f"{sig}\t{domain.get_name()}\n")
 
 
 def map_nrpspredicor_to_norine(as_name: str) -> str:

--- a/antismash/modules/nrps_pks/nrps_predictor.py
+++ b/antismash/modules/nrps_pks/nrps_predictor.py
@@ -27,7 +27,7 @@ def _build_stach_codes() -> Dict[str, Set[str]]:
     """
     data_file = path.get_full_path(__file__, "external/NRPSPredictor2/data/labeled_sigs")
     results: Dict[str, Set[str]] = defaultdict(set)
-    with open(data_file) as handle:
+    with open(data_file, encoding="utf-8") as handle:
         for line in handle:
             # in the form: prediction angstrom_code stach_code
             # with the stach code's 8th character always being '-'

--- a/antismash/modules/nrps_pks/nrps_predictor.py
+++ b/antismash/modules/nrps_pks/nrps_predictor.py
@@ -21,6 +21,7 @@ from .data_structures import Prediction
 from .name_mappings import get_substrate_by_name, is_valid_norine_name
 from .signatures import get_a_dom_signatures
 
+
 def _build_stach_codes() -> Dict[str, Set[str]]:
     """ Builds a mapping of Stachelhaus prediction to code from NRPSPredictor2's
         data for use in checking how good a hit it really is
@@ -198,7 +199,6 @@ class PredictorSVMResult(Prediction):
                                   json["single_amino_pred"], json["stachelhaus_predictions"],
                                   json["uncertain"], json["stachelhaus_seq"],
                                   json["stachelhaus_match_count"])
-
 
 
 def read_output(lines: List[str]) -> Dict[str, Prediction]:

--- a/antismash/modules/nrps_pks/orderfinder.py
+++ b/antismash/modules/nrps_pks/orderfinder.py
@@ -195,7 +195,7 @@ def generate_substrates_order(geneorder: List[CDSFeature], consensus_predictions
             components.append((substrate, monomer, [domain.domain or "" for domain in module.domains]))
 
         if monomers:
-            monomers_by_cds.append("(%s)" % (" - ".join(monomers)))
+            monomers_by_cds.append(f"({' - '.join(monomers)})")
 
     polymer = " + ".join(monomers_by_cds)
     smiles = gen_smiles_from_pksnrps(components)

--- a/antismash/modules/nrps_pks/parsers.py
+++ b/antismash/modules/nrps_pks/parsers.py
@@ -70,7 +70,7 @@ def generate_nrps_consensus(results: Dict[str, Prediction]) -> str:
         if len(prediction.get_classification()) == 1:
             best = prediction.get_classification(as_norine=True)[0]
             if not set(best).issubset(ALLOWABLE_PREDICTION_CHARACTERS):
-                raise ValueError("%s generated bad prediction string: %s" % (method, best))
+                raise ValueError(f"{method} generated bad prediction string: {best}")
             hit_counts[best] += 1
 
     consensus = "X"
@@ -103,7 +103,7 @@ def calculate_consensus_prediction(cds_features: List[CDSFeature], results: Dict
     trans_at: Dict[str, str] = {}  # feature name -> prediction
 
     for cds in cds_features:
-        assert cds.region, "Orphaned CDS found: %s" % cds
+        assert cds.region, f"Orphaned CDS found: {cds}"
         for domain in cds.nrps_pks.domains:
             predictions = results[domain.feature_name]
             if 'OTHER' in domain.label:
@@ -181,7 +181,7 @@ def update_prediction(locus: str, preds: Dict[str, str], target: str,
     """
     assert len(lists) == len(mappings)
     for idx, target_element in enumerate(target_list):
-        key = "nrpspksdomains_{}_{}.{}".format(locus, target, idx + 1)
+        key = f"nrpspksdomains_{locus}_{target}.{idx + 1}"
         for sublist, mapping in zip(lists, mappings):
             for position in sublist:
                 if not target_element < position:

--- a/antismash/modules/nrps_pks/results.py
+++ b/antismash/modules/nrps_pks/results.py
@@ -251,7 +251,7 @@ class NRPS_PKS_Results(ModuleResults):
                 # otherwise one of many without prediction methods/relevance (PCP, Cglyc, etc)
 
                 for method, pred in domain.get_predictions().items():
-                    feature.specificity.append("%s: %s" % (method, pred))
+                    feature.specificity.append(f"{method}: {pred}")
 
             for module in cds_feature.modules:
                 if not module.is_complete():
@@ -267,6 +267,6 @@ class NRPS_PKS_Results(ModuleResults):
                     if module.module_type == module.types.PKS and "PKS_AT" not in domains:
                         substrate = "mal"
                     else:
-                        raise ValueError("missing substrate in non-transAT module: %s" % module)
+                        raise ValueError(f"missing substrate in non-transAT module: {module}")
 
                 module.add_monomer(substrate, modify_substrate(module, substrate))

--- a/antismash/modules/nrps_pks/smiles_generator.py
+++ b/antismash/modules/nrps_pks/smiles_generator.py
@@ -22,7 +22,7 @@ def _load_smiles() -> Dict[str, str]:
     """Load smiles from a dictionary mapping residues to SMILES string"""
     aa_smiles: Dict[str, str] = {}
 
-    with open(path.get_full_path(__file__, 'data', 'aaSMILES.txt'), 'r') as handle:
+    with open(path.get_full_path(__file__, "data", "aaSMILES.txt"), "r", encoding="utf-8") as handle:
         for line in handle:
             line = line.split("#", 1)[0].strip()
             if not line:

--- a/antismash/modules/nrps_pks/smiles_generator.py
+++ b/antismash/modules/nrps_pks/smiles_generator.py
@@ -28,7 +28,7 @@ def _load_smiles() -> Dict[str, str]:
             if not line:
                 continue
             smiles = line.split()
-            assert len(smiles) == 2, "Invalid smiles line {!r}".format(line)
+            assert len(smiles) == 2, f"Invalid smiles line {line!r}"
             assert smiles[0].lower() not in aa_smiles, f"{smiles[0]} contained twice in smiles data"
             aa_smiles[smiles[0].lower()] = smiles[1]
 
@@ -93,7 +93,7 @@ class Atom:
         if not self.branches:
             return "".join(smiles)
         for branch in self.branches:
-            smiles.append("(%s)" % "".join(atom.to_smiles() for atom in branch))
+            smiles.append(f"({''.join(atom.to_smiles() for atom in branch)})")
         return "".join(smiles)
 
     def flatten(self) -> List["Atom"]:
@@ -139,7 +139,7 @@ class Bonds:
                 # ring identifiers/references
                 if symbol.isdigit():
                     if not atoms or isinstance(atoms[-1], list):
-                        raise ValueError("invalid smiles: %s" % (symbol + smiles))
+                        raise ValueError(f"invalid smiles: {symbol + smiles}")
                     # if it's new, then it's a declaration
                     if symbol not in self._atoms_by_identifier:
                         atoms[-1].identifier = symbol
@@ -205,7 +205,7 @@ def methylate(smiles: str, variant: str) -> str:
             is possible
     """
     if variant not in "CNO":
-        raise ValueError("expected methylation variant of C, N, or O, not %s" % variant)
+        raise ValueError(f"expected methylation variant of C, N, or O, not {variant}")
     bonds = Bonds(smiles)
     atoms = list(bonds)
     start = 1
@@ -250,7 +250,7 @@ def gen_smiles_from_pksnrps(components: List[Tuple[str, str, List[str]]]) -> str
         smiles_chunk = _SMILES[substrate.lower()]
         for domain in domains:
             for prefix in "cno":
-                if domain == "%cMT" % prefix:
+                if domain == f"{prefix}MT":
                     smiles_chunk = methylate(smiles_chunk, prefix.upper())
         return smiles_chunk
 

--- a/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
+++ b/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
@@ -65,7 +65,7 @@ class IntegrationNRPSPKS(unittest.TestCase):
                      ("bpsB", 1), ("bpsB", 2), ("bpsB", 3),
                      ("bpsC", 1),
                      ("bpsD", 1)]
-        nrps_names = ['nrpspksdomains_%s_AMP-binding.%d' % a_dom for a_dom in a_domains]
+        nrps_names = [f"nrpspksdomains_{name}_AMP-binding.{index}" for name, index in a_domains]
         feature_names = nrps_names + ["nrpspksdomains_pks_CAL_domain.1"]
         assert set(results.domain_predictions) == set(feature_names)
 

--- a/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
+++ b/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
@@ -143,14 +143,15 @@ class IntegrationNRPSPKS(unittest.TestCase):
                             'nrpspksdomains_STAUR_3984_PKS_KR.1',
                             'nrpspksdomains_STAUR_3985_PKS_KR.1',
                             'nrpspksdomains_STAUR_3983_PKS_KR.1',
-                            'nrpspksdomains_STAUR_3983_PKS_KR.1',
                             'nrpspksdomains_STAUR_3982_PKS_KR.1'}
         assert set(results.domain_predictions) == expected_domains
 
     def test_get_a_dom_signatures(self):
         filename = path.get_full_path(__file__, 'data', 'dom_signatures.txt')
         data = []
-        for line in open(filename, 'r', encoding="utf-8"):
+        with open(filename, "r", encoding="utf-8") as handle:
+            lines = handle.readlines()
+        for line in lines:
             line = line.strip()
             if not line:
                 continue

--- a/antismash/modules/nrps_pks/test/test_nrps_predictor.py
+++ b/antismash/modules/nrps_pks/test/test_nrps_predictor.py
@@ -15,7 +15,7 @@ from antismash.modules.nrps_pks import nrps_predictor, data_structures
 
 def read_file():
     output = path.get_full_path(__file__, 'data', 'nrps_pred2_Y16952.txt')
-    with open(output) as handle:
+    with open(output, encoding="utf-8") as handle:
         content = handle.read()
     assert content.startswith('#')
     assert content.count('\n') == 9

--- a/antismash/modules/nrps_pks/test/test_nrps_predictor.py
+++ b/antismash/modules/nrps_pks/test/test_nrps_predictor.py
@@ -90,9 +90,9 @@ class TestPrediction(unittest.TestCase):
             stach = "X" * i + "DAFYLGMMCK"[i:]
             line = (
                 "nrpspksdomains_bpsA_AMP-binding.1	L--SFDASLFEMYLLTGGDRNMYGPTEATMCATW	"
-                "%s	hydrophobic-aliphatic	N/A	val,leu,ile,abu,iva	leu	leu	"
+                f"{stach}	hydrophobic-aliphatic	N/A	val,leu,ile,abu,iva	leu	leu	"
                 "orn,lys,arg	gly,ala	0	0:0	0.000000e+00"
-            ) % stach
+            )
             pred = nrps_predictor.PredictorSVMResult.from_line(line)
             assert pred.stachelhaus_match_count == 10 - i
 

--- a/antismash/modules/nrps_pks/test/test_orderfinder.py
+++ b/antismash/modules/nrps_pks/test/test_orderfinder.py
@@ -359,7 +359,7 @@ class TestFollowers(unittest.TestCase):
     def test_gaps(self):
         cdses = []
         for i, name in enumerate("ABC"):
-            cdses.append(DummyCDS(start=i*10, end=i*10+1, strand=-1 if name =="B" else 1, locus_tag=name))
+            cdses.append(DummyCDS(start=i*10, end=i*10+1, strand=-1 if name == "B" else 1, locus_tag=name))
         assert orderfinder.get_follower_genes(cdses) == {}
 
     def test_no_gaps_forward(self):
@@ -392,4 +392,3 @@ class TestFollowers(unittest.TestCase):
             "A": "B",
             "D": "C",
         }
-

--- a/antismash/modules/nrps_pks/test/test_parsers.py
+++ b/antismash/modules/nrps_pks/test/test_parsers.py
@@ -10,6 +10,7 @@ from antismash.modules.nrps_pks import parsers
 from antismash.modules.nrps_pks.data_structures import Prediction, SimplePrediction
 from antismash.modules.nrps_pks.name_mappings import KNOWN_SUBSTRATES
 
+
 class TestNrpsConsensus(unittest.TestCase):
     def setUp(self) -> None:
         self.go = parsers.generate_nrps_consensus

--- a/antismash/modules/nrps_pks/test/test_smiles_conversion.py
+++ b/antismash/modules/nrps_pks/test/test_smiles_conversion.py
@@ -20,7 +20,7 @@ SIGNATURE_FILE = path.get_full_path(
 
 def load_sigs() -> set[str]:
     signatures: set[str] = set()
-    with open(SIGNATURE_FILE, 'r') as handle:
+    with open(SIGNATURE_FILE, "r", encoding="utf-8") as handle:
         for line in handle:
             raw_name, _ = line.split('\t', 1)
             names = raw_name.split("/")

--- a/antismash/modules/nrps_pks/test/test_stachelhaus.py
+++ b/antismash/modules/nrps_pks/test/test_stachelhaus.py
@@ -44,7 +44,6 @@ class TestStachelhausPrediction(unittest.TestCase):
         assert restored.get_classification() == []
         assert restored.aa10 == "FAKEDATAOK"
 
-
         data = json.dumps(self.prediction.to_json())
         restored = stachelhaus.StachelhausPrediction.from_json(json.loads(data))
         assert restored.get_classification() == self.prediction.get_classification()
@@ -69,7 +68,7 @@ FAKE_A_DOMAIN_SIGNATURES = (
     ("DVSAIGCVTK", "LDLIFDVSVSEMAMIVGGEINCYGPTETTVTATL"),  # should hit once, Trp
     ("DAACIGNVVK", "MWHVFDASIAEPCLITGGDYNNYGPTENTVVATW"),  # should hit two 10 AA sigs but only one 34 AA sig, Trp
     ("DAACIGNVVK", "LWHVFDASIAEPCLITGGDYNNYGPTENTVVATW"),  # shouldn't hit any 34 AA sig, but consensus Trp anyway
-    ("DFWNIGMVHK", "LALAFDFSVWEGNQIFGGEVNMYGITETTVHVSY"),  # no aa34 hits, consensus Thr with a more complicated consensus
+    ("DFWNIGMVHK", "LALAFDFSVWEGNQIFGGEVNMYGITETTVHVSY"),  # no aa34 hits, consensus Thr but complicated
     ("DVMFYTALVK", "LRQMFDVSFMECFLYTTGEINAYGPSEAHLVSAR"),  # multiple substrates in consensus results, Trp|Tyr
     (None, None),                                          # Should not break on this
 )
@@ -93,7 +92,6 @@ class TestStachelhaus(unittest.TestCase):
                 "none"]:
             self.domains.append(DummyAntismashDomain(locus_tag="A", domain_id=domain_id))
 
-
     @patch.object(stachelhaus, "get_a_dom_signatures", side_effect=FAKE_A_DOMAIN_SIGNATURES)
     def test_run_stachelhaus(self, _patched_get_a_dom_signatures):
         predictions = stachelhaus.run_stachelhaus(self.domains, self.config)
@@ -111,7 +109,8 @@ class TestStachelhaus(unittest.TestCase):
         assert "none" not in predictions
 
     @patch.object(stachelhaus, "init_data", return_value=FAKE_KNOWN_STACH_CODES)
-    @patch.object(stachelhaus, "get_a_dom_signatures", side_effect=[("FAKEDATAOK", "ILIKEDATAEVENFAKEDATADIDISAYILIKED")])
+    @patch.object(stachelhaus, "get_a_dom_signatures",
+                  side_effect=[("FAKEDATAOK", "ILIKEDATAEVENFAKEDATADIDISAYILIKED")])
     def test_run_stachelhaus_combine_consensus(self, _patched_sigs, _patched_codes):
         domains = [
             DummyAntismashDomain(locus_tag="A", domain_id="different_multi"),

--- a/antismash/modules/pfam2go/pfam2go.py
+++ b/antismash/modules/pfam2go/pfam2go.py
@@ -21,7 +21,7 @@ class GeneOntology:  # pylint: disable=too-few-public-methods
     """A single Gene Ontology term; holds Gene Ontology ID and its human-readable description."""
     def __init__(self, _id: str, description: str) -> None:
         if not _id.startswith('GO:'):
-            raise ValueError('Invalid Gene Ontology ID: {0}'.format(_id))
+            raise ValueError(f"Invalid Gene Ontology ID: {_id}")
         self.id = _id
         assert isinstance(description, str)
         self.description = description

--- a/antismash/modules/pfam2go/pfam2go.py
+++ b/antismash/modules/pfam2go/pfam2go.py
@@ -129,7 +129,7 @@ def construct_mapping(mapfile: str) -> Dict[str, GeneOntologies]:
     """
     results = {}
     gene_ontology_per_pfam: Dict[str, List[GeneOntology]] = defaultdict(list)
-    with open(path.get_full_path(__file__, mapfile), 'r') as pfam_map:
+    with open(path.get_full_path(__file__, mapfile), "r", encoding="utf-8") as pfam_map:
         for line in pfam_map:
             if line.startswith('!'):
                 continue

--- a/antismash/modules/pfam2go/test/test_pfam2go.py
+++ b/antismash/modules/pfam2go/test/test_pfam2go.py
@@ -19,7 +19,7 @@ from antismash.modules.pfam2go import pfam2go
 def set_dummy_with_pfams(pfam_ids: Dict[str, FeatureLocation]) -> DummyRecord:
     pfam_domains = []
     for pfam_id, pfam_location in pfam_ids.items():
-        domain_id = '%s.%d.%d' % (pfam_id, pfam_location.start, pfam_location.end)
+        domain_id = f"{pfam_id}.{pfam_location.start}.{pfam_location.end}"
         pfam_domain = DummyPFAMDomain(location=pfam_location, protein_start=0, protein_end=5,
                                       identifier=pfam_id, domain_id=domain_id)
         pfam_domains.append(pfam_domain)

--- a/antismash/modules/rrefinder/__init__.py
+++ b/antismash/modules/rrefinder/__init__.py
@@ -75,9 +75,9 @@ def check_options(options: ConfigType) -> List[str]:
     """
     issues = []
     if options.rre_cutoff <= 0:
-        issues.append("RREFinder cutoff is negative: %s" % options.rre_cutoff)
+        issues.append(f"RREFinder cutoff is negative: {options.rre_cutoff}")
     if options.rre_min_length <= 0:
-        issues.append("RREFinder minimum length is negative: %s" % options.rre_cutoff)
+        issues.append(f"RREFinder minimum length is negative: {options.rre_cutoff}")
     return issues
 
 

--- a/antismash/modules/rrefinder/rre_domain.py
+++ b/antismash/modules/rrefinder/rre_domain.py
@@ -44,7 +44,7 @@ class RREDomain(AntismashDomain):
         """
         super().__init__(location, TOOL, protein_location, locus_tag, domain=domain)
         if not isinstance(description, str):
-            raise TypeError("RRE description must be a string, not %s" % type(description))
+            raise TypeError(f"RRE description must be a string, not {type(description)}")
         if not description:
             raise ValueError("RRE description cannot be empty")
         self.description = description
@@ -57,7 +57,7 @@ class RREDomain(AntismashDomain):
         self.version = int(version)
 
         if not (len(identifier) == 9 and identifier.startswith('RREFam') and identifier[6:].isdecimal()):
-            raise ValueError("invalid RREFam identifier: %s" % identifier)
+            raise ValueError(f"invalid RREFam identifier: {identifier}")
         self.identifier = identifier
 
     @property
@@ -67,7 +67,7 @@ class RREDomain(AntismashDomain):
         """
         if not self.version:
             return self.identifier
-        return "%s.%d" % (self.identifier, self.version)
+        return f"{self.identifier}.{self.version}"
 
     def to_biopython(self, qualifiers: Dict[str, List[str]] = None) -> List[SeqFeature]:
         mine: Dict[str, List[str]] = OrderedDict()

--- a/antismash/modules/rrefinder/rrefinder.py
+++ b/antismash/modules/rrefinder/rrefinder.py
@@ -138,9 +138,9 @@ class RREFinderResults(ModuleResults):
     def refilter(self, min_length: int, min_score: float) -> "RREFinderResults":
         """Trims the results to stricter thresholds for score and length"""
         if min_length < self.min_length:
-            raise ValueError("cannot refilter to a more lenient length: %s -> %s" % (self.min_length, min_length))
+            raise ValueError(f"cannot refilter to a more lenient length: {self.min_length} -> {min_length}")
         if min_score < self.bitscore_cutoff:
-            raise ValueError("cannot refilter to a more lenient score: %s -> %s" % (self.bitscore_cutoff, min_score))
+            raise ValueError(f"cannot refilter to a more lenient score: {self.bitscore_cutoff} -> {min_score}")
         by_cds, by_proto = filter_hits(self.hits_by_cds, self.hits_by_protocluster, min_length, min_score)
         self.hits_by_cds = by_cds
         self.hits_by_protocluster = by_proto

--- a/antismash/modules/rrefinder/rrefinder.py
+++ b/antismash/modules/rrefinder/rrefinder.py
@@ -129,9 +129,8 @@ class RREFinderResults(ModuleResults):
 
         # Refilter the hits (in case the cutoff is now more stringent)
         by_proto = {int(key): val for key, val in json['hits_by_protocluster'].items()}
-        filtered_hits_by_cds, filtered_hits_by_protocluster = filter_hits(hits_by_cds,
-                                                                        by_proto,
-                                                                        min_length, bitscore_cutoff)
+        filtered_hits_by_cds, filtered_hits_by_protocluster = filter_hits(hits_by_cds, by_proto,
+                                                                          min_length, bitscore_cutoff)
         return RREFinderResults(record.id, bitscore_cutoff, min_length,
                                 filtered_hits_by_protocluster, filtered_hits_by_cds)
 
@@ -204,7 +203,7 @@ def run_rrefinder(record: Record, bitscore_cutoff: float, min_length: int, datab
     # Gather all RRE candidates
     candidates_by_protocluster, cds_info = gather_rre_candidates(record)
     # Run hmmscan per protocluster and gather the hits
-    if cds_info == {}:
+    if not cds_info:
         filtered_hits_by_protocluster: Dict[int, List[str]] = {}
         filtered_hits_by_cds: Dict[str, List[HmmerHit]] = {}
     else:
@@ -215,6 +214,6 @@ def run_rrefinder(record: Record, bitscore_cutoff: float, min_length: int, datab
         hits_by_cds = extract_rre_hits(hmm_results)
         # Filter the hits
         filtered_hits_by_cds, filtered_hits_by_protocluster = filter_hits(hits_by_cds, candidates_by_protocluster,
-                                                                        min_length, bitscore_cutoff)
+                                                                          min_length, bitscore_cutoff)
     return RREFinderResults(record.id, bitscore_cutoff, min_length,
                             filtered_hits_by_protocluster, filtered_hits_by_cds)

--- a/antismash/modules/rrefinder/test/integration_rrefinder.py
+++ b/antismash/modules/rrefinder/test/integration_rrefinder.py
@@ -16,7 +16,7 @@ from antismash.modules import rrefinder
 class RREFinderIntegration(unittest.TestCase):
     def setUp(self):
         self.options = build_config(["--minimal", "--rre", "--enable-html"],
-                       isolated=True, modules=antismash.get_all_modules())
+                                    isolated=True, modules=antismash.get_all_modules())
 
     def tearDown(self):
         destroy_config()
@@ -28,7 +28,7 @@ class RREFinderIntegration(unittest.TestCase):
 
         options = build_config(["--minimal", "--enable-html", "--rre",
                                 "--rre-cutoff", "-10", "--rre-minlength", "-1"],
-                  isolated=True, modules=antismash.get_all_modules())
+                               isolated=True, modules=antismash.get_all_modules())
         issues = rrefinder.check_options(options)
         assert len(issues) == 2
         assert "RREFinder cutoff is negative" in issues[0]

--- a/antismash/modules/rrefinder/test/test_rre_domain.py
+++ b/antismash/modules/rrefinder/test/test_rre_domain.py
@@ -20,7 +20,7 @@ class TestRRE(unittest.TestCase):
         self.locus_tag = 'locus_tag_a'
         self.identifier = 'RREFam001'
         self.version = 1
-        self.full_identifier = '%s.%d' % (self.identifier, self.version)
+        self.full_identifier = f"{self.identifier}.{self.version}"
         self.rre = RREDomain(self.location, self.description, self.protein_location,
                              self.full_identifier, self.locus_tag, self.domain)
         self.rre.domain_id = f"{self.locus_tag}_{self.identifier}_1"

--- a/antismash/modules/rrefinder/test/test_rrefinder.py
+++ b/antismash/modules/rrefinder/test/test_rrefinder.py
@@ -54,8 +54,8 @@ class TestRREResults(unittest.TestCase):
 
         build_config([
             "--rre",
-            "--rre-cutoff", "%.1f" % self.bitscore_cutoff,
-            "--rre-minlength", "%i" % self.min_length,
+            "--rre-cutoff", f"{self.bitscore_cutoff:.1f}",
+            "--rre-minlength", str(self.min_length),
         ], isolated=True, modules=antismash.get_all_modules())
 
         # Here a mock so that the call to its functions can be tracked
@@ -101,7 +101,7 @@ class TestRREResults(unittest.TestCase):
         assert feature.description == hit.description
         assert feature.domain == hit.domain
         assert feature.locus_tag == hit.locus_tag
-        assert feature.domain_id == '{}_{}_{}.1'.format(self.tool, hit.locus_tag, hit.domain)
+        assert feature.domain_id == f"{self.tool}_{hit.locus_tag}_{hit.domain}.1"
         assert feature.database == self.database
         assert feature.detection == self.detection
         assert feature.score == hit.score

--- a/antismash/modules/sactipeptides/__init__.py
+++ b/antismash/modules/sactipeptides/__init__.py
@@ -51,8 +51,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
     failure_messages = []
     for binary_name in ['hmmpfam2']:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate executable for %r" %
-                                    binary_name)
+            failure_messages.append(f"Failed to locate executable for {binary_name}")
     failure_messages.extend(prepare_data(logging_only=True))
     failure_messages.extend(comparippson.check_prereqs(options))
 

--- a/antismash/modules/sactipeptides/html_output.py
+++ b/antismash/modules/sactipeptides/html_output.py
@@ -34,7 +34,6 @@ def generate_html(region_layer: RegionLayer, results: SactiResults,
     for locus, motifs in motifs_by_locus.items():
         motifs_by_core = defaultdict(list)
         for motif in motifs:
-            leader = motif.leader
             core = motif.core
             motifs_by_core[core].append(motif)
         motifs_by_locus_by_core[locus] = motifs_by_core

--- a/antismash/modules/sactipeptides/specific_analysis.py
+++ b/antismash/modules/sactipeptides/specific_analysis.py
@@ -473,17 +473,17 @@ def generate_rodeo_svm_csv(leader: str, core: str, previously_gathered_tabs: Lis
     # (Aromatics, Neg charged, Pos charged, Charged, Aliphatic, Hydroxyl)
     amino_groups = ["FWY", "DE", "RK", "RKDE", "GAVLMI", "ST"]
     for group in amino_groups:
-        columns.append(sum([precursor.count(aa) for aa in group]))
+        columns.append(sum(precursor.count(aa) for aa in group))
     # Number in leader of each amino acid
     columns += [leader.count(aa) for aa in "ARDNCQEGHILKMFPSTWYV"]
     # Number in leader of each amino acid type
     for group in amino_groups:
-        columns.append(sum([leader.count(aa) for aa in group]))
+        columns.append(sum(leader.count(aa) for aa in group))
     # Number in core of each amino acid
     columns += [core.count(aa) for aa in "ARDNCQEGHILKMFPSTWYV"]
     # Number in core of each amino acid type
     for group in amino_groups:
-        columns.append(sum([core.count(aa) for aa in group]))
+        columns.append(sum(core.count(aa) for aa in group))
     # Number of each peptidase Pfam hit (PF05193/PF00082/PF03572/PF00675/PF02517/PF02163/PF00326)
     peptidase_domains = ["PF05193", "PF00082", "PF03572", "PF00675", "PF02517", "PF02163", "PF00326"]
     for peptidase in peptidase_domains:

--- a/antismash/modules/sactipeptides/specific_analysis.py
+++ b/antismash/modules/sactipeptides/specific_analysis.py
@@ -370,7 +370,7 @@ def acquire_rodeo_heuristics(cluster: secmet.Protocluster, query: secmet.CDSFeat
         tabs += [1, 0]
     # SS profile count > 1
     # is there more than one Cx..C structure in the sequence
-    cysrex = '(?=(C.{%d,%d}C))' % (CHAIN_LOWER, CHAIN_UPPER)
+    cysrex = f"(?=(C.{{{CHAIN_LOWER},{CHAIN_UPPER}}}C))"
     rex4 = re.compile(cysrex)
     if len(rex4.findall(core)) > 1:
         score += 2
@@ -394,7 +394,7 @@ def structure_analysis(seq: str) -> Tuple[int, float, float, List[int]]:
                 a list containing counts of each possible C...C size
     """
     # define Cys-gap structures with a c-terminal Cys
-    cysrex = '(?=(C.{%d,%d}C))' % (CHAIN_LOWER, CHAIN_UPPER)
+    cysrex = f"(?=(C.{{{CHAIN_LOWER},{CHAIN_UPPER}}}C))"
 
     core = str(seq)
 

--- a/antismash/modules/sactipeptides/specific_analysis.py
+++ b/antismash/modules/sactipeptides/specific_analysis.py
@@ -141,7 +141,8 @@ def run_non_biosynthetic_phmms(cluster_fasta: str) -> Dict[str, List[HSP]]:
     """ Try to identify cleavage site using pHMM """
     if not cluster_fasta:
         return {}
-    with open(path.get_full_path(__file__, "data", "non_biosyn_hmms", "hmmdetails.txt"), "r") as handle:
+    with open(path.get_full_path(__file__, "data", "non_biosyn_hmms", "hmmdetails.txt"),
+              "r", encoding="utf-8") as handle:
         hmmdetails = [line.split("\t") for line in handle.read().splitlines() if line.count("\t") == 3]
     signature_profiles = [HmmSignature(details[0], details[1], int(details[2]), details[3]) for details in hmmdetails]
 

--- a/antismash/modules/smcog_trees/__init__.py
+++ b/antismash/modules/smcog_trees/__init__.py
@@ -55,7 +55,7 @@ class SMCOGTreeResults(ModuleResults):
         logging.debug("annotating genes with SMCOG trees: %d genes", len(self.tree_images))
         for feature in record.get_cds_features_within_regions():
             if feature.get_name() in self.tree_images:
-                feature.notes.append("smCOG tree PNG image: smcogs/%s" % self.tree_images[feature.get_name()])
+                feature.notes.append(f"smCOG tree PNG image: smcogs/{self.tree_images[feature.get_name()]}")
 
 
 def check_options(_options: ConfigType) -> List[str]:
@@ -106,7 +106,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
     failure_messages = []
     for binary_name in ['fasttree']:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate file: %r" % binary_name)
+            failure_messages.append(f"Failed to locate executable: {binary_name}")
 
     return failure_messages
 

--- a/antismash/modules/smcog_trees/test/integration_smcogs.py
+++ b/antismash/modules/smcog_trees/test/integration_smcogs.py
@@ -47,7 +47,7 @@ class Base(unittest.TestCase):
 
     def build_record(self, genbank):
         # construct a working record
-        with open(genbank) as handle:
+        with open(genbank, encoding="utf-8") as handle:
             seq_record = seqio.read(handle, "genbank")
         record = secmet.Record.from_biopython(seq_record, taxon="bacteria")
         assert record.get_protoclusters()
@@ -94,7 +94,7 @@ class TestTreeGeneration(Base):
             options = build_config(args, isolated=True, modules=antismash.get_all_modules())
             antismash.run_antismash(helpers.get_path_to_nisin_genbank(), options)
 
-            with open(os.path.join(output_dir, "nisin.json")) as res_file:
+            with open(os.path.join(output_dir, "nisin.json"), encoding="utf-8") as res_file:
                 assert "antismash.modules.smcog_trees" in res_file.read()
 
             tree_files = list(glob.glob(os.path.join(output_dir, "smcogs", "*.png")))

--- a/antismash/modules/smcog_trees/trees.py
+++ b/antismash/modules/smcog_trees/trees.py
@@ -97,7 +97,7 @@ def trim_alignment(input_number: int, contents: dict[str, str]) -> None:
     # check all sequences are the same length
     sequence_length = len(list(contents.values())[0])
     for name, seq in contents.items():
-        assert sequence_length == len(seq), "%s has different sequence length" % name
+        assert sequence_length == len(seq), f"{name} has different sequence length"
     # stripping ( and ) because it breaks newick tree parsing
     # and keeping only the last two fields (id and description)
     names = ["|".join(name.replace("(", "_").replace(")", "_").rsplit('|', 2)[-2:]) for name in list(contents)]
@@ -117,7 +117,7 @@ def trim_alignment(input_number: int, contents: dict[str, str]) -> None:
 
     # Shorten sequences to detected conserved regions
     seqs = [seq[first_shared_amino:last_shared_amino] for seq in seqs]
-    seed_fasta_name = "trimmed_alignment" + str(input_number) + ".fasta"
+    seed_fasta_name = f"trimmed_alignment{input_number}.fasta"
     fasta.write_fasta(names, seqs, seed_fasta_name)
 
 
@@ -128,13 +128,13 @@ def draw_tree(input_number: int, output_dir: str, tag: str) -> str:
             the filename of the image generated
     """
     matplotlib.use('Agg')
-    command = ["fasttree", "-quiet", "-fastest", "-noml", "trimmed_alignment%d.fasta" % input_number]
+    command = ["fasttree", "-quiet", "-fastest", "-noml", f"trimmed_alignment{input_number}.fasta"]
     run_result = subprocessing.execute(command)
     if not run_result.successful():
-        raise RuntimeError("Fasttree failed to run successfully:", run_result.stderr)
+        raise RuntimeError(f"Fasttree failed to run successfully: {run_result.stderr}")
 
     handle = StringIO(run_result.stdout)
-    tree_filename = os.path.join(output_dir, tag + '.png')
+    tree_filename = os.path.join(output_dir, f"{tag}.png")
     try:
         tree = Phylo.read(handle, 'newick')
     except NewickError:
@@ -156,6 +156,6 @@ def draw_tree(input_number: int, output_dir: str, tag: str) -> str:
     fig = matplotlib.pyplot.gcf()
     fig.set_size_inches(20, (tree.count_terminals() / 3))
     matplotlib.pyplot.axis('off')
-    fig.savefig(os.path.join(output_dir, tag + '.png'), bbox_inches='tight')
+    fig.savefig(tree_filename, bbox_inches='tight')
     matplotlib.pyplot.close(fig)
     return tree_filename

--- a/antismash/modules/t2pks/__init__.py
+++ b/antismash/modules/t2pks/__init__.py
@@ -65,13 +65,13 @@ def check_prereqs(options: ConfigType) -> List[str]:
     failure_messages = []
     for binary_name in ['hmmscan', "hmmpress", 'blastp']:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate file: %r" % binary_name)
+            failure_messages.append(f"Failed to locate executable: {binary_name}")
 
     for blastdb in ['KSIII', 'AT', 'LIG']:
         for ext in ['.fasta', '.phr', '.pin', '.psq']:
             dbfile = path.get_full_path(__file__, 'data', blastdb + ext)
             if path.locate_file(dbfile) is None:
-                failure_messages.append("Failed to locate file %r" % dbfile)
+                failure_messages.append(f"Failed to locate file: {dbfile}")
 
     failure_messages.extend(prepare_data(logging_only=True))
 

--- a/antismash/modules/t2pks/html_output.py
+++ b/antismash/modules/t2pks/html_output.py
@@ -29,12 +29,11 @@ def generate_html(region_layer: RegionLayer, results: T2PKSResults,
 
     template = FileTemplate(path.get_full_path(__file__, "templates", "sidepanel.html"))
 
-    tooltip_content = ("Predictions of starter units, elongations, product classes, "
-                       "and potential molecular weights for type II PKS clusters."
-                      )
-
-    tooltip_content += "<br>More detailed information is available %s." % docs_link("here", "modules/t2pks")
-
+    tooltip_content = (
+        "Predictions of starter units, elongations, product classes, "
+        "and potential molecular weights for type II PKS clusters."
+        f"<br>More detailed information is available {docs_link('here', 'modules/t2pks')}."
+    )
     html.add_sidepanel_section("Type II PKS", template.render(predictions=predictions,
                                                               tooltip_content=tooltip_content))
 

--- a/antismash/modules/t2pks/results.py
+++ b/antismash/modules/t2pks/results.py
@@ -21,10 +21,10 @@ class Prediction:
         self.evalue = float(evalue)
 
     def __repr__(self) -> str:
-        return "Prediction({}, {:.1f}, {:g})".format(self.name, self.score, self.evalue)
+        return f"Prediction({self.name}, {self.score:.1f}, {self.evalue:g})"
 
     def __str__(self) -> str:
-        return "{} (Score: {:.1f}; E-value: {:g})".format(self.name, self.score, self.evalue)
+        return f"{self.name} (Score: {self.score:.1f}; E-value: {self.evalue:g})"
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Prediction):
@@ -53,13 +53,13 @@ class CDSPrediction:
         self.evalue = evalue
 
     def __repr__(self) -> str:
-        return "CDSPrediction({}, {})".format(self.ptype, self.pfunc)
+        return f"CDSPrediction({self.ptype}, {self.pfunc})"
 
     def __str__(self) -> str:
         base = self.ptype
         if self.pfunc is not None:
-            base = '{} {}'.format(self.ptype, self.pfunc)
-        return '{} (Score: {:.1f}; E-value: {:g})'.format(base, self.bitscore, self.evalue)
+            base = f"{self.ptype} {self.pfunc}"
+        return f"{base} (Score: {self.bitscore:.1f}; E-value: {self.evalue:g})"
 
     def to_json(self) -> Tuple[str, Optional[str], float, float]:
         """ Converts a CDSPrediction into a JSON friendly format """
@@ -69,7 +69,7 @@ class CDSPrediction:
     def from_json(json: Tuple[str, Optional[str], float, float]) -> "CDSPrediction":
         """ Rebuilds a CDSPrediction from JSON """
         if len(json) != 4:
-            raise ValueError("Invalid CDSPrediction JSON: %s" % str(json))
+            raise ValueError(f"Invalid CDSPrediction JSON: {json}")
         func = None
         if json[1] is not None:
             func = str(json[1])
@@ -96,21 +96,24 @@ class ProtoclusterPrediction:
         self.end = end
 
     def __repr__(self) -> str:
-        return "ClusterPrediction(starters={}, elongations={}, classes={})".format(
-                    [unit.name for unit in self.starter_units],
-                    [elong.name for elong in self.malonyl_elongations],
-                    sorted(self.product_classes))
+        starters = [unit.name for unit in self.starter_units]
+        elongations = [elong.name for elong in self.malonyl_elongations]
+        classes = sorted(self.product_classes)
+        return f"ClusterPrediction(starters={starters}, elongations={elongations}, classes={classes})"
 
     def __str__(self) -> str:
-        string = 'Starter units: ' + str(self.starter_units)
-        string += '\nMalonyl elongations: ' + str(self.malonyl_elongations)
-        string += '\nProduct classes: ' + ','.join(sorted(self.product_classes))
-        string += '\nMolecular weights: ' + str(self.molecular_weights)
+        parts = [
+            f"Starter units: {self.starter_units}",
+            f"Malonyl elongations: {self.malonyl_elongations}",
+            f"Product classes: {','.join(sorted(self.product_classes))}",
+            f"Molecular weights: {self.molecular_weights}",
+            f"CDSs: {len(self.cds_predictions)}",
+        ]
 
-        string += '\nCDSs: {}'.format(len(self.cds_predictions))
         for cds, predictions in self.cds_predictions.items():
-            string += '\n{}\n {}'.format(cds, '\n '.join(map(str, predictions)))
-        return string
+            parts.append(str(cds))
+            parts.append(" " + ("\n ".join(map(str, predictions))))
+        return "\n".join(parts)
 
     def to_json(self) -> Dict[str, Any]:
         """ Converts a ClusterPrediction into a JSON friendly format """
@@ -150,14 +153,14 @@ class T2PKSResults(ModuleResults):
         self.cluster_predictions: Dict[int, ProtoclusterPrediction] = {}
 
     def __repr__(self) -> str:
-        return "T2PKSResults(clusters=%s)" % list(self.cluster_predictions)
+        return f"T2PKSResults(clusters={list(self.cluster_predictions)})"
 
     def __str__(self) -> str:
-        string = ''
+        parts = []
         for cluster_id, prediction in self.cluster_predictions.items():
-            string += 'Protocluster {}\n'.format(cluster_id)
-            string += str(prediction)
-        return string
+            parts.append(f"Protocluster {cluster_id}\n")
+            parts.append(str(prediction))
+        return "".join(parts)
 
     def to_json(self) -> Dict[str, Any]:
         clusters = {cluster_number: pred.to_json() for cluster_number, pred in self.cluster_predictions.items()}

--- a/antismash/modules/t2pks/t2pks_analysis.py
+++ b/antismash/modules/t2pks/t2pks_analysis.py
@@ -304,4 +304,4 @@ def analyse_cluster(cluster: Protocluster, record: Record) -> ProtoclusterPredic
         weights.update(predict_molecular_weight(preds_by_protein, starter_names, elong_names))
 
     return ProtoclusterPrediction(preds_by_cds, starter_units, malonyl_elongations,
-                             product_classes, weights, cluster.location.start, cluster.location.end)
+                                  product_classes, weights, cluster.location.start, cluster.location.end)

--- a/antismash/modules/t2pks/t2pks_analysis.py
+++ b/antismash/modules/t2pks/t2pks_analysis.py
@@ -21,10 +21,10 @@ from antismash.common.secmet import Protocluster, CDSFeature, Record
 
 from .results import ProtoclusterPrediction, CDSPrediction, Prediction
 
-with open(path.get_full_path(__file__, "data", "weights.json"), 'r') as handle:
+with open(path.get_full_path(__file__, "data", "weights.json"), "r", encoding="utf-8") as handle:
     WEIGHTS = json.load(handle)
 
-with open(path.get_full_path(__file__, "data", "classification.json"), 'r') as handle:
+with open(path.get_full_path(__file__, "data", "classification.json"), "r", encoding="utf-8") as handle:
     CLASSIFICATIONS = json.load(handle)
 
 

--- a/antismash/modules/t2pks/t2pks_analysis.py
+++ b/antismash/modules/t2pks/t2pks_analysis.py
@@ -63,7 +63,7 @@ def run_starter_unit_blastp(cds_hmm_hits: Dict[CDSFeature, List[HMMResult]]
                 continue
             blast_database = path.get_full_path(__file__, 'data', hit.hit_id)
             blastp_results.extend(subprocessing.run_blastp(blast_database, query_sequence))
-            blastp_fasta_files.add(path.get_full_path(__file__, 'data', hit.hit_id + '.fasta'))
+            blastp_fasta_files.add(path.get_full_path(__file__, "data", f"{hit.hit_id}.fasta"))
 
     if not blastp_results:
         return {}
@@ -234,7 +234,7 @@ def predict_molecular_weight(preds_by_protein: Dict[str, List[CDSPrediction]],
         starter_weight = WEIGHTS['starter_unit'][unit]
         for elongations in elongation_names:
             for elongation in elongations.split('|'):
-                combo = "%s_%s" % (unit, elongation)
+                combo = f"{unit}_{elongation}"
                 mws[combo] = (starter_weight
                               + int(elongation) * WEIGHTS['malonyl']
                               + tailoring_mw)

--- a/antismash/modules/t2pks/test/test_results.py
+++ b/antismash/modules/t2pks/test/test_results.py
@@ -94,13 +94,13 @@ class TestProtoclusterPrediction(unittest.TestCase):
         classes = {"benzoisochromanequinone"}
         weights = {"acetyl_7": 451.23}
         cluster_pred = ProtoclusterPrediction(preds_by_cds,
-                                         starter_units=starters,
-                                         malonyl_elongations=elongations,
-                                         product_classes=classes,
-                                         molecular_weights=weights,
-                                         start=100,
-                                         end=2000
-                                         )
+                                              starter_units=starters,
+                                              malonyl_elongations=elongations,
+                                              product_classes=classes,
+                                              molecular_weights=weights,
+                                              start=100,
+                                              end=2000
+                                              )
         assert cluster_pred.cds_predictions == preds_by_cds
         assert cluster_pred.starter_units == starters
         assert cluster_pred.malonyl_elongations == elongations
@@ -120,11 +120,11 @@ class TestProtoclusterPrediction(unittest.TestCase):
 
 def build_dummy_cluster_prediction():
     return ProtoclusterPrediction(build_dummy_cds_predictions(),
-                             [Prediction('acetyl', 0., 0.)],
-                             [Prediction('7', 743.5, 1.2e-226)],
-                             {"benzoisochromanequinone"},
-                             {"acetyl_7": 451.23},
-                             start=0, end=1500)
+                                  [Prediction('acetyl', 0., 0.)],
+                                  [Prediction('7', 743.5, 1.2e-226)],
+                                  {"benzoisochromanequinone"},
+                                  {"acetyl_7": 451.23},
+                                  start=0, end=1500)
 
 
 class TestT2PKSResults(unittest.TestCase):

--- a/antismash/modules/tfbs_finder/html_output.py
+++ b/antismash/modules/tfbs_finder/html_output.py
@@ -36,7 +36,7 @@ def will_handle(_products: list[str], _categories: set[str]) -> bool:
 
 
 def generate_html(region_layer: RegionLayer, results: TFBSFinderResults,
-                  _record_layer: RecordLayer, options_layer: OptionsLayer
+                  _record_layer: RecordLayer, _options_layer: OptionsLayer
                   ) -> HTMLSections:
     """ Generates HTML output for the module """
     html = HTMLSections("tfbs-finder")

--- a/antismash/modules/tfbs_finder/test/integration_tfbs_finder.py
+++ b/antismash/modules/tfbs_finder/test/integration_tfbs_finder.py
@@ -2,7 +2,7 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
 # for test files, silence irrelevant and noisy pylint warnings
-# pylint: disable=no-self-use,protected-access,missing-docstring
+# pylint: disable=protected-access,missing-docstring
 
 import unittest
 

--- a/antismash/modules/thiopeptides/__init__.py
+++ b/antismash/modules/thiopeptides/__init__.py
@@ -73,8 +73,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
     failure_messages = []
     for binary_name in ['hmmpfam2']:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate executable for %r" %
-                                    binary_name)
+            failure_messages.append(f"Failed to locate executable for {binary_name}")
     failure_messages.extend(prepare_data(logging_only=True))
     failure_messages.extend(comparippson.check_prereqs(options))
 

--- a/antismash/modules/thiopeptides/rodeo.py
+++ b/antismash/modules/thiopeptides/rodeo.py
@@ -101,7 +101,7 @@ def acquire_rodeo_heuristics(leader: str, core: str,  # pylint: disable=too-many
         tabs.append(0)
     # Leader net charge < 5
     charge_dict = {"E": -1, "D": -1, "K": 1, "R": 1}
-    leader_charge = sum([charge_dict[aa] for aa in leader if aa in charge_dict])
+    leader_charge = sum(charge_dict.get(aa, 0) for aa in leader)
     if leader_charge < 5:
         score += 2
         tabs.append(1)
@@ -126,13 +126,13 @@ def acquire_rodeo_heuristics(leader: str, core: str,  # pylint: disable=too-many
     else:
         tabs.append(0)
     # Core contains >= 2 positive residues
-    if sum([core.count(aa) for aa in "RK"]) >= 2:
+    if sum(core.count(aa) for aa in "RK") >= 2:
         score -= 1
         tabs.append(1)
     else:
         tabs.append(0)
     # Number of heterocyclizable residues to core ratio > 0.4
-    if sum([core.count(aa) for aa in "CST"]) / len(core) >= 0.4:
+    if sum(core.count(aa) for aa in "CST") / len(core) >= 0.4:
         score += 2
         tabs.append(1)
     else:
@@ -177,49 +177,24 @@ def generate_rodeo_svm_csv(leader: str, core: str, previously_gathered_tabs: Lis
     # Ratio of length of leader / length of core
     columns.append(len(core) / len(leader))
     # Ratio of heterocyclizable residues / length of core
-    columns.append(sum([core.count(aa) for aa in "CST"]) / len(core))
+    columns.append(sum(core.count(aa) for aa in "CST") / len(core))
     # Number in leader of each amino acid
     columns += [leader.count(aa) for aa in "ARDNCQEGHILKMFPSTWYV"]
-    # Aromatics in leader
-    columns.append(sum([leader.count(aa) for aa in "FWY"]))
-    # Neg charged in leader
-    columns.append(sum([leader.count(aa) for aa in "DE"]))
-    # Pos charged in leader
-    columns.append(sum([leader.count(aa) for aa in "RK"]))
-    # Charged in leader
-    columns.append(sum([leader.count(aa) for aa in "RKDE"]))
-    # Aliphatic in leader
-    columns.append(sum([leader.count(aa) for aa in "GAVLMI"]))
-    # Hydroxyl in leader
-    columns.append(sum([leader.count(aa) for aa in "ST"]))
+    # groups for aromatics, neg charged, pos charged, aliphatic, and hydroxyl
+    groups = ["FWY", "DE", "RK", "RKDE", "GAVLMI", "ST"]
+    # leader groups
+    for group in groups:
+        columns.append(sum(leader.count(aa) for aa in group))
     # Counts of AAs in core
     columns += [core.count(aa) for aa in "ARDNCQEGHILKMFPSTWYV"]
-    # Aromatics in core
-    columns.append(sum([core.count(aa) for aa in "FWY"]))
-    # Neg charged in core
-    columns.append(sum([core.count(aa) for aa in "DE"]))
-    # Pos charged in core
-    columns.append(sum([core.count(aa) for aa in "RK"]))
-    # Charged in core
-    columns.append(sum([core.count(aa) for aa in "RKDE"]))
-    # Aliphatic in core
-    columns.append(sum([core.count(aa) for aa in "GAVLMI"]))
-    # Hydroxyl in core
-    columns.append(sum([core.count(aa) for aa in "ST"]))
+    # core groups
+    for group in groups:
+        columns.append(sum(core.count(aa) for aa in group))
     # Counts of AAs in entire precursor (leader+core)
     columns += [precursor.count(aa) for aa in "ARDNCQEGHILKMFPSTWYV"]
-    # Aromatics in precursor
-    columns.append(sum([precursor.count(aa) for aa in "FWY"]))
-    # Neg charged in precursor
-    columns.append(sum([precursor.count(aa) for aa in "DE"]))
-    # Pos charged in precursor
-    columns.append(sum([precursor.count(aa) for aa in "RK"]))
-    # Charged in precursor
-    columns.append(sum([precursor.count(aa) for aa in "RKDE"]))
-    # Aliphatic in precursor
-    columns.append(sum([precursor.count(aa) for aa in "GAVLMI"]))
-    # Hydroxyl in precursor
-    columns.append(sum([precursor.count(aa) for aa in "ST"]))
+    # combined groups
+    for group in groups:
+        columns.append(sum(precursor.count(aa) for aa in group))
     return columns
 
 

--- a/antismash/modules/thiopeptides/specific_analysis.py
+++ b/antismash/modules/thiopeptides/specific_analysis.py
@@ -323,7 +323,7 @@ class Thiopeptide:
         """ determines the possible alternative weights assuming one or
             more of the Ser/Thr residues aren't dehydrated
         """
-        if self._alt_weights != []:
+        if self._alt_weights:
             return self._alt_weights
 
         self._calculate_mw()
@@ -334,7 +334,7 @@ class Thiopeptide:
         """ determines the possible mature alternative weights which includes mw,
             monoisotopic mass and alternative weightss due to different hydrated residues
         """
-        if self._mature_alt_weights != []:
+        if self._mature_alt_weights:
             return self._mature_alt_weights
 
         self._calculate_mw()

--- a/antismash/modules/thiopeptides/specific_analysis.py
+++ b/antismash/modules/thiopeptides/specific_analysis.py
@@ -430,7 +430,8 @@ def get_detected_domains(cluster: secmet.Protocluster) -> Set[str]:
 
 def run_non_biosynthetic_phmms(cluster_fasta: str) -> Dict[str, Any]:
     """ Try to identify cleavage site using pHMM """
-    with open(path.get_full_path(__file__, "data", "non_biosyn_hmms", "hmmdetails.txt"), "r") as handle:
+    with open(path.get_full_path(__file__, "data", "non_biosyn_hmms", "hmmdetails.txt"),
+              "r", encoding="utf-8") as handle:
         hmmdetails = [line.split("\t") for line in handle.read().splitlines() if line.count("\t") == 3]
     signature_profiles = [HmmSignature(details[0], details[1], int(details[2]), details[3]) for details in hmmdetails]
     non_biosynthetic_hmms_by_id: Dict[str, Any] = defaultdict(list)

--- a/antismash/modules/thiopeptides/specific_analysis.py
+++ b/antismash/modules/thiopeptides/specific_analysis.py
@@ -225,11 +225,19 @@ class Thiopeptide:
         self._c_cut = ccut
 
     def __repr__(self) -> str:
-        return "Thiopeptide(..%s, %s, %r, %r, %s(%s), %s, %s, %s, %s)" % (
-                        self.end, self.score, self._core,
-                        self.thio_type, self._monoisotopic_weight, self._weight,
-                        self.macrocycle, self.amidation, self.mature_features,
-                        self.c_cut)
+        return (
+            "Thiopeptide("
+            f"..{self.end}, "
+            f"{self.score}, "
+            f"{self._core!r}, "
+            f"{self.thio_type!r}, "
+            f"{self._monoisotopic_weight}({self._weight}), "
+            f"{self.macrocycle}, "
+            f"{self.amidation}, "
+            f"{self.mature_features}, "
+            f"{self.c_cut}"
+            ")"
+        )
 
     def _calculate_mw(self) -> None:
         """
@@ -479,7 +487,7 @@ def determine_precursor_peptide_candidate(query: secmet.CDSFeature, domains: Set
         return None
 
     # Create FASTA sequence for feature under study
-    thio_a_fasta = ">%s\n%s" % (query.get_name(), query_sequence)
+    thio_a_fasta = f">{query.get_name()}\n{query_sequence}"
 
     # Run sequence against pHMM; if positive, parse into a vector containing START, END and SCORE
     end, score = run_cleavage_site_phmm(thio_a_fasta, 'thio_cleave.hmm', -3.00)
@@ -526,7 +534,7 @@ def find_tail(query: secmet.CDSFeature, core: str) -> str:
     thresh_c_hit = -9
 
     temp = core[-10:]
-    core_a_fasta = ">%s\n%s" % (query.get_name(), temp)
+    core_a_fasta = f">{query.get_name()}\n{temp}"
 
     c_term_profile = path.get_full_path(__file__, "data", 'thio_tail.hmm')
     c_hmmer_res = subprocessing.run_hmmpfam2(c_term_profile, core_a_fasta)
@@ -560,7 +568,7 @@ def run_thiopred(query: secmet.CDSFeature, thio_type: str, domains: Set[str]) ->
 
     # leader cleavage "validation"
     profile_pep = path.get_full_path(__file__, "data", 'thiopep2.hmm')
-    core_a_fasta = ">%s\n%s" % (query.get_name(), result.core)
+    core_a_fasta = f">{query.get_name()}\n{result.core}"
     hmmer_res_pep = subprocessing.run_hmmpfam2(profile_pep, core_a_fasta)
 
     thresh_pep_hit = -2

--- a/antismash/modules/thiopeptides/test/integration_thiopeptides.py
+++ b/antismash/modules/thiopeptides/test/integration_thiopeptides.py
@@ -93,7 +93,7 @@ class TestIntegration(unittest.TestCase):
     def test_thiostrepton(self):
         def callback(outdir):
             # make sure the html_output section was tested
-            with open(os.path.join(outdir, "index.html")) as handle:
+            with open(os.path.join(outdir, "index.html"), encoding="utf-8") as handle:
                 content = handle.read()
                 assert "Leader:" in content
 

--- a/antismash/modules/tta/__init__.py
+++ b/antismash/modules/tta/__init__.py
@@ -30,7 +30,7 @@ def check_options(options: ConfigType) -> List[str]:
     """
     issues = []
     if options.tta_threshold < 0 or options.tta_threshold > 1:
-        issues.append("Supplied threshold is out of range 0 to 1: %s" % options.tta_threshold)
+        issues.append(f"Supplied threshold is out of range 0 to 1: {options.tta_threshold}")
     return issues
 
 

--- a/antismash/outputs/html/__init__.py
+++ b/antismash/outputs/html/__init__.py
@@ -57,15 +57,16 @@ def prepare_data(_logging_only: bool = False) -> List[str]:
     flavours = ["bacteria", "fungi", "plants"]
 
     with path.changed_directory(path.get_full_path(__file__, "css")):
-        built_files = [os.path.abspath("%s.css" % flavour) for flavour in flavours]
+        built_files = [os.path.abspath(f"{flavour}.css") for flavour in flavours]
 
         if path.is_outdated(built_files, glob.glob("*.scss")):
             logging.info("CSS files out of date, rebuilding")
 
             for flavour in flavours:
-                target = "%s.css" % flavour
-                assert os.path.exists(flavour + ".scss"), flavour
-                result = scss.Compiler(output_style="expanded").compile(flavour + ".scss")
+                target = f"{flavour}.css"
+                source = f"{flavour}.scss"
+                assert os.path.exists(source), flavour
+                result = scss.Compiler(output_style="expanded").compile(source)
                 assert result
                 with open(target, "w") as out:
                     out.write(result)
@@ -101,7 +102,7 @@ def write(records: List[Record], results: List[Dict[str, ModuleResults]],
     """
     output_dir = options.output_dir
 
-    copy_template_dir('css', output_dir, pattern="%s.css" % options.taxon)
+    copy_template_dir('css', output_dir, pattern=f"{options.taxon}.css")
     copy_template_dir('js', output_dir)
     # if there wasn't an antismash.js in the JS dir, fall back to one in databases
     local_path = os.path.join(output_dir, "js", "antismash.js")

--- a/antismash/outputs/html/__init__.py
+++ b/antismash/outputs/html/__init__.py
@@ -68,7 +68,7 @@ def prepare_data(_logging_only: bool = False) -> List[str]:
                 assert os.path.exists(source), flavour
                 result = scss.Compiler(output_style="expanded").compile(source)
                 assert result
-                with open(target, "w") as out:
+                with open(target, "w", encoding="utf-8") as out:
                     out.write(result)
     return []
 
@@ -117,7 +117,7 @@ def write(records: List[Record], results: List[Dict[str, ModuleResults]],
 
     copy_template_dir('images', output_dir)
 
-    with open(os.path.join(options.output_dir, 'index.html'), 'w') as result_file:
+    with open(os.path.join(options.output_dir, "index.html"), "w", encoding="utf-8") as result_file:
         content = generate_webpage(records, results, options, all_modules)
         # strip all leading whitespace and blank lines, as they're meaningless to HTML
         content = re.sub("^( *|$)", "", content, flags=re.M)

--- a/antismash/outputs/html/generate_html_table.py
+++ b/antismash/outputs/html/generate_html_table.py
@@ -25,7 +25,7 @@ def generate_html_table(outfile_name: str, mibig_entries: List[MibigEntry]) -> N
     """
     os.makedirs(os.path.dirname(outfile_name), exist_ok=True)
 
-    with open(outfile_name, 'w') as handle:
+    with open(outfile_name, "w", encoding="utf-8") as handle:
         env = Environment(autoescape=True, undefined=StrictUndefined,
                           loader=FileSystemLoader(get_full_path(__file__, "templates")))
         template = env.get_template('mibig_hits_table.html')

--- a/antismash/outputs/html/generator.py
+++ b/antismash/outputs/html/generator.py
@@ -23,6 +23,7 @@ from antismash.common.module_results import ModuleResults
 from antismash.common.secmet import Record
 from antismash.common.json import JSONOrf
 from antismash.config import ConfigType
+from antismash.modules import tfbs_finder as tfbs, tta
 from antismash.outputs.html import js
 from antismash.custom_typing import AntismashModule, VisualisationModule
 
@@ -244,7 +245,7 @@ def generate_webpage(records: List[Record], results: List[Dict[str, ModuleResult
                               config=options, job_id=job_id, page_title=page_title,
                               records_without_regions=record_layers_without_regions,
                               svg_tooltip=svg_tooltip, get_region_css=js.get_region_css,
-                              as_js_url=as_js_url,
+                              as_js_url=as_js_url, tta_name=tta.__name__, tfbs_name=tfbs.__name__,
                               )
     return content
 

--- a/antismash/outputs/html/generator.py
+++ b/antismash/outputs/html/generator.py
@@ -105,20 +105,19 @@ def write_regions_js(records: List[Dict[str, Any]], output_dir: str,
         of code"""
 
     with open(os.path.join(output_dir, 'regions.js'), 'w') as handle:
-        handle.write("var recordData = %s;\n" % json.dumps(records, indent=1))
+        handle.write(f"var recordData = {json.dumps(records, indent=1)};\n")
         regions: Dict[str, Any] = {"order": []}
         for record in records:
             for region in record['regions']:
                 regions[region['anchor']] = region
                 regions['order'].append(region['anchor'])
-        handle.write('var all_regions = %s;\n' % json.dumps(regions, indent=1))
+        handle.write(f"var all_regions = {json.dumps(regions, indent=1)};\n")
 
         details = {
             "nrpspks": {region["id"]: region for region in js_domains},
         }
-        handle.write('var details_data = %s;\n' % json.dumps(details, indent=1))
-
-        handle.write('var resultsData = %s;\n' % json.dumps(module_results, indent=1))
+        handle.write(f"var details_data = {json.dumps(details, indent=1)};\n")
+        handle.write(f"var resultsData = {json.dumps(module_results, indent=1)};\n")
 
 
 def generate_html_sections(records: List[RecordLayer], results: Dict[str, Dict[str, ModuleResults]],
@@ -234,7 +233,7 @@ def generate_webpage(records: List[Record], results: List[Dict[str, ModuleResult
                    "Multiple genes and area features can be selected by clicking them while holding the Ctrl key."
                    )
     doc_target = "understanding_output/#the-antismash-5-region-concept"
-    svg_tooltip += "<br>More detailed help is available %s." % docs_link("here", doc_target)
+    svg_tooltip += f"<br>More detailed help is available {docs_link('here', doc_target)}."
 
     as_js_url = build_antismash_js_url(options)
 
@@ -295,5 +294,5 @@ def generate_searchgtr_htmls(records: List[Record], options: ConfigType) -> None
             with open(formfileloc, "w") as formfile:
                 specificformtemplate = searchgtrformtemplateparts[0].replace("GlycTr", gene_id)
                 formfile.write(specificformtemplate)
-                formfile.write("%s\n%s" % (gene_id, feature.translation))
+                formfile.write(f"{gene_id}\n{feature.translation}")
                 formfile.write(searchgtrformtemplateparts[1])

--- a/antismash/outputs/html/generator.py
+++ b/antismash/outputs/html/generator.py
@@ -104,7 +104,7 @@ def write_regions_js(records: List[Dict[str, Any]], output_dir: str,
     """ Writes out the cluster and domain JSONs to file for the javascript sections
         of code"""
 
-    with open(os.path.join(output_dir, 'regions.js'), 'w') as handle:
+    with open(os.path.join(output_dir, "regions.js"), "w", encoding="utf-8") as handle:
         handle.write(f"var recordData = {json.dumps(records, indent=1)};\n")
         regions: Dict[str, Any] = {"order": []}
         for record in records:
@@ -265,7 +265,8 @@ def find_plugins_for_cluster(plugins: List[AntismashModule],
 
 def load_searchgtr_search_form_template() -> List[str]:
     """ for SEARCHGTR HTML files, load search form template """
-    with open(path.get_full_path(__file__, "templates", "searchgtr_form.html"), "r") as handle:
+    with open(path.get_full_path(__file__, "templates", "searchgtr_form.html"),
+              "r", encoding="utf-8") as handle:
         template = handle.read().replace("\r", "\n")
     return template.split("FASTASEQUENCE")
 
@@ -291,7 +292,7 @@ def generate_searchgtr_htmls(records: List[Record], options: ConfigType) -> None
             link_loc = os.path.join("html", feature.get_name() + "_searchgtr.html")
             gene_id = feature.get_name()
             js.searchgtr_links[record.id + "_" + gene_id] = link_loc
-            with open(formfileloc, "w") as formfile:
+            with open(formfileloc, "w", encoding="utf-8") as formfile:
                 specificformtemplate = searchgtrformtemplateparts[0].replace("GlycTr", gene_id)
                 formfile.write(specificformtemplate)
                 formfile.write(f"{gene_id}\n{feature.translation}")

--- a/antismash/outputs/html/js.py
+++ b/antismash/outputs/html/js.py
@@ -18,7 +18,7 @@ from antismash.common.secmet.features.protocluster import SideloadedProtocluster
 from antismash.common.secmet.features.subregion import SideloadedSubRegion
 from antismash.config import ConfigType
 from antismash.detection.tigrfam.tigr_domain import TIGRDomain
-from antismash.modules import clusterblast, tfbs_finder as tfbs, tta
+from antismash.modules import clusterblast, smcog_trees, tfbs_finder as tfbs, tta
 from antismash.outputs.html.generate_html_table import generate_html_table
 
 searchgtr_links: Dict[str, str] = {}  # TODO: refactor away from global
@@ -394,7 +394,7 @@ def get_description(record: Record, feature: CDSFeature, type_: str,
                              "program=blastp;database=pub/transporter.pep;"
                              f"sequence=sequence%%0A{feature.translation}")
 
-    if options.smcog_trees:
+    if smcog_trees in options.all_enabled_modules:
         for note in feature.notes:  # TODO find a better way to store image urls
             if note.startswith('smCOG tree PNG image:'):
                 urls["smcog_tree"] = note.split(':')[-1]

--- a/antismash/outputs/html/templates/regions.html
+++ b/antismash/outputs/html/templates/regions.html
@@ -47,14 +47,14 @@
                 <rect x=0 y=2 height=4 width=8 class="svgene-resistance"></rect>
             </svg>
         {% endcall %}
-        {% if (options.tta_enabled or not options.minimal) and record.get_gc_content() >= options.tta_threshold %}
+        {% if tta_name in results and record.get_gc_content() >= options.tta_threshold %}
             {% call le.symbol_legend('legend-tta-codon', 'TTA codons') %}
                 <svg viewbox="0 0 6 6">
                     <polyline class="svgene-tta-codon" points="3,0 0,6 6,6 3,0">
                 </svg>
             {% endcall %}
         {% endif %}
-        {% if (options.tfbs or not options.minimal) %}
+        {% if tfbs_name in results %}
             {% call le.static_symbol_legend('legend-binding-site', 'binding site') %}
                 <svg viewbox="0 -1 8 8">
                     <g class="svgene-binding-site">

--- a/antismash/outputs/html/test/test_css_components.py
+++ b/antismash/outputs/html/test/test_css_components.py
@@ -19,7 +19,7 @@ class TestClusterCSS(unittest.TestCase):
             "unknown",  # for regions containing only subregions
         }
         less = path.get_full_path(__file__, "..", "css", "secmet.scss")
-        with open(less) as handle:
+        with open(less, encoding="utf-8") as handle:
             for line in handle.readlines():
                 if line.startswith('.'):
                     class_ = line[1:].split()[0]

--- a/antismash/outputs/html/visualisers/generic_domains.py
+++ b/antismash/outputs/html/visualisers/generic_domains.py
@@ -20,11 +20,11 @@ from antismash.outputs.html import js
 assert HmmerResults.schema_version == 2, "HmmerResults version mismatch, update required"
 
 # a simplified and modified version of https://github.com/Alexamk/decRiPPter/tree/master/data/domains
-with open(path.get_full_path(__file__, "data", "pfam_transport.txt")) as _handle:
+with open(path.get_full_path(__file__, "data", "pfam_transport.txt"), encoding="utf-8") as _handle:
     PFAM_TRANSPORT = set(_handle.read().splitlines())
-with open(path.get_full_path(__file__, "data", "pfam_biosynthetic.txt")) as _handle:
+with open(path.get_full_path(__file__, "data", "pfam_biosynthetic.txt"), encoding="utf-8") as _handle:
     PFAM_BIOSYNTHETIC = set(_handle.read().splitlines())
-with open(path.get_full_path(__file__, "data", "pfam_regulatory.txt")) as _handle:
+with open(path.get_full_path(__file__, "data", "pfam_regulatory.txt"), encoding="utf-8") as _handle:
     PFAM_REGULATORY = set(_handle.read().splitlines())
 
 

--- a/antismash/support/genefinding/__init__.py
+++ b/antismash/support/genefinding/__init__.py
@@ -58,7 +58,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
         binaries = ['glimmerhmm']
     for binary_name in binaries:
         if binary_name not in options.executables:
-            failure_messages.append("Failed to locate executable for %r" % binary_name)
+            failure_messages.append(f"Failed to locate executable for {binary_name}")
 
     return failure_messages
 
@@ -100,4 +100,4 @@ def run_on_record(record: Record, options: ConfigType) -> None:
         logging.debug("Running prodigal based genefinding")
         return run_prodigal(record, options)
 
-    raise ValueError("Unknown genefinding tool: %s" % options.genefinding_tool)
+    raise ValueError(f"Unknown genefinding tool: {options.genefinding_tool}")

--- a/antismash/support/genefinding/run_glimmerhmm.py
+++ b/antismash/support/genefinding/run_glimmerhmm.py
@@ -26,7 +26,7 @@ def write_search_fasta(record: Record) -> str:
         Returns:
             the name of the file created
     """
-    filename = "{}.fasta".format(record.id)
+    filename = f"{record.id}.fasta"
     with open(filename, 'w') as handle:
         seqio.write([record.to_biopython()], handle, 'fasta')
     return filename
@@ -41,7 +41,7 @@ def run_external(fasta_filename: str) -> str:
     run_result = execute(glimmerhmm)
     if run_result.stderr.find('ERROR') > -1:
         logging.error("Failed to run GlimmerHMM: %r", run_result.stderr)
-        raise RuntimeError("Failed to run GlimmerHMM: %s" % run_result.stderr)
+        raise RuntimeError(f"Failed to run GlimmerHMM: {run_result.stderr}")
     return run_result.stdout
 
 
@@ -65,5 +65,6 @@ def run_glimmerhmm(record: Record) -> None:
     features = get_features_from_file(handle)["input"]
     for feature in features:
         if len(feature.location) >= (MAX_TRANSLATION_LENGTH * 3) * .9:
-            logging.warning(f"Ignoring potential gene too long for dependencies: {len(feature.location) // 1000}kb")
+            logging.warning("Ignoring potential gene too long for dependencies: %dkb",
+                            len(feature.location) // 1000)
         record.add_biopython_feature(feature)

--- a/antismash/support/genefinding/run_glimmerhmm.py
+++ b/antismash/support/genefinding/run_glimmerhmm.py
@@ -27,7 +27,7 @@ def write_search_fasta(record: Record) -> str:
             the name of the file created
     """
     filename = f"{record.id}.fasta"
-    with open(filename, 'w') as handle:
+    with open(filename, 'w', encoding="utf-8") as handle:
         seqio.write([record.to_biopython()], handle, 'fasta')
     return filename
 

--- a/antismash/support/genefinding/run_prodigal.py
+++ b/antismash/support/genefinding/run_prodigal.py
@@ -43,7 +43,7 @@ def run_prodigal(record: Record, options: ConfigType) -> None:
             logging.error("Failed to run prodigal: %s", err)
             raise RuntimeError(f"prodigal error: {err}")
         found = 0
-        with open(result_file, "r") as handle:
+        with open(result_file, "r", encoding="utf-8") as handle:
             lines = handle.readlines()
         for line in lines:
             # skip first line

--- a/antismash/support/genefinding/run_prodigal.py
+++ b/antismash/support/genefinding/run_prodigal.py
@@ -28,8 +28,8 @@ def run_prodigal(record: Record, options: ConfigType) -> None:
         name = record.id.lstrip('-')
         if not name:
             name = "unknown"
-        fasta_file = '%s.fasta' % name
-        result_file = '%s.predict' % name
+        fasta_file = f"{name}.fasta"
+        result_file = f"{name}.predict"
         write_fasta([name], [str(record.seq)], fasta_file)
 
         # run prodigal
@@ -40,8 +40,8 @@ def run_prodigal(record: Record, options: ConfigType) -> None:
 
         err = execute(prodigal).stderr
         if err.find('Error') > -1:
-            logging.error("Failed to run prodigal: %r", err)
-            raise RuntimeError("prodigal error: %s" % err)
+            logging.error("Failed to run prodigal: %s", err)
+            raise RuntimeError(f"prodigal error: {err}")
         found = 0
         with open(result_file, "r") as handle:
             lines = handle.readlines()
@@ -68,12 +68,12 @@ def run_prodigal(record: Record, options: ConfigType) -> None:
 
             length = end - start
             if length > (MAX_TRANSLATION_LENGTH * 3) * .9:
-                logging.warning(f"Ignoring potential gene too long for dependencies: {length // 1000}kb")
+                logging.warning("Ignoring potential gene too long for dependencies: %dkb", length // 1000)
                 continue
 
             loc = FeatureLocation(start-1, end, strand=strand)
             translation = record.get_aa_translation_from_location(loc)
-            feature = CDSFeature(loc, locus_tag='ctg%s_%s' % (record.record_index, name),
+            feature = CDSFeature(loc, locus_tag=f"ctg{record.record_index}_{name}",
                                  translation=translation, translation_table=record.transl_table)
             record.add_cds_feature(feature)
             found += 1

--- a/antismash/test/integration/integration_antismash.py
+++ b/antismash/test/integration/integration_antismash.py
@@ -146,8 +146,8 @@ class TestModuleData(unittest.TestCase):
 
     def test_prepare_module_data_with_container_data(self):
         modules = get_all_modules()
-        options = build_config(["--databases", "/some/mounted_at_runtime/path"],
-                               isolated=True, modules=modules)
+        build_config(["--databases", "/some/mounted_at_runtime/path"],
+                     isolated=True, modules=modules)
         # there should be no errors for missing databases
         prepare_module_data()
 

--- a/antismash/test/integration/integration_antismash.py
+++ b/antismash/test/integration/integration_antismash.py
@@ -144,7 +144,7 @@ class TestModuleData(unittest.TestCase):
         # there should be no errors for missing databases
         antismash.main.check_prerequisites(modules, options)
 
-    def test_prepare_module_data_with_container_data(self):
+    def test_prepare_data_with_container_data(self):
         modules = get_all_modules()
         build_config(["--databases", "/some/mounted_at_runtime/path"],
                      isolated=True, modules=modules)


### PR DESCRIPTION
Fixes the majority of style issues found via pylint and flake8 that aren't variants of `too-many-*`. 

Some style messages were common enough to justify a single commit for that specific type.