### PR TITLE
html: swap from pyScss to libsass for CSS generation

### DIFF
--- a/antismash/outputs/html/__init__.py
+++ b/antismash/outputs/html/__init__.py
@@ -13,10 +13,7 @@ import shutil
 from typing import Dict, List, Optional
 import warnings
 
-# silence warnings about nested sets (relevant for pyScss <= 1.3.7 and python >= 3.5)
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    import scss
+import sass
 
 from antismash.common import html_renderer, path
 from antismash.common.module_results import ModuleResults
@@ -66,8 +63,7 @@ def prepare_data(_logging_only: bool = False) -> List[str]:
                 target = f"{flavour}.css"
                 source = f"{flavour}.scss"
                 assert os.path.exists(source), flavour
-                result = scss.Compiler(output_style="expanded").compile(source)
-                assert result
+                result = sass.compile(filename=source, output_style="compact")
                 with open(target, "w", encoding="utf-8") as out:
                     out.write(result)
     return []

--- a/antismash/outputs/html/css/secmet.scss
+++ b/antismash/outputs/html/css/secmet.scss
@@ -5,7 +5,7 @@
     a, a:link, a:visited {
         color: $fg;
     }
-    rect& {
+    @at-root rect#{&} {
         fill: $bg;
         stroke: $highlight;
     }
@@ -215,20 +215,24 @@
     @include hydrocarbon;
 }
 
-.unknown {
+@mixin unknown {
     @include secmet(black, #f2f2f2, black);
 }
 
+.unknown {
+    @include unknown;
+}
+
 .saccharide {
-    @extend .unknown;
+    @include unknown;
 }
 
 .fatty_acid {
-    @extend .unknown;
+    @include unknown;
 }
 
 .halogenated {
-    @extend .unknown;
+    @include unknown;
 }
 
 .hybrid { // needs to remain at the bottom to override all the above

--- a/antismash/outputs/html/css/style.scss
+++ b/antismash/outputs/html/css/style.scss
@@ -1072,7 +1072,7 @@ ul.dropdown-options {
     & .body-details-header,
     & .sidepanel-details-header {
         font-size: 90%;
-        background-color: rgba($antismash-main, 60%);
+        background-color: rgba($antismash-main, 0.6);
         color: white;
         margin-right: 0.1em;
         padding-left: 0.5em;
@@ -1089,7 +1089,7 @@ ul.dropdown-options {
         @include unselectable();
 
         &:hover {
-            background-color: rgba($antismash-main, 80%);
+            background-color: rgba($antismash-main, 0.8);
         }
     }
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     'nrpys >= 0.1.1',
     'pysvg-py3',
     'bcbio-gff',
-    'pyScss',
+    'libsass >= 0.22',
     'matplotlib',
     'scipy',
     'scikit-learn >= 0.19.0',


### PR DESCRIPTION
libsass has the equivalent function as pyScss, but is more reliable and has less warnings/issues with newer python. It does require a few changes to the SCSS file, but after those it builds a mostly identical (barring style and a couple of fixes) CSS file as a result.