### PR TITLE
nrps_pks_domains: Also identify TauD dioxygenase domains

### DIFF
--- a/antismash/detection/nrps_pks_domains/module_identification.py
+++ b/antismash/detection/nrps_pks_domains/module_identification.py
@@ -61,6 +61,7 @@ MODIFIERS = {
     "oMT",
     "Beta_elim_lyase",
     "LPG_synthase_C",
+    "TauD",
 }
 CARRIER_PROTEINS = {
     "ACP",


### PR DESCRIPTION
like in BGC0000424