### PR TITLE
Misc fixes

### DIFF
--- a/antismash/download_databases.py
+++ b/antismash/download_databases.py
@@ -442,10 +442,10 @@ def _main() -> None:
         antiSMASH's module data is prepared.
     """
     # Small dance to grab the antiSMASH config for the database dir.
-    # We don't actually want to keep anything else, but we need to load all the
-    # modules to make sure we can parse the file.
+    # All the modules are required to parse the config file,
+    # and any executable paths defined should be kept.
     all_modules = antismash.get_detection_modules() + antismash.get_analysis_modules()
-    config = antismash.config.build_config(args=[], parser=None, isolated=True, modules=all_modules)
+    config = antismash.config.build_config(args=[], parser=None, isolated=False, modules=all_modules)
 
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/antismash/modules/nrps_pks/html_output.py
+++ b/antismash/modules/nrps_pks/html_output.py
@@ -49,11 +49,16 @@ def generate_html(region_layer: RegionLayer, results: NRPS_PKS_Results,
               " (and, for some tools, further expanded for extra details). "
               )
 
-    if not nrps_layer.has_any_polymer():
-        return html
+    template_components = []
+    # only show a polymer tab if there's polymers
+    if nrps_layer.has_any_polymer():
+        template_components.append(("products.html", "NRPS/PKS products", "nrps_pks_products", prod_tt))
 
-    for filename, name, class_name, tooltip in [("products.html", "NRPS/PKS products", "nrps_pks_products", prod_tt),
-                                                ("monomers.html", "NRPS/PKS monomers", "", mon_tt)]:
+    # always include monomers, if available
+    if features_with_domain_predictions:
+        template_components.append(("monomers.html", "NRPS/PKS monomers", "nrps_pks_monomers", mon_tt))
+
+    for filename, name, class_name, tooltip in template_components:
         template = FileTemplate(path.get_full_path(__file__, "templates", filename))
         section = template.render(record=record_layer,
                                   region=nrps_layer,

--- a/antismash/modules/smcog_trees/trees.py
+++ b/antismash/modules/smcog_trees/trees.py
@@ -21,6 +21,7 @@ import matplotlib
 
 from antismash.common import path, fasta, subprocessing
 from antismash.common.secmet import CDSFeature
+from antismash.config import get_config
 
 # silence the matplotlib noisy logging (relevant when options.debug is set)
 logging.getLogger('matplotlib').setLevel(logging.WARNING)
@@ -128,7 +129,8 @@ def draw_tree(input_number: int, output_dir: str, tag: str) -> str:
             the filename of the image generated
     """
     matplotlib.use('Agg')
-    command = ["fasttree", "-quiet", "-fastest", "-noml", f"trimmed_alignment{input_number}.fasta"]
+    command = [get_config().executables.fasttree, "-quiet", "-fastest", "-noml",
+               f"trimmed_alignment{input_number}.fasta"]
     run_result = subprocessing.execute(command)
     if not run_result.successful():
         raise RuntimeError(f"Fasttree failed to run successfully: {run_result.stderr}")

--- a/antismash/outputs/html/templates/cds_detail.html
+++ b/antismash/outputs/html/templates/cds_detail.html
@@ -43,7 +43,7 @@
 
  {% if pfam_notes %}
  <br>
- <span class="bold">PFAM hits:</span>{{collapser_start(feature.get_name(), level="none")}}
+ <span class="bold">Pfam hits:</span>{{collapser_start(feature.get_name(), level="none")}}
  {% for note in pfam_notes %}
   {{note}}<br>
  {% endfor %}
@@ -62,7 +62,7 @@
 
  {% if go_notes %}
   <br>
-  <span class="bold"> Gene Ontology terms for PFAM domains:</span>{{collapser_start(feature.get_name(), level="none")}}
+  <span class="bold">Gene Ontology terms for Pfam domains:</span>{{collapser_start(feature.get_name(), level="none")}}
   {% for note in go_notes %}
    {{note}}<br>
   {% endfor %}


### PR DESCRIPTION
- Fixes database download script not respecting `executable_paths` option, if defined, in antiSMASH config files
- Fixes the `smcog_trees` module not respecting `fasttree` when defined in `executable_paths`
- Changes "PFAM" to "Pfam" in CDS focus panel, since that's the correct casing when not using an accession
- Shows monomer predictions tab for NRPS/PKS regions if any predictions were made, previously this would be hidden along with polymer predictions if no polymers were present (i.e. when no complete NRPS/PKS modules were detected in the region)