### PR TITLE
Fix: diamond version subcommand fails with --threads 

### DIFF
--- a/antismash/common/subprocessing/diamond.py
+++ b/antismash/common/subprocessing/diamond.py
@@ -16,12 +16,14 @@ from .base import execute, get_config, RunResult
 
 
 def run_diamond(subcommand: str,
-                opts: Optional[List[str]] = None) -> RunResult:
+                opts: Optional[List[str]] = None,
+                use_default_opts: bool = True) -> RunResult:
     """ Run a diamond subcommand, possibly with further options.
 
         Arguments:
             subcommand: the diamond subcommand to run
             opts: a list of additional argument strings to pass to diamond
+            use_default_opts: use default options for diamond run (e.g. threads, tmpdir)
 
         Returns:
             RunResult of running diamond
@@ -33,9 +35,12 @@ def run_diamond(subcommand: str,
         params = [
             config.executables.diamond,
             subcommand,
+        ]
+        if use_default_opts:
+            params.extend( [
             "--threads", str(config.cpus),
             "--tmpdir", temp_dir,
-        ]
+        ])
 
         if opts:
             params.extend(opts)
@@ -99,7 +104,7 @@ def run_diamond_version() -> str:
             The numeric part of "diamond version"
     """
 
-    version_string = run_diamond("version").stdout
+    version_string = run_diamond("version", use_default_opts=False).stdout
     if not version_string.startswith("diamond version "):
         msg = "unexpected output from diamond-executable: %s, check path"
         raise RuntimeError(msg % get_config().executables.diamond)

--- a/antismash/common/subprocessing/test/test_diamond.py
+++ b/antismash/common/subprocessing/test/test_diamond.py
@@ -17,7 +17,7 @@ from .helpers import DummyResult
 def test_diamond_version(mock_run_diamond):
     version = subprocessing.run_diamond_version()
     assert version == "1.2.3"
-    mock_run_diamond.assert_called_once_with("version")
+    mock_run_diamond.assert_called_once_with("version", use_default_opts=False)
 
 
 @patch("antismash.common.subprocessing.diamond.run_diamond", return_value=DummyResult("lots of useless text"))


### PR DESCRIPTION
Only provide --threads to diamond command when it isn't a 'version' subcommand. 
The 'version' subcommand (breaks with v diamond 2.1.7) will  give these errors:
```
$ diamond version
diamond version 2.1.7

$ diamond version --threads 2
Error: Option is not permitted for this workflow: threads

$ diamond version --tmpdir /scratch/
Error: Option is not permitted for this workflow: tmpdir
```