### PR TITLE
Small fixes

### DIFF
--- a/antismash/common/secmet/features/module.py
+++ b/antismash/common/secmet/features/module.py
@@ -60,12 +60,13 @@ class Module(Feature):
 
         # if the parent CDSes are on the reverse strand, the domains are in the wrong order
         # so ensure they're sorted here as they appear in the translation
-        reverse = domains[0].location.strand == -1
+        strand = domains[0].location.strand
+        reverse = strand == -1
         domains = sorted(domains, key=lambda x: x.location.start, reverse=reverse)
         if reverse:
-            location = FeatureLocation(domains[-1].location.start, domains[0].location.end)
+            location = FeatureLocation(domains[-1].location.start, domains[0].location.end, strand=strand)
         else:
-            location = FeatureLocation(domains[0].location.start, domains[-1].location.end)
+            location = FeatureLocation(domains[0].location.start, domains[-1].location.end, strand=strand)
         super().__init__(location, self.FEATURE_TYPE, created_by_antismash=True)
 
         if not isinstance(module_type, ModuleType):

--- a/antismash/common/secmet/features/test/test_module.py
+++ b/antismash/common/secmet/features/test/test_module.py
@@ -237,3 +237,12 @@ class TestModule(unittest.TestCase):
         assert module.get_parent_protein_location("B") == FeatureLocation(1, 6)
         with self.assertRaisesRegex(ValueError, "has no parent"):
             module.get_parent_protein_location("C")
+
+    def test_module_strand(self):
+        for strand in [1, -1]:
+            domains = [
+                DummyAntismashDomain(locus_tag="A", protein_start=5, protein_end=10, strand=strand),
+                DummyAntismashDomain(locus_tag="B", protein_start=15, protein_end=20, strand=strand),
+            ]
+            module = create_module(domains=domains)
+            assert module.location.strand == strand

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -473,6 +473,27 @@ def frameshift_location_by_qualifier(location: Location, raw_start: Union[str, i
     return _adjust_location_by_offset(location, codon_start)
 
 
+def offset_location(location: Location, offset: int) -> Location:
+    """ Creates a new location at the given offset to the original.
+        Will not loop over the origin and offsets cannot make locations negative.
+
+        Arguments:
+            location: the location to shift
+            offset: the amount to offset
+
+        Returns:
+            a new location instance
+    """
+    parts = location.parts
+    new = []
+    for part in parts:
+        assert part.start + offset >= 0
+        new.append(FeatureLocation(part.start + offset, part.end + offset, strand=part.strand))
+    if isinstance(location, CompoundLocation):
+        return CompoundLocation(new, operator=location.operator)
+    return new[0]
+
+
 def remove_redundant_exons(location: Location) -> Location:
     """ Generates a new location that with redudant exons removed.
         Redundant exons are those that cover a location already covered by a larger exon.

--- a/antismash/common/serialiser.py
+++ b/antismash/common/serialiser.py
@@ -69,6 +69,9 @@ class AntismashResults:
         input_file = data["input_file"]
         taxon = data.get("taxon", "bacteria")
         records = [Record.from_biopython(record_from_json(rec), taxon) for rec in data["records"]]
+        for record, rec_json in zip(records, data["records"]):
+            if "original_id" in rec_json:
+                record.original_id = rec_json["original_id"]
         results = [rec["modules"] for rec in data["records"]]
         return AntismashResults(input_file, records, results, version, taxon=taxon)
 
@@ -121,6 +124,8 @@ def dump_records(records: List[SeqRecord], results: List[Dict[str, Union[Dict[st
         secmet = secmet_records[i]
         json_record = record_to_json(record)
         json_record["areas"] = gather_record_areas(secmet)
+        if secmet.original_id:
+            json_record["original_id"] = secmet.original_id
         modules: Dict[str, Dict] = OrderedDict()
         if result:
             logging.debug("Record %s has results for modules: %s", record.id,

--- a/antismash/common/test/test_serialiser.py
+++ b/antismash/common/test/test_serialiser.py
@@ -146,3 +146,21 @@ class TestAreas(unittest.TestCase):
         bio = record.to_biopython()
         full = serialiser.dump_records([bio], [{}], [record])
         assert full[0]["areas"] == results
+
+
+def test_storing_original_ids():
+    records = [
+        DummyRecord(seq="A"*3, record_id="A"),
+        DummyRecord(seq="G"*3, record_id="B"),
+    ]
+    assert records[0].original_id is None
+    records[1].original_id = "some really long name"
+    results = serialiser.AntismashResults("dummy.gbk", records, [{}, {}], "dummy", taxon="dummytaxon")
+    json_handle = StringIO()
+    results.write_to_file(json_handle)
+    json_handle.seek(0)
+    new_results = serialiser.AntismashResults.from_file(json_handle)
+    for old, new in zip(records, new_results.records):
+        assert old.seq == new.seq  # a simple check that other data matches
+        assert old.id == new.id
+        assert old.original_id == new.original_id


### PR DESCRIPTION
- Adds original record ID to JSON output if a record name was truncated (by `--no-allow-long-headers`).
- Fixes region genbank files containing protocluster features with location qualifiers that reported locations as per the full record, rather than just the region. 
- Fixes #579