### PR TITLE
hmm_detection: fix off by one in cyanobactin dynamic profile

### DIFF
--- a/antismash/detection/hmm_detection/dynamic_profiles/cyanobactin_precursor.py
+++ b/antismash/detection/hmm_detection/dynamic_profiles/cyanobactin_precursor.py
@@ -55,7 +55,7 @@ def find_hits(record: Record, allowable_misses: int = ALLOWABLE_MISSES) -> Dict[
                 idx -= 12
                 if idx < 0:
                     continue
-            if idx + 15 > len(cds.translation):
+            if idx + 15 >= len(cds.translation):
                 continue
             bitscore = check_match(cds.translation, idx, allowable_misses)
             if bitscore:

--- a/antismash/detection/hmm_detection/dynamic_profiles/test/test_cyanobactin_precursor.py
+++ b/antismash/detection/hmm_detection/dynamic_profiles/test/test_cyanobactin_precursor.py
@@ -22,6 +22,7 @@ class TestCyanobactinPrecursor(unittest.TestCase):
             ("two_mismatches", "MTAANIRPQQVAPVERETISTAKDQSGQVQAQTSQIWGSPVPFAGDDAE"),
             ("random_other_thing", "MAGICHATMAGICCATMAGICRAT"),
             ("too_short", "MAGIC"),
+            ("off_by_one_check", "MCKTLHDTNEGKNLTPFSSGPVR"),
             ("pv_too_early", "MPVMAGICHATMAGICCATMAGICRAT"),
             ("kk_too_late", "MAGICHATMAGICCATMAGICRATKKN")
         ]


### PR DESCRIPTION
Under very specific conditions, the cyanobactin dynamic profile could walk off the end of the translation due to the length check being off by one. This PR fixes that.