### PR TITLE
Better support for using antiSMASH as a library

### DIFF
--- a/antismash/common/html_renderer.py
+++ b/antismash/common/html_renderer.py
@@ -6,7 +6,7 @@
 """
 
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import jinja2 as _jinja2
 from markupsafe import Markup
@@ -284,12 +284,12 @@ class _Template:  # pylint: disable=too-few-public-methods
 
         Non-functional on its own, requires self.template to be set to a jinja Template
     """
-    def __init__(self, template_dir: Optional[str] = None) -> None:
+    def __init__(self, search_path: Optional[Union[str, list[str]]] = None) -> None:
         self.template: Optional[_jinja2.Template] = None
-        if not template_dir:
+        if not search_path:
             loader = _jinja2.BaseLoader()
         else:
-            loader = _jinja2.FileSystemLoader(template_dir)
+            loader = _jinja2.FileSystemLoader(search_path)
         self.env = _jinja2.Environment(loader=loader, autoescape=True,
                                        undefined=_jinja2.StrictUndefined)
 
@@ -322,6 +322,8 @@ class StringTemplate(_Template):  # pylint: disable=too-few-public-methods
 
 class FileTemplate(_Template):  # pylint: disable=too-few-public-methods
     """ A template renderer for file templates """
-    def __init__(self, template_file: str) -> None:
-        super().__init__(os.path.dirname(template_file))
+    def __init__(self, template_file: str, extra_paths: Optional[list[str]] = None) -> None:
+        if extra_paths is None:
+            extra_paths = []
+        super().__init__(search_path=[os.path.dirname(template_file)] + extra_paths)
         self.template = self.env.get_template(os.path.basename(template_file))

--- a/antismash/common/test/test_html_renderer.py
+++ b/antismash/common/test/test_html_renderer.py
@@ -6,6 +6,7 @@
 
 import re
 import unittest
+from unittest.mock import patch
 
 from antismash.common import html_renderer as renderer
 from antismash.config import build_config
@@ -233,3 +234,17 @@ class TestJS(unittest.TestCase):
 
     def test_url_has_version(self):
         assert renderer.get_antismash_js_version() in renderer.get_antismash_js_url()
+
+
+def test_extra_template_paths():
+    with patch.object(renderer._jinja2, "Environment"):
+        with patch.object(renderer._jinja2, "FileSystemLoader") as mocked_loader:
+            renderer.FileTemplate("some/path/template.html")
+            mocked_loader.assert_called_once_with(["some/path"])
+        with patch.object(renderer._jinja2, "FileSystemLoader") as mocked_loader:
+            extras = [
+                "/some/abs/path",
+                "../a/rel/dir",
+            ]
+            renderer.FileTemplate("some/path/template.html", extra_paths=extras)
+            mocked_loader.assert_called_once_with(["some/path"] + extras)

--- a/antismash/config/__init__.py
+++ b/antismash/config/__init__.py
@@ -151,6 +151,10 @@ def build_config(args: List[str], parser: Optional[AntismashParser] = None, isol
         result = parser.parse_args(args)
         result.database_dir = databases
 
+    # set a base value for the record count limit
+    default.__dict__.update({"triggered_limit": False})
+
+    # then update with all the values from config files
     default.__dict__.update(result.__dict__)
     config = Config(default)
     assert isinstance(config, ConfigType)

--- a/antismash/outputs/html/generator.py
+++ b/antismash/outputs/html/generator.py
@@ -29,6 +29,8 @@ from antismash.custom_typing import AntismashModule, VisualisationModule
 
 from .visualisers import gene_table
 
+TEMPLATE_PATH = path.get_full_path(__file__, "templates")
+
 
 def _get_visualisers() -> List[VisualisationModule]:
     """ Gather all the visualisation-only submodules """
@@ -206,7 +208,7 @@ def generate_webpage(records: List[Record], results: List[Dict[str, ModuleResult
     json_records, js_domains, js_results = build_json_data(records, results, options, all_modules)
     write_regions_js(json_records, options.output_dir, js_domains, js_results)
 
-    template = FileTemplate(path.get_full_path(__file__, "templates", "overview.html"))
+    template = FileTemplate(os.path.join(TEMPLATE_PATH, "overview.html"))
 
     options_layer = OptionsLayer(options, all_modules)
     record_layers_with_regions = []
@@ -266,7 +268,7 @@ def find_plugins_for_cluster(plugins: List[AntismashModule],
 
 def load_searchgtr_search_form_template() -> List[str]:
     """ for SEARCHGTR HTML files, load search form template """
-    with open(path.get_full_path(__file__, "templates", "searchgtr_form.html"),
+    with open(os.path.join(TEMPLATE_PATH, "searchgtr_form.html"),
               "r", encoding="utf-8") as handle:
         template = handle.read().replace("\r", "\n")
     return template.split("FASTASEQUENCE")

--- a/antismash/outputs/html/test/test_generation.py
+++ b/antismash/outputs/html/test/test_generation.py
@@ -37,7 +37,6 @@ class TestOutput(unittest.TestCase):
 
         # add information normally added by record processing
         record.record_index = 1
-        update_config({"triggered_limit": False})
 
         # make sure HTML is generated without errors
         with TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
* Allows additional directories to be provided to HTML template classes to ease reuse of antiSMASH HTML templates/macros
* Moves the template directory construction to using a constant, so it's able to be overridden if necessary
* Adds a default value for the `triggered_limit` member of the config object, to prevent it from not existing when later required in the case of antiSMASH's record processing not being used