### PR TITLE
Improve help options

### DIFF
--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -280,58 +280,34 @@ class SplitCommaAction(argparse.Action):
         setattr(namespace, self.dest, str(values).split(","))
 
 
-class ModuleArgs:
-    """ The vehicle for adding module specific arguments in sane groupings.
-        Each module should have a unique prefix for their arguments, for clarity
-        and safety. The prefix only has to be supplied when constructing a
-        ModuleArgs instance, it will be automatically applied to each argument
-        added.
+class _SimpleArgs:
+    """ Groups command line arguments which are unrelated to antiSMASH modules
+    (such as help options). For module specific arguments, use ModuleArgs.
 
-        To add arguments, use the following:
-            for an analysis option (e.g. --pref-general):
-                ModuleArgs.add_analysis_toggle('general', ...)
-            for a module config option (e.g. --pref-max-size):
-                ModuleArgs.add_option('max-size', ...)
+    To add arguments, use the following:
+            _SimpleArgs.add_option('max-size', ...)
 
-        Arguments:
-            title: The label shown on the help screen
-            prefix: A prefix to use for all options used by the module
-            override_safeties: If True, overrides many safety and consistency
-                    checks, only exists to help placeholders and will be removed
-            enabled_by_default: whether the module's analysis will be on by
-                    default or whether it has to be specifically enabled,
-                    if True, it will create a --enable-* arg to be used if
-                    --minimal is provided.
-            basic_help: Whether help for module options (not analysis toggles)
-                    should be shown in the basic --help output.
-    """
-    def __init__(self, title: str, prefix: str, override_safeties: bool = False,
-                 enabled_by_default: bool = False, basic_help: bool = False) -> None:
+    Arguments:
+        title: The label shown on the help screen
+        override_safeties: If True, overrides many safety and consistency
+            checks, only exists to help placeholders and will be removed
+        basic_help: Whether help for module options (not analysis toggles)
+            should be shown in the basic --help output.
+            """
+    def __init__(self, title: str, override_safeties: bool = False, basic_help: bool = False) -> None:
         if not title:
             raise ValueError("Argument group must have a title")
         self.title = str(title)
         self.parser = AntismashParser(parents=[])
         self.override = override_safeties
-        self.enabled_by_default = enabled_by_default
-        # options for the module
+
+        # store options for this argument group
         self.options = self.parser.add_argument_group(title=title, basic=basic_help)
-        # the main analysis toggle(s)
-        self.group = self.parser.add_argument_group(title="Additional analysis",
-                                                    basic=True)
-        # check the prefix is valid
-        if not isinstance(prefix, str):
-            raise TypeError("Argument prefix must be a string")
-        if len(prefix) < 2 and not self.override:
-            raise ValueError("Argument prefixes must be at least 2 chars")
-        if prefix and not prefix[0].isalpha():
-            raise ValueError("Argument prefixes cannot start with numbers")
-        if prefix and not prefix.isalnum():
-            raise ValueError("Argument prefixes must be alphanumeric")
-        self.prefix = prefix
 
         self.skip_type_check = self.override
         self.args: List[argparse.Action] = []
         self.basic = basic_help
+        self.prefix = ""  # core groups won't have one, but needed for writing config files
 
     def add_option(self, name: str, *args: Any, **kwargs: Any) -> None:
         """ Add a commandline option that takes a value """
@@ -346,13 +322,6 @@ class ModuleArgs:
             # if it has a type, ensure the default is that type
             assert isinstance(default, option_type)
         self._add_argument(self.options, name, *args, **kwargs)
-
-    def add_analysis_toggle(self, name: str, *args: Any, **kwargs: Any) -> None:
-        """ Add a simple on-off option to appear in the "Additional analysis"
-            section. Every module that isn't running by default must have one
-            of these arguments.
-        """
-        self._add_argument(self.group, name, *args, **kwargs)
 
     def _add_argument(self, group: argparse._ArgumentGroup, name: str,  # pylint: disable=protected-access
                       *args: Any, **kwargs: Any) -> None:
@@ -411,8 +380,64 @@ class ModuleArgs:
         if not isinstance(name, str) or not isinstance(dest, str):
             raise TypeError("Argument name and dest must be strings")
 
+        return name, dest
+
+
+class ModuleArgs(_SimpleArgs):
+    """ The vehicle for adding module specific arguments in sane groupings.
+        Each module should have a unique prefix for their arguments, for clarity
+        and safety. The prefix only has to be supplied when constructing a
+        ModuleArgs instance, it will be automatically applied to each argument
+        added.
+
+        To add arguments, use the following:
+            for an analysis option (e.g. --pref-general):
+                ModuleArgs.add_analysis_toggle('general', ...)
+            for a module config option (e.g. --pref-max-size):
+                ModuleArgs.add_option('max-size', ...)
+
+        Arguments:
+            title: The label shown on the help screen
+            prefix: A prefix to use for all options used by the module
+            override_safeties: If True, overrides many safety and consistency
+                    checks, only exists to help placeholders and will be removed
+            enabled_by_default: whether the module's analysis will be on by
+                    default or whether it has to be specifically enabled,
+                    if True, it will create a --enable-* arg to be used if
+                    --minimal is provided.
+            basic_help: Whether help for module options (not analysis toggles)
+                    should be shown in the basic --help output.
+    """
+    def __init__(self, title: str, prefix: str, override_safeties: bool = False,
+                  enabled_by_default: bool = False, basic_help: bool = False) -> None:
+        super().__init__(title, override_safeties, basic_help)
+        self.enabled_by_default = enabled_by_default
+        # store options of specific modules
+        self._analysis_toggles = self.parser.add_argument_group(title="Additional analysis",
+                                                    basic=True)
+
+    # check if the prefix is valid
+        if not isinstance(prefix, str):
+            raise TypeError("Argument prefix must be a string")
+        if len(prefix) < 2 and not self.override:
+            raise ValueError("Argument prefixes must be at least 2 chars")
+        if prefix and not prefix[0].isalpha():
+            raise ValueError("Argument prefixes cannot start with numbers")
+        if prefix and not prefix.isalnum():
+            raise ValueError("Argument prefixes must be alphanumeric")
+        self.prefix = prefix
+
+    def add_analysis_toggle(self, name: str, *args: Any, **kwargs: Any) -> None:
+        """ Add a simple on-off option to appear in the "Additional analysis"
+        section. Every module that isn't running by default must have one
+        of these arguments.
+        """
+        self._add_argument(self._analysis_toggles, name, *args, **kwargs)
+
+    def process_names(self, name: str, dest: str) -> Tuple[str, str]:
+        name, dest = super().process_names(name, dest)
+
         # skip the remaining safety checks if set up
-        # required for some core options only
         if self.override:
             return name, dest
 

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -473,7 +473,7 @@ def build_parser(from_config_file: bool = False, modules: List[AntismashModule] 
         Returns:
             an AntismashParser instance with options for all provided modules
     """
-    parents = [basic_options(), output_options(), advanced_options(),
+    parents = [help_options(), basic_options(), output_options(), advanced_options(),
                debug_options()]
     minimal = specific_debugging(modules)
     if minimal:
@@ -491,29 +491,27 @@ def build_parser(from_config_file: bool = False, modules: List[AntismashModule] 
                         metavar='SEQUENCE',
                         nargs="*",
                         help="GenBank/EMBL/FASTA file(s) containing DNA.")
-
-    # optional non-grouped arguments
-    parser.add_argument('-h', '--help',
-                        dest='help',
-                        action='store_true',
-                        default=False,
-                        help="Show this help text.")
-    parser.add_argument('--help-showall',
-                        dest='help_showall',
-                        action='store_true',
-                        default=False,
-                        help="Show full lists of arguments on this help text.")
-    parser.add_argument('-c', '--cpus',
-                        dest='cpus',
-                        type=int,
-                        default=multiprocessing.cpu_count(),
-                        help="How many CPUs to use in parallel. (default: %(default)s)")
     return parser
 
+def help_options() -> _SimpleArgs:
+    """ Constructs help options for antismash. """
+    group = _SimpleArgs("Help options", basic_help=True)
 
-def basic_options() -> ModuleArgs:
+    group.add_option('-h', '--help',
+                    dest='help',
+                    action='store_true',
+                    default=False,
+                    help="Show basic help text.")
+    group.add_option('--help-showall',
+                    dest='help_showall',
+                    action='store_true',
+                    default=False,
+                    help="Show full list of arguments.")
+    return group
+
+def basic_options() -> _SimpleArgs:
     """ Constructs basic options for antismash. """
-    group = ModuleArgs("Basic analysis options", '', override_safeties=True, basic_help=True)
+    group = _SimpleArgs("Basic analysis options", basic_help=True)
 
     group.add_option('--taxon',
                      dest='taxon',
@@ -521,6 +519,11 @@ def basic_options() -> ModuleArgs:
                      choices=['bacteria', 'fungi'],
                      type=str,
                      help="Taxonomic classification of input sequence. (default: %(default)s)")
+    group.add_option('-c', '--cpus',
+                    dest='cpus',
+                    type=int,
+                    default=multiprocessing.cpu_count(),
+                    help="How many CPUs to use in parallel. (default for this machine: %(default)s)")
     return group
 
 

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -513,7 +513,7 @@ def basic_options() -> _SimpleArgs:
     """ Constructs basic options for antismash. """
     group = _SimpleArgs("Basic analysis options", basic_help=True)
 
-    group.add_option('--taxon',
+    group.add_option('-t', '--taxon',
                      dest='taxon',
                      default='bacteria',
                      choices=['bacteria', 'fungi'],

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -524,6 +524,13 @@ def basic_options() -> _SimpleArgs:
                     type=int,
                     default=multiprocessing.cpu_count(),
                     help="How many CPUs to use in parallel. (default for this machine: %(default)s)")
+    group.add_option('--databases',
+                    dest='database_dir',
+                    default=os.path.join(os.path.dirname(os.path.dirname(__file__)), 'databases'),
+                    metavar="PATH",
+                    action=FullPathAction,
+                    type=str,
+                    help="Root directory of the databases (default: %(default)s).")
     return group
 
 
@@ -582,13 +589,6 @@ def advanced_options() -> ModuleArgs:
                      type=int,
                      default=-1,
                      help="End analysis at nucleotide specified")
-    group.add_option('--databases',
-                     dest='database_dir',
-                     default=os.path.join(os.path.dirname(os.path.dirname(__file__)), 'databases'),
-                     metavar="PATH",
-                     action=FullPathAction,
-                     type=str,
-                     help="Root directory of the databases (default: %(default)s).")
     group.add_option('--write-config-file',
                      dest='write_config_file',
                      default="",

--- a/antismash/detection/hmm_detection/__init__.py
+++ b/antismash/detection/hmm_detection/__init__.py
@@ -125,7 +125,7 @@ def get_supported_cluster_types(strictness: str, category: Optional[str] = None)
 def get_arguments() -> ModuleArgs:
     """ Constructs commandline arguments and options for this module
     """
-    args = ModuleArgs('Advanced options', 'hmmdetection')
+    args = ModuleArgs('HMM detection options', 'hmmdetection')
     args.add_option('strictness',
                     dest='strictness',
                     type=str,

--- a/antismash/detection/sideloader/__init__.py
+++ b/antismash/detection/sideloader/__init__.py
@@ -62,7 +62,7 @@ class SideloadAction(argparse.Action):
 def get_arguments() -> ModuleArgs:
     """ Constructs commandline arguments and options for this module
     """
-    args = ModuleArgs("Advanced options", "sideload")
+    args = ModuleArgs("Sideload options", "sideload")
     args.add_option("sideload",
                     dest="sideload",
                     metavar="JSON",


### PR DESCRIPTION
Currently, the default `-h` output does not show that users can access the complete list of antiSMASH options with `--help-showall`.
Therefore, `--help-showall` was added to a new arg group 'Help options' that shows on `-h`.
Because there was no class for non module-related arg groups, a new class _SimpleArgs was created.
This class allows core options to be printed without immediately printing the list of analysis toggles (which is done by the ModuleArgs class).

Also:
- Adds a short form, `-t`, for `--taxon`
- Moves `--databases` flag from advanced to basic options
- Puts sideload and hmm detection options in seperate arg groups