### PR TITLE
chore: change version from future versions to 'dev'

### DIFF
--- a/antismash/main.py
+++ b/antismash/main.py
@@ -40,7 +40,7 @@ from antismash.outputs import html, svg
 from antismash.support import genefinding
 from antismash.custom_typing import AntismashModule
 
-__version__ = "7.0.0beta2"
+__version__ = "7.dev"
 
 
 def _gather_analysis_modules() -> List[AntismashModule]:


### PR DESCRIPTION
For versioning of development builds, the git hash is already included, so it is less confusing to have just `7.dev-<hash>` than a version which may not exist (e.g. `6.2.0-<hash>` as existed some time ago).