### PR TITLE
hmm_detection: return DUF692 to RiPP-like, since methanobactin is more specific

### DIFF
--- a/antismash/detection/hmm_detection/cluster_rules/relaxed.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/relaxed.txt
@@ -45,7 +45,7 @@ CONDITIONS strepbact or Antimicrobial14 or Bacteriocin_IId or BacteriocIIc_cy
             or LcnG-beta or Cloacin or Linocin_M18
             or TIGR03651 or TIGR03693
             or TIGR03601 or TIGR03795
-            or TIGR03975 or TIGR01193
+            or TIGR03975 or DUF692 or TIGR01193
             or all_YcaO
 
 RULE RRE-containing


### PR DESCRIPTION
When creating the methanobactin rule, which uses DUF692 *and* another profile, the DUF692 profile was removed, resulting in some previously detected RiPP-likes no longer being found.