### PR TITLE
Further fixes for lost protoclusters

### DIFF
--- a/antismash/common/secmet/features/candidate_cluster/formation.py
+++ b/antismash/common/secmet/features/candidate_cluster/formation.py
@@ -83,6 +83,10 @@ def create_candidates_from_protoclusters(protoclusters: List[Protocluster]) -> L
     # finally, create singles for every protocluster not in interleaved or hybrid
     unassigned.extend(singles)  # and those where kind promotion applied
     for cluster in set(unassigned):
+        existing_candidate = existing.get((cluster.location.start, cluster.location.end))
+        # don't add a single if it's the same coordinates as the parent candidate
+        if existing_candidate and cluster in existing_candidate.protoclusters:
+            continue
         candidates.append(CandidateCluster(CandidateClusterKind.SINGLE, [cluster]))
 
     # and as a sanity check, ensure all protoclusters belong to at least one candidate

--- a/antismash/common/secmet/features/candidate_cluster/structures.py
+++ b/antismash/common/secmet/features/candidate_cluster/structures.py
@@ -67,7 +67,7 @@ class CandidateCluster(CDSCollection):
         self._core_location = None
 
     def __repr__(self) -> str:
-        return f"CandidateCluster({self.location}, {self.kind})"
+        return f"CandidateCluster({self.location}, {self.kind}, {self.products})"
 
     def get_candidate_cluster_number(self) -> int:
         """ Returns the candidate clusters's numeric ID, only guaranteed to be consistent for

--- a/antismash/common/secmet/features/candidate_cluster/test/test_formation.py
+++ b/antismash/common/secmet/features/candidate_cluster/test/test_formation.py
@@ -184,23 +184,22 @@ class TestCreation(unittest.TestCase):
         assert created[2].location == FeatureLocation(1050, 4000)
 
     def test_contained_neighbours(self):
+        # if a larger protocluster contains another entirely in its neighbourhood
+        # it shouldn't create a single which has the exact same coordinates
+        # as the neighbour
         big = create_cluster(0, 100, 130, 230, "a")
         small = create_cluster(10, 20, 30, 40, "b")
 
         created = creator([big, small])
 
-        assert len(created) == 3
+        assert len(created) == 2
         assert created[0].kind == CandidateCluster.kinds.NEIGHBOURING
         assert created[0].location == big.location
         assert created[0].products == ["a", "b"]
 
         assert created[1].kind == CandidateCluster.kinds.SINGLE
-        assert created[1].location == big.location
-        assert created[1].products == ["a"]
-
-        assert created[2].kind == CandidateCluster.kinds.SINGLE
-        assert created[2].location == small.location
-        assert created[2].products == ["b"]
+        assert created[1].location == small.location
+        assert created[1].products == ["b"]
 
     def test_multiple_contained_in_hybrid(self):
         clusters = [

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -344,7 +344,7 @@ class CDSFeature(Feature):
         return str(self)
 
     def __str__(self) -> str:
-        return f"CDS(self.get_name(), {self.location})"
+        return f"CDS({self.get_name()}, {self.location})"
 
     def strip_antismash_annotations(self) -> None:
         """ Remove all antiSMASH-specific annotations from the feature """


### PR DESCRIPTION
In some rare circumstances, it was possible for protoclusters to be lost. This typically happened on contig edges, when a cluster was considered "interleaved" but only had a very minor overlap, such that a candidate that had the same coordinates as another would've been created but was being dropped, which also potentially dropped one or more protoclusters.

This PR fixes the known cases of these lost protoclusters by "promoting" any orphaned protocluster into the more strict type that already existed at those coordinates. For these protoclusters that are promoted, a SINGLE candidate cluster will also be created, unless there's already another stronger candidate cluster at those specific coordinates as well (likely only to happen on contig boundaries).

A related change is that it is no longer true that all protoclusters in a NEIGHBOURING candidate will have a matching SINGLE. In the case that the SINGLE's coordinates already exist as a candidate (e.g. for a neighbouring case where a small protocluster is entirely contained within the neighbourhood of a larger protocluster), it will not be created.

Also fixes/improves a couple of repr strings for related classes.