### PR TITLE
Misc fixes

### DIFF
--- a/antismash/detection/hmm_detection/cluster_rules/strict.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/strict.txt
@@ -449,9 +449,9 @@ RULE aminocoumarin
     NEIGHBOURHOOD 10
     CONDITIONS novK or novJ or novI or novH or SpcDK_cou
 
-RULE NRPS-independent-siderophore
+RULE NI-siderophore
     CATEGORY other
-    DESCRIPTION IucA/IucC-like siderophores
+    DESCRIPTION NRPS-independent IucA/IucC-like siderophores
     CUTOFF 20
     NEIGHBOURHOOD 5
     CONDITIONS IucA_IucC

--- a/antismash/detection/nrps_pks_domains/test/integration_domains.py
+++ b/antismash/detection/nrps_pks_domains/test/integration_domains.py
@@ -123,7 +123,7 @@ class TestAnalyses(unittest.TestCase):
             "kirAII": [
                 ["PKS_KS", "Trans-AT-KS", "DB"],
                 ["PKS_KS", "Trans-AT-KS"],  # this has no hit for a further subtype
-                ["PKS_KS", "Trans-AT-KS", "AA"],
+                ["PKS_KS", "Trans-AT-KS", "beta-D-OH"],
             ]
         }
         assert found == expected

--- a/antismash/modules/lanthipeptides/specific_analysis.py
+++ b/antismash/modules/lanthipeptides/specific_analysis.py
@@ -517,7 +517,7 @@ def determine_precursor_peptide_candidate(record: Record, query: CDSFeature, dom
         return None
 
     # Create FASTA sequence for feature under study
-    lan_a_fasta = f">{query.get_name()}\n{query.translation}"
+    lan_a_fasta = f">query\n{query.translation}"
 
     # Run sequence against pHMM; if positive, parse into a vector containing START, END and SCORE
     cleavage_result = run_cleavage_site_phmm(lan_a_fasta, hmmer_profile, THRESH_DICT[lant_class])
@@ -565,7 +565,7 @@ def run_lanthipred(record: Record, query: CDSFeature, lant_class: str,
 
     if lant_class in ("Class-II", "Class-III"):
         profile = path.get_full_path(__file__, hmmer_profiles[lant_class])
-        lan_a_fasta = f">{query.get_name()}\n{query_sequence}"
+        lan_a_fasta = f">query\n{query_sequence}"
         cleavage_result = predict_cleavage_site(profile, lan_a_fasta)
 
         if cleavage_result is None:

--- a/antismash/modules/lassopeptides/specific_analysis.py
+++ b/antismash/modules/lassopeptides/specific_analysis.py
@@ -616,7 +616,7 @@ def determine_precursor_peptide_candidate(record: Record, cluster: Protocluster,
         return None
 
     # Create FASTA sequence for feature under study
-    lasso_a_fasta = f">{query.get_name()}\n{query_sequence}"
+    lasso_a_fasta = f">query\n{query_sequence}"
 
     # Run sequence against pHMM to find the cleavage site position
     end, score = run_cleavage_site_phmm(lasso_a_fasta, 'precursor_2637.hmm', -20.00)
@@ -654,7 +654,7 @@ def run_lassopred(record: Record, cluster: Protocluster, query: CDSFeature) -> O
     thresh_c_hit = -7.5
 
     aux = result.core[(len(result.core) // 2):]
-    core_a_fasta = f">{query.get_name()}\n{aux}"
+    core_a_fasta = f">query\n{aux}"
 
     profile = path.get_full_path(__file__, 'data', c_term_hmmer_profile)
     hmmer_res = subprocessing.run_hmmpfam2(profile, core_a_fasta)

--- a/antismash/modules/thiopeptides/specific_analysis.py
+++ b/antismash/modules/thiopeptides/specific_analysis.py
@@ -488,7 +488,7 @@ def determine_precursor_peptide_candidate(query: secmet.CDSFeature, domains: Set
         return None
 
     # Create FASTA sequence for feature under study
-    thio_a_fasta = f">{query.get_name()}\n{query_sequence}"
+    thio_a_fasta = f">query\n{query_sequence}"
 
     # Run sequence against pHMM; if positive, parse into a vector containing START, END and SCORE
     end, score = run_cleavage_site_phmm(thio_a_fasta, 'thio_cleave.hmm', -3.00)
@@ -517,7 +517,7 @@ def determine_precursor_peptide_candidate(query: secmet.CDSFeature, domains: Set
     return thiopeptide
 
 
-def find_tail(query: secmet.CDSFeature, core: str) -> str:
+def find_tail(core: str) -> str:
     """ Finds the tail of a prepeptide, if it exists
 
         Arguments:
@@ -535,7 +535,7 @@ def find_tail(query: secmet.CDSFeature, core: str) -> str:
     thresh_c_hit = -9
 
     temp = core[-10:]
-    core_a_fasta = f">{query.get_name()}\n{temp}"
+    core_a_fasta = f">query\n{temp}"
 
     c_term_profile = path.get_full_path(__file__, "data", 'thio_tail.hmm')
     c_hmmer_res = subprocessing.run_hmmpfam2(c_term_profile, core_a_fasta)
@@ -569,7 +569,7 @@ def run_thiopred(query: secmet.CDSFeature, thio_type: str, domains: Set[str]) ->
 
     # leader cleavage "validation"
     profile_pep = path.get_full_path(__file__, "data", 'thiopep2.hmm')
-    core_a_fasta = f">{query.get_name()}\n{result.core}"
+    core_a_fasta = f">query\n{result.core}"
     hmmer_res_pep = subprocessing.run_hmmpfam2(profile_pep, core_a_fasta)
 
     thresh_pep_hit = -2
@@ -598,7 +598,7 @@ def run_thiopred(query: secmet.CDSFeature, thio_type: str, domains: Set[str]) ->
         result.leader = result.leader + result.core[:diff]
         result.core = aux
 
-    result.c_cut = find_tail(query, result.core)
+    result.c_cut = find_tail(result.core)
 
     query.gene_functions.add(secmet.GeneFunction.ADDITIONAL, "thiopeptides",
                              "predicted thiopeptide")

--- a/antismash/outputs/html/css/secmet.scss
+++ b/antismash/outputs/html/css/secmet.scss
@@ -127,7 +127,7 @@
     @include secmet(white, crimson, blue);
 }
 
-.NRPS-independent-siderophore {
+.NI-siderophore {
     @include metallophore;
 }
 

--- a/antismash/outputs/html/css/style.scss
+++ b/antismash/outputs/html/css/style.scss
@@ -430,6 +430,11 @@ nav {
     margin-right: 20px;
     border-radius: 5px;
     background-color: #eee;
+
+    & a,.link-like {  // special handling to make both versions look the same
+        background-color: unset;
+        line-height: 100%
+    }
 }
 
 .cluster-rules {

--- a/antismash/outputs/html/css/style.scss
+++ b/antismash/outputs/html/css/style.scss
@@ -45,7 +45,7 @@ a, .clipboard-copy, .link-like {
     cursor: pointer;
     padding-right: 0.3em;
     padding-left: 0.3em;
-    padding-top: 0.3em;
+    padding-top: 0.1em;
     font-size: 95%;  /* just enough to have background between links in text */
 
     &:active {
@@ -980,6 +980,9 @@ rect.generic-type-transport {
 .external-link:after {
     @include decorator();
     font-size: 75%;
+    background-size: 1em 1em;
+    height: 1em;
+    width: 1em;
     background-image: url(../images/external-link-alt-solid.svg);
 }
 


### PR DESCRIPTION
* changes all RiPP modules to not use CDS names in their trivial use of `hmmpfam2` (prevents/fixes #501 style naming problems with older HMMer binaries)
* fixes links in chromium browsers slightly overlapping when lines of lines wrap (e.g. in overview table for a region with many products)
* fixes inconsistency in region SVG and genbank download buttons
* renames rule `NRPS-independent-siderophore` to `NI-siderophore`, adding the extra information in the description