### PR TITLE
Misc small changes

### DIFF
--- a/antismash/common/comparippson/data/build_data.py
+++ b/antismash/common/comparippson/data/build_data.py
@@ -126,7 +126,7 @@ def gather_entries(files: List[str]) -> List[Entry]:
                 # some RiPP modules keep motifs in different layouts
                 if name == "thiopeptides":
                     motifs = results["motifs"]
-                elif name in ["lanthipeptides", "sactipeptides", "thiopeptides"]:
+                elif name in ["lanthipeptides", "lassopeptides", "sactipeptides", "thiopeptides"]:
                     motifs = []
                     for _locus, motifs_for_locus in results["motifs"].items():
                         motifs.extend(motifs_for_locus)

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -50,6 +50,8 @@ def _strict_parse(filename: str) -> List[SeqRecord]:
         # strip the "Ignoring" part, since it's not being ignored
         if message.startswith("Ignoring invalid location"):
             message = message[9:]
+        if isinstance(err, AttributeError):
+            message = f"error within parsing library: {message}"
         logging.error('Parsing %r failed: %s', filename, message)
         raise AntismashInputError(message) from err
     finally:

--- a/antismash/common/secmet/features/module.py
+++ b/antismash/common/secmet/features/module.py
@@ -248,4 +248,4 @@ class Module(Feature):
         return module
 
     def __repr__(self) -> str:
-        return f"Module(self.location, {self.module_type}: {[dom.domain for dom in self.domains]}"
+        return f"Module({self.location}, {self.module_type}: {[dom.domain for dom in self.domains]}"

--- a/antismash/common/serialiser.py
+++ b/antismash/common/serialiser.py
@@ -277,7 +277,6 @@ def feature_to_json(feature: SeqFeature) -> Dict[str, Any]:
     """ Creates a JSON representation of a SeqFeature """
     return {"location": str(feature.location),
             "type": feature.type,
-            "id": feature.id,
             "qualifiers": feature.qualifiers}
 
 
@@ -288,5 +287,4 @@ def feature_from_json(data: Union[str, Dict]) -> SeqFeature:
     assert isinstance(data, dict)
     return SeqFeature(location=location_from_string(data["location"]),
                       type=data["type"],
-                      id=data["id"],
                       qualifiers=data["qualifiers"])

--- a/antismash/common/test/test_serialiser.py
+++ b/antismash/common/test/test_serialiser.py
@@ -80,19 +80,14 @@ class TestFeatureSerialiser(unittest.TestCase):
         location = FeatureLocation(1, 6, strand=1)
         f_type = "test type"
         qualifiers = {"a": ["1", "2"], "b": ["3", "4"]}
-        f_id = "dummy id"
         # skipping biopython deprecated members: ref, ref_db, strand, location_operator
 
         feature = SeqFeature(location=location, type=f_type,
-                             qualifiers=qualifiers, id=f_id)
-        print(str(feature))
-
+                             qualifiers=qualifiers)
         json = serialiser.feature_to_json(feature)
         print(json)  # for debugging failures
         new_feature = serialiser.feature_from_json(json)
-        print(str(new_feature))
         assert new_feature.qualifiers == feature.qualifiers
-        assert new_feature.id == feature.id
         assert new_feature.type == feature.type
         assert str(new_feature.location) == str(new_feature.location)
 

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -534,6 +534,11 @@ def advanced_options() -> ModuleArgs:
                      type=int,
                      default=-1,
                      help="Only process the largest <limit> records (default: %(default)s). -1 to disable")
+    group.add_option('--abort-on-invalid-records',
+                     dest="abort_on_invalid_records",
+                     action=argparse.BooleanOptionalAction,
+                     default=True,
+                     help="Abort runs when encountering invalid records instead of skipping them")
     group.add_option('--minlength',
                      dest="minlength",
                      type=int,

--- a/antismash/detection/hmm_detection/cluster_rules/strict.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/strict.txt
@@ -182,7 +182,7 @@ RULE lanthipeptide-class-ii
 
 RULE lanthipeptide-class-iii
     CATEGORY RiPP
-    DESCRIPTION Class III lanthipeptide clusters
+    DESCRIPTION Class III lanthipeptide
     EXAMPLE NCBI FN178622.1 0-6400 labyrinthopeptin
     CUTOFF 20
     NEIGHBOURHOOD 10

--- a/antismash/detection/nrps_pks_domains/domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/domain_identification.py
@@ -248,7 +248,7 @@ def generate_domains(record: Record) -> NRPSPKSDomains:
 
         # combine modules that cross CDS boundaries, if possible and relevant
         info = CDSModuleInfo(cds, modules)
-        if prev and prev.modules and info.modules:
+        if prev and prev.modules and info.modules and prev.cds.region == cds.region:
             combine_modules(info, prev)  # modifies the lists of modules linked in each CDSResult
         prev = info
 

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -541,7 +541,8 @@ def read_data(sequence_file: Optional[str], options: ConfigType) -> serialiser.A
     if sequence_file:
         records = record_processing.parse_input_sequence(
             sequence_file, options.taxon, options.minlength, options.start,
-            options.end, gff_file=options.genefinding_gff3
+            options.end, gff_file=options.genefinding_gff3,
+            ignore_invalid_records=not options.abort_on_invalid_records,
         )
         results = serialiser.AntismashResults(sequence_file.rsplit(os.sep, 1)[-1],
                                               records, [{} for i in records],

--- a/antismash/modules/cluster_compare/html_output.py
+++ b/antismash/modules/cluster_compare/html_output.py
@@ -29,7 +29,7 @@ def generate_html(region_layer: RegionLayer, results: ClusterCompareResults,
     """
 
     html = HTMLSections("cluster-compare")
-    base_tooltip = ("Shows careas that are similar to the current region to a reference database.<br>"
+    base_tooltip = ("Shows areas that are similar to the current region to a reference database.<br>"
                     "Mouseover a score cell in the table to get a breakdown of how "
                     "the score was calculated.")
 

--- a/antismash/modules/nrps_pks/html_output.py
+++ b/antismash/modules/nrps_pks/html_output.py
@@ -43,7 +43,7 @@ def generate_html(region_layer: RegionLayer, results: NRPS_PKS_Results,
     prod_tt = ("Shows estimated product structure and polymer for each candidate cluster in the region. "
                "To show the product, click on the expander or the candidate cluster feature drawn in the overview. "
                )
-    mon_tt = ("Shows the predicted monomers for each adenylation domain and acyltransferase within genes. "
+    mon_tt = ("Shows the predicted substrates for each adenylation domain and acyltransferase within genes. "
               "Each gene prediction can be expanded to view detailed predictions of each domain. "
               "Each prediction can be expanded to view the predictions by tool "
               " (and, for some tools, further expanded for extra details). "
@@ -56,7 +56,7 @@ def generate_html(region_layer: RegionLayer, results: NRPS_PKS_Results,
 
     # always include monomers, if available
     if features_with_domain_predictions:
-        template_components.append(("monomers.html", "NRPS/PKS monomers", "nrps_pks_monomers", mon_tt))
+        template_components.append(("monomers.html", "NRPS/PKS substrates", "nrps_pks_monomers", mon_tt))
 
     for filename, name, class_name, tooltip in template_components:
         template = FileTemplate(path.get_full_path(__file__, "templates", filename))

--- a/antismash/modules/nrps_pks/orderfinder.py
+++ b/antismash/modules/nrps_pks/orderfinder.py
@@ -333,6 +333,13 @@ def find_possible_orders(cds_features: List[CDSFeature], start_cds: Optional[CDS
 
     tails = {v: k for k, v in chains.items()}
 
+    # if the end CDS is the tail end of a split module,
+    # use the beginning of that chain as the 'end CDS'
+    if end_cds:
+        while end_cds in tails:
+            end_cds = tails[end_cds]
+        end_cds = end_cds
+
     cds_to_order = []
     for cds in cds_features:
         # the permutations shouldn't include chained CDSes or the start or end

--- a/antismash/modules/nrps_pks/templates/monomers.html
+++ b/antismash/modules/nrps_pks/templates/monomers.html
@@ -1,6 +1,6 @@
 <div class="more-details">
     <div class="heading">
-      <span>NRPS/PKS monomer predictions</span>
+      <span>NRPS/PKS substrate predictions</span>
       {{help_tooltip(tooltip, "nrps-monomers")}}
     </div>
   <dl class="prediction-text">

--- a/antismash/modules/nrps_pks/test/test_orderfinder.py
+++ b/antismash/modules/nrps_pks/test/test_orderfinder.py
@@ -233,7 +233,7 @@ class TestOrdering(unittest.TestCase):
         best = self.run_ranking_as_genes(n_terms, c_terms, possible_orders)
         assert best == "BAC"
 
-    def test_order_C002271_c19(self):  # pylint: disable=invalid-name
+    def test_order_CP002271_c19(self):  # pylint: disable=invalid-name
         cdss = {}
         for i, name in enumerate(["STAUR_3972", "STAUR_3982", "STAUR_3983",
                                   "STAUR_3984", "STAUR_3985"]):
@@ -327,7 +327,7 @@ class TestEnzymeCounter(unittest.TestCase):
         results = orderfinder.find_candidate_cluster_modular_enzymes(genes)
         return ([cds.get_name() for cds in results[0]], results[1], results[2])
 
-    def test_C002271_c19(self):  # pylint: disable=invalid-name
+    def test_CP002271_c19(self):  # pylint: disable=invalid-name
         gene_names = ['STAUR_3972', 'STAUR_3982', 'STAUR_3983', 'STAUR_3984', 'STAUR_3985']
         gene_domains = {'STAUR_3985': [('ACP',), ('PKS_KS', 'PKS_AT', 'PKS_DH', 'PKS_KR', 'ACP')],
                         'STAUR_3984': [('PKS_KS', 'PKS_AT', 'PKS_DH', 'PKS_KR', 'ACP')],

--- a/antismash/modules/nrps_pks/test/test_orderfinder.py
+++ b/antismash/modules/nrps_pks/test/test_orderfinder.py
@@ -304,6 +304,19 @@ class TestOrdering(unittest.TestCase):
         # again, regardless of where the block is, the order within the block must be fixed
         assert all(check(order, "BCDE") for order in chained)
 
+    def test_chained_end(self):
+        # catches an edge case where order finding generated duplicates of genes
+        # specifically where a single gene contained a termination domain and was
+        # provided as the "end" cds, where it was also the tail end of a chain of
+        # cross-CDS modules
+        cdses = [DummyCDS(1, 2, locus_tag="A"), DummyCDS(3, 4, locus_tag="B")]
+        orders = orderfinder.find_possible_orders(cdses, start_cds=None, end_cds=cdses[-1],
+                                                  chains={cdses[0]: cdses[1]})
+        assert len(orders) == 1
+        order = orders[0]
+        assert len(order) == len(set(order))
+        assert order == cdses
+
 
 class TestEnzymeCounter(unittest.TestCase):
     def run_finder(self, names, modules_by_cds):

--- a/antismash/support/genefinding/run_glimmerhmm.py
+++ b/antismash/support/genefinding/run_glimmerhmm.py
@@ -28,7 +28,7 @@ def write_search_fasta(record: Record) -> str:
         Returns:
             the name of the file created
     """
-    filename = f"{record.id}.fasta"
+    filename = f"r{record.record_index}.fasta"
     with open(filename, 'w', encoding="utf-8") as handle:
         seqio.write([record.to_biopython()], handle, 'fasta')
     return filename

--- a/antismash/support/genefinding/run_prodigal.py
+++ b/antismash/support/genefinding/run_prodigal.py
@@ -28,8 +28,8 @@ def run_prodigal(record: Record, options: ConfigType) -> None:
         name = record.id.lstrip('-')
         if not name:
             name = "unknown"
-        fasta_file = f"{name}.fasta"
-        result_file = f"{name}.predict"
+        fasta_file = f"r{record.record_index}.fasta"
+        result_file = f"r{record.record_index}.predict"
         write_fasta([name], [str(record.seq)], fasta_file)
 
         # run prodigal


### PR DESCRIPTION
Changes:
- Adds a pair of options `--abort-on-invalid-records` (the default) and `--no-abort-on-invalid-records`. The default behaviour is unchanged, but the `no-abort` version will allow runs to simply discard invalid records and continue on those that remain valid
- Improves reporting of some input parsing failures where biopython itself crashes
- Renames the "NRPS/PKS monomers" sidepanel tab in the HTML output to "NRPS/PKS substrates", as only the unmodified substrates are shown
- Rewords the lanthipeptide rules to have consistent description style in order to simplify scraping of those files for uses other than antiSMASH
- Removes the `id` field from JSON output of records which weren't ever used and resulted in a great deal of `id="<unknown id>"` repetition bloating the file size

Fixes:
- Fixes lassopeptides being missed in the CompaRiPPson data generation script
- Fixes possible crashes in genefinding, where using record names for tempfiles could result in filenames being too long for the system (typically only applicable for cases where FASTA files embedded enormous amounts of information in the headers)
- Fixes a rare occurrence of cross-CDS NRPS/PKS modules also being cross-_region_ when the last CDS in a region and the first CDS in the next region were compatible
- Fixes a duplication in NRPS/PKS orderfinding that was only partially fixed in #530, specifically for cases where a single module with a termination domain was present in a CDS that also led with the tail of a cross-CDS module
- Fixes yet another broken string interpolation that I introduced in 8c37552
- Fixes a few typos in tests and tooltips