### PR TITLE
TFBS fixes/updates

### DIFF
--- a/antismash/modules/tfbs_finder/test/test_tfbs_finder.py
+++ b/antismash/modules/tfbs_finder/test/test_tfbs_finder.py
@@ -32,6 +32,7 @@ from antismash.modules.tfbs_finder.tfbs_finder import (
     PWM_PATH,
 )
 from antismash.modules.tfbs_finder.html_output import (
+    add_neighbouring_genes,
     generate_javascript_data,
     get_sequence_matches,
 )
@@ -221,6 +222,27 @@ class TestFinder(unittest.TestCase):
         assert data[1]['start'] == 1
         assert data[1]['score'] == 40.0
         assert data[1]['confidence'] == 'medium'
+
+    def test_contained_gene(self):
+        hit = {"start": 5, "end": 15}
+        genes = [DummyCDS(start=0, end=3), DummyCDS(start=8, end=11), DummyCDS(start=13, end=18, strand=-1)]
+        results = add_neighbouring_genes(hit, genes)
+        assert results["left"] == {
+            "location": 3,
+            "name": genes[0].get_name(),
+            "strand": 1,
+        }
+        assert results["mid"] == {
+            "location": 8,
+            "length": 3,
+            "name": genes[1].get_name(),
+            "strand": 1,
+        }
+        assert results["right"] == {
+            "location": 13,
+            "name": genes[2].get_name(),
+            "strand": -1,
+        }
 
 
 class TestAreaFinding(unittest.TestCase):

--- a/antismash/modules/tfbs_finder/test/test_tfbs_finder.py
+++ b/antismash/modules/tfbs_finder/test/test_tfbs_finder.py
@@ -8,6 +8,7 @@ import json
 import unittest
 
 from Bio.Seq import Seq
+from Bio.SeqFeature import FeatureLocation
 
 from antismash import get_all_modules
 from antismash.common.secmet.test.helpers import DummyRegion, DummySubRegion
@@ -42,7 +43,7 @@ class TestResults(unittest.TestCase):
     def setUp(self):
         self.record = DummyRecord()
         self.record.id = 'test_record'
-        self.hits_by_region = {1: [TFBSHit('Test1', 1, 'TestHit', 'T', Confidence.STRONG, 1, 10, 10)]}
+        self.hits_by_region = {1: [TFBSHit('Test1', 1, 'TestHit', 'TGA', Confidence.STRONG, 1, 10, 10)]}
 
         build_config([
             "--tfbs",
@@ -105,6 +106,15 @@ class TestResults(unittest.TestCase):
             other = DummyRecord()
             other.id = self.record.id * 2
             results.add_to_record(other)
+
+    def test_new_feature_from_hits(self):
+        data = self.create_results(hits_by_region=self.hits_by_region)
+        assert len(data.features) == 1
+        feature = data.features[0]
+        assert feature.strand == 1
+        assert feature.location == FeatureLocation(1, 4, 1)
+        assert feature.type == "misc_feature"
+        assert feature.created_by_antismash
 
 
 def make_dummy_matrix(name="name"):

--- a/antismash/support/genefinding/run_glimmerhmm.py
+++ b/antismash/support/genefinding/run_glimmerhmm.py
@@ -18,6 +18,8 @@ from antismash.common.secmet import Record
 from antismash.common.secmet.features.cds_feature import MAX_TRANSLATION_LENGTH
 from antismash.common.subprocessing import execute
 
+MIN_TRANSLATION_LENGTH = 10  # anything less than this isn't worth creating
+
 
 def write_search_fasta(record: Record) -> str:
     """ Constructs a FASTA representation of a record and writes it to a
@@ -67,4 +69,7 @@ def run_glimmerhmm(record: Record) -> None:
         if len(feature.location) >= (MAX_TRANSLATION_LENGTH * 3) * .9:
             logging.warning("Ignoring potential gene too long for dependencies: %dkb",
                             len(feature.location) // 1000)
+            continue
+        if len(feature.location) < MIN_TRANSLATION_LENGTH * 3:
+            continue
         record.add_biopython_feature(feature)


### PR DESCRIPTION
Includes what was in #580 before I accidentally remove the changes and it auto-closed; binding sites now create matching features in Genbank output

Also fixes another TFBS crash when incoming gene annotations are poor and mark genes small enough to be fully contained by a binding site. For an example, see attached:
![image](https://user-images.githubusercontent.com/1700735/232738966-62b9c98c-dac4-4859-ab7f-c98b896bef76.png)

The PR also adds a small tweak to glimmerhmm gene finding to prevent this kind of gene annotation, as it was the tool creating the poor quality gene annotations originally.