### PR TITLE
nrps_pks_domains: add Interface and IBH_Asp domain detection and drawing

### DIFF
--- a/antismash/detection/nrps_pks_domains/module_identification.py
+++ b/antismash/detection/nrps_pks_domains/module_identification.py
@@ -89,6 +89,8 @@ OTHER = {
     "FkbH",
     "GNAT",
     "Hal",
+    "IBH_Asp",  # Aspartate beta-hydroxylyase forming the head part of a fused domain
+    "Interface",  # Interface domain forming the tail part of a fused doman
     "NAD_binding_4",
     "Polyketide_cyc", "Polyketide_cyc2",  # type-II PKS specific
     "PS",
@@ -100,6 +102,8 @@ SPECIAL = {
     "Trans-AT_docking",
     "TIGR01720",  # NRPS domain, between an Epimerase and the next Condensation
 }
+
+FUSED_STARTERS = ADENYLATIONS.union(ACYLTRANSFERASES, {"Interface"})
 
 CLASSIFICATIONS = {
     "A": ADENYLATIONS,
@@ -205,6 +209,10 @@ class Component:
     def is_special(self) -> bool:
         """ Returns True if the component has a special function for specific modules """
         return self.label in SPECIAL
+
+    def is_fused_starter(self) -> bool:
+        """ Returns True if the component can start a fused module even if the head module is complete """
+        return self.label in FUSED_STARTERS
 
     def is_pks_specific(self) -> bool:
         """ Returns True if the component is specific to PKS modules """
@@ -577,9 +585,8 @@ def combine_modules(current: CDSModuleInfo, previous: CDSModuleInfo) -> Optional
         return None
     head = previous.modules[-1]
     tail = current.modules[0]
-    # modules without a starter can be complete, so if the head is just the starter, that's valid
-    # otherwise both modules must be incomplete, or still compatible
-    invalid_tail = tail.is_complete() and not tail.is_starter_module()
+    # complete tails can only be part of a fused module if they start with a domain in FUSED_STARTERS
+    invalid_tail = tail.is_complete() and not tail.components[0].is_fused_starter()
     if head.is_complete() or invalid_tail:
         return None
     # and avoid creating hybrid modules

--- a/antismash/outputs/html/visualisers/nrps_pks_domains.py
+++ b/antismash/outputs/html/visualisers/nrps_pks_domains.py
@@ -70,6 +70,8 @@ _ABBREVIATED_DOMAINS = {
     "PKS_DH2": "DH",
     "PKS_DHt": "DHt",
     "PKS_ER": "ER",
+    "Interface": "I",
+    "IBH_Asp": "βH",
 }
 _CLASS_BY_ABBREVIATION = {
     "A": "adenylation",


### PR DESCRIPTION
Adds detection and drawing for two largely-siderophore-specific NRPS domains, `Interface` and `IBH_Asp`, that were described here: [10.1073/pnas.1903161116](https://www.pnas.org/doi/10.1073/pnas.1903161116). The interface domain is a member of the condensation superfamily, and IBH_Asp is an aspartate beta-hydroxylase that occurs as a fused NRPS domain. 
![image](https://user-images.githubusercontent.com/21180350/220509769-a3c7f841-2509-4fa3-b725-1a4185926e42.png)

* The `IBH_Asp` HMM is part of the NRP-metallophore rule. The HMM was converted to `HMMER3/b` but is otherwise identical and uses the same cutoff. The alignment used to make the `Interface` HMM is [here](https://drive.google.com/file/d/13xmgNwytHNMz1Er7QuIqdfbDXjygrRkS/view?usp=share_link) and the cutoff of 150 was assigned on MIBiG clusters and additional NRP metallophore BGCs (roughly TP>180 and FP<120).
* Domains appear in domain/module drawing as `I` and `OH` (Could be Ox or BH instead? Even βH, if a symbol won't cause problems?)  
* The interface domain is generally preceded by a functional condensation domain on the previous gene, and so an exception was added to allow cross-CDS modules if the second gene starts with an interface domain (example 1). It only works for straightforward cases: no non-NRPS gene in between and both genes have a complete module (see failings in example 2). Fixing this seems like more trouble than it's worth.


Example 1: BGC0000330
![image](https://user-images.githubusercontent.com/21180350/220508137-a6d50195-57e6-4d7e-bece-f330b564f168.png)
![image](https://user-images.githubusercontent.com/21180350/220508192-4c03f5bc-958c-4adf-912d-12648daed11a.png)

Example 2: BGC0002422
![image](https://user-images.githubusercontent.com/21180350/220508581-bf313f61-9fd4-48ea-b2c3-a8e4490430d4.png)
![image](https://user-images.githubusercontent.com/21180350/220508507-b1645398-38d6-42d7-a7f2-4f7091ba1dbf.png)
