### PR TITLE
secmet: List genes before other features in Record.get_all_features()

### DIFF
--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -458,8 +458,8 @@ class Record:
             note: This is slow, if only a specific type is required, use
                   the other get_*() functions
         """
-        features = list(self.get_generics())
-        features.extend(self._genes)
+        features: list[Feature] = list(self._genes)
+        features.extend(self.get_generics())
         features.extend(self.get_protoclusters())
         features.extend(self.get_candidate_clusters())
         features.extend(self.get_subregions())


### PR DESCRIPTION
The order of these features matters because this will affect the order of features in the generated GenBank file. Some tools, like bioconvert, rely on the gene feature being the first feature for every location.