### PR TITLE
comparippson: work around mypy issue

### DIFF
--- a/antismash/common/comparippson/data/build_data.py
+++ b/antismash/common/comparippson/data/build_data.py
@@ -333,13 +333,19 @@ if __name__ == "__main__":
 
     if args.asdb:
         # having this import here avoids needing it at all for mibig mode
-        import antismash
+        # the "from" method of importing is required to work around a mypy issue
+        from antismash.modules import (
+            lanthipeptides,
+            lassopeptides,
+            sactipeptides,
+            thiopeptides,
+        )
         from antismash.common.secmet.locations import location_from_string
         RIPP_MODULES = [
-            antismash.modules.lanthipeptides,
-            antismash.modules.lassopeptides,
-            antismash.modules.sactipeptides,
-            antismash.modules.thiopeptides,
+            lanthipeptides,
+            lassopeptides,
+            sactipeptides,
+            thiopeptides,
         ]
 
     try:


### PR DESCRIPTION
For some reason, on both Python 3.9 and 3.10 on _some_ systems, `mypy` (specifically 0.982, the pinned version) complains about missing attributes in the CompaRiPPson data script. Converting those imports/references from direct access (e.g. `antismash.modules.lassopeptides`) to `from antismash.modules import ...` avoids the issue.