### PR TITLE
pfam2go: Add warning on no pfam detection

### DIFF
--- a/antismash/modules/pfam2go/__init__.py
+++ b/antismash/modules/pfam2go/__init__.py
@@ -26,11 +26,13 @@ def get_arguments() -> ModuleArgs:
     return args
 
 
-def check_options(_options: ConfigType) -> List[str]:
-    """ Checks options for conflicts.
-        No extra options, so they can't have conflicts.
-    """
-    return []
+def check_options(options: ConfigType) -> List[str]:
+    """ Pfam2go requires Pfams """
+    problems = []
+    if is_enabled(options) and not (options.fullhmmer or options.clusterhmmer):
+        problems.append("Pfam2go enabled without an Pfam analysis. "
+                        "The --clusterhmmer or --fullhmmer option is required.")
+    return problems
 
 
 def check_prereqs(_options: ConfigType) -> List[str]:


### PR DESCRIPTION
I forgot the Pfam detection flag was `--clusterhmmer` and not `--pfam`. This autocompleted to `--pfam2go` which happily ran with only this understated debug-level message: `No Pfam domains found in record, cannot create Pfam to Gene Ontology mapping`

Enabling --pfam2go without a hmmer flag now gives the following error: `Pfam2go enabled without an Pfam analysis. The --clusterhmmer or --fullhmmer option is required.`