### PR TITLE
Update stable to 7.0.1

### DIFF
--- a/.github/workflows/pylint_issue_reporter.yml
+++ b/.github/workflows/pylint_issue_reporter.yml
@@ -5,6 +5,9 @@ on: [pull_request_target]
 jobs:
   lint_comparison:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
     # install python
     - uses: actions/setup-python@v4

--- a/antismash/common/comparippson/data/build_data.py
+++ b/antismash/common/comparippson/data/build_data.py
@@ -333,13 +333,19 @@ if __name__ == "__main__":
 
     if args.asdb:
         # having this import here avoids needing it at all for mibig mode
-        import antismash
+        # the "from" method of importing is required to work around a mypy issue
+        from antismash.modules import (
+            lanthipeptides,
+            lassopeptides,
+            sactipeptides,
+            thiopeptides,
+        )
         from antismash.common.secmet.locations import location_from_string
         RIPP_MODULES = [
-            antismash.modules.lanthipeptides,
-            antismash.modules.lassopeptides,
-            antismash.modules.sactipeptides,
-            antismash.modules.thiopeptides,
+            lanthipeptides,
+            lassopeptides,
+            sactipeptides,
+            thiopeptides,
         ]
 
     try:

--- a/antismash/common/comparippson/data/build_data.py
+++ b/antismash/common/comparippson/data/build_data.py
@@ -126,7 +126,7 @@ def gather_entries(files: List[str]) -> List[Entry]:
                 # some RiPP modules keep motifs in different layouts
                 if name == "thiopeptides":
                     motifs = results["motifs"]
-                elif name in ["lanthipeptides", "sactipeptides", "thiopeptides"]:
+                elif name in ["lanthipeptides", "lassopeptides", "sactipeptides", "thiopeptides"]:
                     motifs = []
                     for _locus, motifs_for_locus in results["motifs"].items():
                         motifs.extend(motifs_for_locus)

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -50,6 +50,8 @@ def _strict_parse(filename: str) -> List[SeqRecord]:
         # strip the "Ignoring" part, since it's not being ignored
         if message.startswith("Ignoring invalid location"):
             message = message[9:]
+        if isinstance(err, AttributeError):
+            message = f"error within parsing library: {message}"
         logging.error('Parsing %r failed: %s', filename, message)
         raise AntismashInputError(message) from err
     finally:

--- a/antismash/common/secmet/features/module.py
+++ b/antismash/common/secmet/features/module.py
@@ -248,4 +248,4 @@ class Module(Feature):
         return module
 
     def __repr__(self) -> str:
-        return f"Module(self.location, {self.module_type}: {[dom.domain for dom in self.domains]}"
+        return f"Module({self.location}, {self.module_type}: {[dom.domain for dom in self.domains]}"

--- a/antismash/common/serialiser.py
+++ b/antismash/common/serialiser.py
@@ -277,7 +277,6 @@ def feature_to_json(feature: SeqFeature) -> Dict[str, Any]:
     """ Creates a JSON representation of a SeqFeature """
     return {"location": str(feature.location),
             "type": feature.type,
-            "id": feature.id,
             "qualifiers": feature.qualifiers}
 
 
@@ -288,5 +287,4 @@ def feature_from_json(data: Union[str, Dict]) -> SeqFeature:
     assert isinstance(data, dict)
     return SeqFeature(location=location_from_string(data["location"]),
                       type=data["type"],
-                      id=data["id"],
                       qualifiers=data["qualifiers"])

--- a/antismash/common/subprocessing/diamond.py
+++ b/antismash/common/subprocessing/diamond.py
@@ -16,12 +16,14 @@ from .base import execute, get_config, RunResult
 
 
 def run_diamond(subcommand: str,
-                opts: Optional[List[str]] = None) -> RunResult:
+                opts: Optional[List[str]] = None,
+                use_default_opts: bool = True) -> RunResult:
     """ Run a diamond subcommand, possibly with further options.
 
         Arguments:
             subcommand: the diamond subcommand to run
             opts: a list of additional argument strings to pass to diamond
+            use_default_opts: use default options for diamond run (e.g. threads, tmpdir)
 
         Returns:
             RunResult of running diamond
@@ -33,9 +35,12 @@ def run_diamond(subcommand: str,
         params = [
             config.executables.diamond,
             subcommand,
+        ]
+        if use_default_opts:
+            params.extend( [
             "--threads", str(config.cpus),
             "--tmpdir", temp_dir,
-        ]
+        ])
 
         if opts:
             params.extend(opts)
@@ -99,7 +104,7 @@ def run_diamond_version() -> str:
             The numeric part of "diamond version"
     """
 
-    version_string = run_diamond("version").stdout
+    version_string = run_diamond("version", use_default_opts=False).stdout
     if not version_string.startswith("diamond version "):
         msg = "unexpected output from diamond-executable: %s, check path"
         raise RuntimeError(msg % get_config().executables.diamond)

--- a/antismash/common/subprocessing/test/test_diamond.py
+++ b/antismash/common/subprocessing/test/test_diamond.py
@@ -17,7 +17,7 @@ from .helpers import DummyResult
 def test_diamond_version(mock_run_diamond):
     version = subprocessing.run_diamond_version()
     assert version == "1.2.3"
-    mock_run_diamond.assert_called_once_with("version")
+    mock_run_diamond.assert_called_once_with("version", use_default_opts=False)
 
 
 @patch("antismash.common.subprocessing.diamond.run_diamond", return_value=DummyResult("lots of useless text"))

--- a/antismash/common/test/test_serialiser.py
+++ b/antismash/common/test/test_serialiser.py
@@ -80,19 +80,14 @@ class TestFeatureSerialiser(unittest.TestCase):
         location = FeatureLocation(1, 6, strand=1)
         f_type = "test type"
         qualifiers = {"a": ["1", "2"], "b": ["3", "4"]}
-        f_id = "dummy id"
         # skipping biopython deprecated members: ref, ref_db, strand, location_operator
 
         feature = SeqFeature(location=location, type=f_type,
-                             qualifiers=qualifiers, id=f_id)
-        print(str(feature))
-
+                             qualifiers=qualifiers)
         json = serialiser.feature_to_json(feature)
         print(json)  # for debugging failures
         new_feature = serialiser.feature_from_json(json)
-        print(str(new_feature))
         assert new_feature.qualifiers == feature.qualifiers
-        assert new_feature.id == feature.id
         assert new_feature.type == feature.type
         assert str(new_feature.location) == str(new_feature.location)
 

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -280,58 +280,34 @@ class SplitCommaAction(argparse.Action):
         setattr(namespace, self.dest, str(values).split(","))
 
 
-class ModuleArgs:
-    """ The vehicle for adding module specific arguments in sane groupings.
-        Each module should have a unique prefix for their arguments, for clarity
-        and safety. The prefix only has to be supplied when constructing a
-        ModuleArgs instance, it will be automatically applied to each argument
-        added.
+class _SimpleArgs:
+    """ Groups command line arguments which are unrelated to antiSMASH modules
+    (such as help options). For module specific arguments, use ModuleArgs.
 
-        To add arguments, use the following:
-            for an analysis option (e.g. --pref-general):
-                ModuleArgs.add_analysis_toggle('general', ...)
-            for a module config option (e.g. --pref-max-size):
-                ModuleArgs.add_option('max-size', ...)
+    To add arguments, use the following:
+            _SimpleArgs.add_option('max-size', ...)
 
-        Arguments:
-            title: The label shown on the help screen
-            prefix: A prefix to use for all options used by the module
-            override_safeties: If True, overrides many safety and consistency
-                    checks, only exists to help placeholders and will be removed
-            enabled_by_default: whether the module's analysis will be on by
-                    default or whether it has to be specifically enabled,
-                    if True, it will create a --enable-* arg to be used if
-                    --minimal is provided.
-            basic_help: Whether help for module options (not analysis toggles)
-                    should be shown in the basic --help output.
-    """
-    def __init__(self, title: str, prefix: str, override_safeties: bool = False,
-                 enabled_by_default: bool = False, basic_help: bool = False) -> None:
+    Arguments:
+        title: The label shown on the help screen
+        override_safeties: If True, overrides many safety and consistency
+            checks, only exists to help placeholders and will be removed
+        basic_help: Whether help for module options (not analysis toggles)
+            should be shown in the basic --help output.
+            """
+    def __init__(self, title: str, override_safeties: bool = False, basic_help: bool = False) -> None:
         if not title:
             raise ValueError("Argument group must have a title")
         self.title = str(title)
         self.parser = AntismashParser(parents=[])
         self.override = override_safeties
-        self.enabled_by_default = enabled_by_default
-        # options for the module
+
+        # store options for this argument group
         self.options = self.parser.add_argument_group(title=title, basic=basic_help)
-        # the main analysis toggle(s)
-        self.group = self.parser.add_argument_group(title="Additional analysis",
-                                                    basic=True)
-        # check the prefix is valid
-        if not isinstance(prefix, str):
-            raise TypeError("Argument prefix must be a string")
-        if len(prefix) < 2 and not self.override:
-            raise ValueError("Argument prefixes must be at least 2 chars")
-        if prefix and not prefix[0].isalpha():
-            raise ValueError("Argument prefixes cannot start with numbers")
-        if prefix and not prefix.isalnum():
-            raise ValueError("Argument prefixes must be alphanumeric")
-        self.prefix = prefix
 
         self.skip_type_check = self.override
         self.args: List[argparse.Action] = []
         self.basic = basic_help
+        self.prefix = ""  # core groups won't have one, but needed for writing config files
 
     def add_option(self, name: str, *args: Any, **kwargs: Any) -> None:
         """ Add a commandline option that takes a value """
@@ -346,13 +322,6 @@ class ModuleArgs:
             # if it has a type, ensure the default is that type
             assert isinstance(default, option_type)
         self._add_argument(self.options, name, *args, **kwargs)
-
-    def add_analysis_toggle(self, name: str, *args: Any, **kwargs: Any) -> None:
-        """ Add a simple on-off option to appear in the "Additional analysis"
-            section. Every module that isn't running by default must have one
-            of these arguments.
-        """
-        self._add_argument(self.group, name, *args, **kwargs)
 
     def _add_argument(self, group: argparse._ArgumentGroup, name: str,  # pylint: disable=protected-access
                       *args: Any, **kwargs: Any) -> None:
@@ -411,8 +380,64 @@ class ModuleArgs:
         if not isinstance(name, str) or not isinstance(dest, str):
             raise TypeError("Argument name and dest must be strings")
 
+        return name, dest
+
+
+class ModuleArgs(_SimpleArgs):
+    """ The vehicle for adding module specific arguments in sane groupings.
+        Each module should have a unique prefix for their arguments, for clarity
+        and safety. The prefix only has to be supplied when constructing a
+        ModuleArgs instance, it will be automatically applied to each argument
+        added.
+
+        To add arguments, use the following:
+            for an analysis option (e.g. --pref-general):
+                ModuleArgs.add_analysis_toggle('general', ...)
+            for a module config option (e.g. --pref-max-size):
+                ModuleArgs.add_option('max-size', ...)
+
+        Arguments:
+            title: The label shown on the help screen
+            prefix: A prefix to use for all options used by the module
+            override_safeties: If True, overrides many safety and consistency
+                    checks, only exists to help placeholders and will be removed
+            enabled_by_default: whether the module's analysis will be on by
+                    default or whether it has to be specifically enabled,
+                    if True, it will create a --enable-* arg to be used if
+                    --minimal is provided.
+            basic_help: Whether help for module options (not analysis toggles)
+                    should be shown in the basic --help output.
+    """
+    def __init__(self, title: str, prefix: str, override_safeties: bool = False,
+                  enabled_by_default: bool = False, basic_help: bool = False) -> None:
+        super().__init__(title, override_safeties, basic_help)
+        self.enabled_by_default = enabled_by_default
+        # store options of specific modules
+        self._analysis_toggles = self.parser.add_argument_group(title="Additional analysis",
+                                                    basic=True)
+
+    # check if the prefix is valid
+        if not isinstance(prefix, str):
+            raise TypeError("Argument prefix must be a string")
+        if len(prefix) < 2 and not self.override:
+            raise ValueError("Argument prefixes must be at least 2 chars")
+        if prefix and not prefix[0].isalpha():
+            raise ValueError("Argument prefixes cannot start with numbers")
+        if prefix and not prefix.isalnum():
+            raise ValueError("Argument prefixes must be alphanumeric")
+        self.prefix = prefix
+
+    def add_analysis_toggle(self, name: str, *args: Any, **kwargs: Any) -> None:
+        """ Add a simple on-off option to appear in the "Additional analysis"
+        section. Every module that isn't running by default must have one
+        of these arguments.
+        """
+        self._add_argument(self._analysis_toggles, name, *args, **kwargs)
+
+    def process_names(self, name: str, dest: str) -> Tuple[str, str]:
+        name, dest = super().process_names(name, dest)
+
         # skip the remaining safety checks if set up
-        # required for some core options only
         if self.override:
             return name, dest
 

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -473,7 +473,7 @@ def build_parser(from_config_file: bool = False, modules: List[AntismashModule] 
         Returns:
             an AntismashParser instance with options for all provided modules
     """
-    parents = [basic_options(), output_options(), advanced_options(),
+    parents = [help_options(), basic_options(), output_options(), advanced_options(),
                debug_options()]
     minimal = specific_debugging(modules)
     if minimal:
@@ -491,29 +491,27 @@ def build_parser(from_config_file: bool = False, modules: List[AntismashModule] 
                         metavar='SEQUENCE',
                         nargs="*",
                         help="GenBank/EMBL/FASTA file(s) containing DNA.")
-
-    # optional non-grouped arguments
-    parser.add_argument('-h', '--help',
-                        dest='help',
-                        action='store_true',
-                        default=False,
-                        help="Show this help text.")
-    parser.add_argument('--help-showall',
-                        dest='help_showall',
-                        action='store_true',
-                        default=False,
-                        help="Show full lists of arguments on this help text.")
-    parser.add_argument('-c', '--cpus',
-                        dest='cpus',
-                        type=int,
-                        default=multiprocessing.cpu_count(),
-                        help="How many CPUs to use in parallel. (default: %(default)s)")
     return parser
 
+def help_options() -> _SimpleArgs:
+    """ Constructs help options for antismash. """
+    group = _SimpleArgs("Help options", basic_help=True)
 
-def basic_options() -> ModuleArgs:
+    group.add_option('-h', '--help',
+                    dest='help',
+                    action='store_true',
+                    default=False,
+                    help="Show basic help text.")
+    group.add_option('--help-showall',
+                    dest='help_showall',
+                    action='store_true',
+                    default=False,
+                    help="Show full list of arguments.")
+    return group
+
+def basic_options() -> _SimpleArgs:
     """ Constructs basic options for antismash. """
-    group = ModuleArgs("Basic analysis options", '', override_safeties=True, basic_help=True)
+    group = _SimpleArgs("Basic analysis options", basic_help=True)
 
     group.add_option('--taxon',
                      dest='taxon',
@@ -521,6 +519,11 @@ def basic_options() -> ModuleArgs:
                      choices=['bacteria', 'fungi'],
                      type=str,
                      help="Taxonomic classification of input sequence. (default: %(default)s)")
+    group.add_option('-c', '--cpus',
+                    dest='cpus',
+                    type=int,
+                    default=multiprocessing.cpu_count(),
+                    help="How many CPUs to use in parallel. (default for this machine: %(default)s)")
     return group
 
 

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -513,7 +513,7 @@ def basic_options() -> _SimpleArgs:
     """ Constructs basic options for antismash. """
     group = _SimpleArgs("Basic analysis options", basic_help=True)
 
-    group.add_option('--taxon',
+    group.add_option('-t', '--taxon',
                      dest='taxon',
                      default='bacteria',
                      choices=['bacteria', 'fungi'],

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -534,6 +534,11 @@ def advanced_options() -> ModuleArgs:
                      type=int,
                      default=-1,
                      help="Only process the largest <limit> records (default: %(default)s). -1 to disable")
+    group.add_option('--abort-on-invalid-records',
+                     dest="abort_on_invalid_records",
+                     action=argparse.BooleanOptionalAction,
+                     default=True,
+                     help="Abort runs when encountering invalid records instead of skipping them")
     group.add_option('--minlength',
                      dest="minlength",
                      type=int,

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -524,6 +524,13 @@ def basic_options() -> _SimpleArgs:
                     type=int,
                     default=multiprocessing.cpu_count(),
                     help="How many CPUs to use in parallel. (default for this machine: %(default)s)")
+    group.add_option('--databases',
+                    dest='database_dir',
+                    default=os.path.join(os.path.dirname(os.path.dirname(__file__)), 'databases'),
+                    metavar="PATH",
+                    action=FullPathAction,
+                    type=str,
+                    help="Root directory of the databases (default: %(default)s).")
     return group
 
 
@@ -582,13 +589,6 @@ def advanced_options() -> ModuleArgs:
                      type=int,
                      default=-1,
                      help="End analysis at nucleotide specified")
-    group.add_option('--databases',
-                     dest='database_dir',
-                     default=os.path.join(os.path.dirname(os.path.dirname(__file__)), 'databases'),
-                     metavar="PATH",
-                     action=FullPathAction,
-                     type=str,
-                     help="Root directory of the databases (default: %(default)s).")
     group.add_option('--write-config-file',
                      dest='write_config_file',
                      default="",

--- a/antismash/detection/hmm_detection/__init__.py
+++ b/antismash/detection/hmm_detection/__init__.py
@@ -125,7 +125,7 @@ def get_supported_cluster_types(strictness: str, category: Optional[str] = None)
 def get_arguments() -> ModuleArgs:
     """ Constructs commandline arguments and options for this module
     """
-    args = ModuleArgs('Advanced options', 'hmmdetection')
+    args = ModuleArgs('HMM detection options', 'hmmdetection')
     args.add_option('strictness',
                     dest='strictness',
                     type=str,

--- a/antismash/detection/hmm_detection/cluster_rules/relaxed.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/relaxed.txt
@@ -45,7 +45,7 @@ CONDITIONS strepbact or Antimicrobial14 or Bacteriocin_IId or BacteriocIIc_cy
             or LcnG-beta or Cloacin or Linocin_M18
             or TIGR03651 or TIGR03693
             or TIGR03601 or TIGR03795
-            or TIGR03975 or TIGR01193
+            or TIGR03975 or DUF692 or TIGR01193
             or all_YcaO
 
 RULE RRE-containing

--- a/antismash/detection/hmm_detection/cluster_rules/strict.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/strict.txt
@@ -182,7 +182,7 @@ RULE lanthipeptide-class-ii
 
 RULE lanthipeptide-class-iii
     CATEGORY RiPP
-    DESCRIPTION Class III lanthipeptide clusters
+    DESCRIPTION Class III lanthipeptide
     EXAMPLE NCBI FN178622.1 0-6400 labyrinthopeptin
     CUTOFF 20
     NEIGHBOURHOOD 10

--- a/antismash/detection/nrps_pks_domains/domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/domain_identification.py
@@ -248,7 +248,7 @@ def generate_domains(record: Record) -> NRPSPKSDomains:
 
         # combine modules that cross CDS boundaries, if possible and relevant
         info = CDSModuleInfo(cds, modules)
-        if prev and prev.modules and info.modules:
+        if prev and prev.modules and info.modules and prev.cds.region == cds.region:
             combine_modules(info, prev)  # modifies the lists of modules linked in each CDSResult
         prev = info
 

--- a/antismash/detection/sideloader/__init__.py
+++ b/antismash/detection/sideloader/__init__.py
@@ -62,7 +62,7 @@ class SideloadAction(argparse.Action):
 def get_arguments() -> ModuleArgs:
     """ Constructs commandline arguments and options for this module
     """
-    args = ModuleArgs("Advanced options", "sideload")
+    args = ModuleArgs("Sideload options", "sideload")
     args.add_option("sideload",
                     dest="sideload",
                     metavar="JSON",

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -541,7 +541,8 @@ def read_data(sequence_file: Optional[str], options: ConfigType) -> serialiser.A
     if sequence_file:
         records = record_processing.parse_input_sequence(
             sequence_file, options.taxon, options.minlength, options.start,
-            options.end, gff_file=options.genefinding_gff3
+            options.end, gff_file=options.genefinding_gff3,
+            ignore_invalid_records=not options.abort_on_invalid_records,
         )
         results = serialiser.AntismashResults(sequence_file.rsplit(os.sep, 1)[-1],
                                               records, [{} for i in records],

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -741,6 +741,7 @@ def _run_antismash(sequence_file: Optional[str], options: ConfigType) -> int:
         results.timings_by_record[record.id] = timings
 
     # Write results
+    logging.info("Writing results")
     json_filename = canonical_base_filename(results.input_file, options.output_dir, options)
     json_filename += ".json"
     logging.debug("Writing json results to '%s'", json_filename)

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -40,7 +40,7 @@ from antismash.outputs import html, svg
 from antismash.support import genefinding
 from antismash.custom_typing import AntismashModule
 
-__version__ = "7.0.0"
+__version__ = "7.0.1"
 
 
 def _gather_analysis_modules() -> List[AntismashModule]:

--- a/antismash/modules/cluster_compare/html_output.py
+++ b/antismash/modules/cluster_compare/html_output.py
@@ -29,7 +29,7 @@ def generate_html(region_layer: RegionLayer, results: ClusterCompareResults,
     """
 
     html = HTMLSections("cluster-compare")
-    base_tooltip = ("Shows careas that are similar to the current region to a reference database.<br>"
+    base_tooltip = ("Shows areas that are similar to the current region to a reference database.<br>"
                     "Mouseover a score cell in the table to get a breakdown of how "
                     "the score was calculated.")
 

--- a/antismash/modules/clusterblast/test/integration_clusterblast.py
+++ b/antismash/modules/clusterblast/test/integration_clusterblast.py
@@ -34,6 +34,7 @@ class Base(unittest.TestCase):
         self.diamond_ver_major = _major
         self.diamond_ver_minor = _minor
         self.diamond_ver_patch = _patch
+        self.diamond_version = (_major, _minor, _patch)
         self.old_config = get_config().__dict__
         update_config({"genefinding_gff3": ""})
         self.options = update_config(options)
@@ -104,7 +105,7 @@ class GeneralIntegrationTest(Base):
         return results.general, results
 
     def test_nisin(self, _patched_known):
-        expected_hits = 3 if (self.diamond_ver_major == 2 and self.diamond_ver_patch < 15) else 2
+        expected_hits = 3 if self.diamond_version < (2, 0, 15) else 2
         results = self.check_nisin(expected_hits)
         ranking = results.region_results[0].ranking
         assert len(ranking) == expected_hits

--- a/antismash/modules/nrps_pks/html_output.py
+++ b/antismash/modules/nrps_pks/html_output.py
@@ -43,7 +43,7 @@ def generate_html(region_layer: RegionLayer, results: NRPS_PKS_Results,
     prod_tt = ("Shows estimated product structure and polymer for each candidate cluster in the region. "
                "To show the product, click on the expander or the candidate cluster feature drawn in the overview. "
                )
-    mon_tt = ("Shows the predicted monomers for each adenylation domain and acyltransferase within genes. "
+    mon_tt = ("Shows the predicted substrates for each adenylation domain and acyltransferase within genes. "
               "Each gene prediction can be expanded to view detailed predictions of each domain. "
               "Each prediction can be expanded to view the predictions by tool "
               " (and, for some tools, further expanded for extra details). "
@@ -56,7 +56,7 @@ def generate_html(region_layer: RegionLayer, results: NRPS_PKS_Results,
 
     # always include monomers, if available
     if features_with_domain_predictions:
-        template_components.append(("monomers.html", "NRPS/PKS monomers", "nrps_pks_monomers", mon_tt))
+        template_components.append(("monomers.html", "NRPS/PKS substrates", "nrps_pks_monomers", mon_tt))
 
     for filename, name, class_name, tooltip in template_components:
         template = FileTemplate(path.get_full_path(__file__, "templates", filename))

--- a/antismash/modules/nrps_pks/orderfinder.py
+++ b/antismash/modules/nrps_pks/orderfinder.py
@@ -333,6 +333,13 @@ def find_possible_orders(cds_features: List[CDSFeature], start_cds: Optional[CDS
 
     tails = {v: k for k, v in chains.items()}
 
+    # if the end CDS is the tail end of a split module,
+    # use the beginning of that chain as the 'end CDS'
+    if end_cds:
+        while end_cds in tails:
+            end_cds = tails[end_cds]
+        end_cds = end_cds
+
     cds_to_order = []
     for cds in cds_features:
         # the permutations shouldn't include chained CDSes or the start or end

--- a/antismash/modules/nrps_pks/templates/monomers.html
+++ b/antismash/modules/nrps_pks/templates/monomers.html
@@ -1,6 +1,6 @@
 <div class="more-details">
     <div class="heading">
-      <span>NRPS/PKS monomer predictions</span>
+      <span>NRPS/PKS substrate predictions</span>
       {{help_tooltip(tooltip, "nrps-monomers")}}
     </div>
   <dl class="prediction-text">

--- a/antismash/modules/nrps_pks/test/test_orderfinder.py
+++ b/antismash/modules/nrps_pks/test/test_orderfinder.py
@@ -233,7 +233,7 @@ class TestOrdering(unittest.TestCase):
         best = self.run_ranking_as_genes(n_terms, c_terms, possible_orders)
         assert best == "BAC"
 
-    def test_order_C002271_c19(self):  # pylint: disable=invalid-name
+    def test_order_CP002271_c19(self):  # pylint: disable=invalid-name
         cdss = {}
         for i, name in enumerate(["STAUR_3972", "STAUR_3982", "STAUR_3983",
                                   "STAUR_3984", "STAUR_3985"]):
@@ -327,7 +327,7 @@ class TestEnzymeCounter(unittest.TestCase):
         results = orderfinder.find_candidate_cluster_modular_enzymes(genes)
         return ([cds.get_name() for cds in results[0]], results[1], results[2])
 
-    def test_C002271_c19(self):  # pylint: disable=invalid-name
+    def test_CP002271_c19(self):  # pylint: disable=invalid-name
         gene_names = ['STAUR_3972', 'STAUR_3982', 'STAUR_3983', 'STAUR_3984', 'STAUR_3985']
         gene_domains = {'STAUR_3985': [('ACP',), ('PKS_KS', 'PKS_AT', 'PKS_DH', 'PKS_KR', 'ACP')],
                         'STAUR_3984': [('PKS_KS', 'PKS_AT', 'PKS_DH', 'PKS_KR', 'ACP')],

--- a/antismash/modules/nrps_pks/test/test_orderfinder.py
+++ b/antismash/modules/nrps_pks/test/test_orderfinder.py
@@ -304,6 +304,19 @@ class TestOrdering(unittest.TestCase):
         # again, regardless of where the block is, the order within the block must be fixed
         assert all(check(order, "BCDE") for order in chained)
 
+    def test_chained_end(self):
+        # catches an edge case where order finding generated duplicates of genes
+        # specifically where a single gene contained a termination domain and was
+        # provided as the "end" cds, where it was also the tail end of a chain of
+        # cross-CDS modules
+        cdses = [DummyCDS(1, 2, locus_tag="A"), DummyCDS(3, 4, locus_tag="B")]
+        orders = orderfinder.find_possible_orders(cdses, start_cds=None, end_cds=cdses[-1],
+                                                  chains={cdses[0]: cdses[1]})
+        assert len(orders) == 1
+        order = orders[0]
+        assert len(order) == len(set(order))
+        assert order == cdses
+
 
 class TestEnzymeCounter(unittest.TestCase):
     def run_finder(self, names, modules_by_cds):

--- a/antismash/support/genefinding/run_glimmerhmm.py
+++ b/antismash/support/genefinding/run_glimmerhmm.py
@@ -28,7 +28,7 @@ def write_search_fasta(record: Record) -> str:
         Returns:
             the name of the file created
     """
-    filename = f"{record.id}.fasta"
+    filename = f"r{record.record_index}.fasta"
     with open(filename, 'w', encoding="utf-8") as handle:
         seqio.write([record.to_biopython()], handle, 'fasta')
     return filename

--- a/antismash/support/genefinding/run_prodigal.py
+++ b/antismash/support/genefinding/run_prodigal.py
@@ -28,8 +28,8 @@ def run_prodigal(record: Record, options: ConfigType) -> None:
         name = record.id.lstrip('-')
         if not name:
             name = "unknown"
-        fasta_file = f"{name}.fasta"
-        result_file = f"{name}.predict"
+        fasta_file = f"r{record.record_index}.fasta"
+        result_file = f"r{record.record_index}.predict"
         write_fasta([name], [str(record.seq)], fasta_file)
 
         # run prodigal


### PR DESCRIPTION
Prepares for bugfix release 7.0.1, which fixes some issues identified in antiSMASH 7.0.0 and adds some small quality of life features:

* Fixes issues involving newer diamond versions (2.1 and above)
* Fixes some cross-CDS module behaviour in NRPS/PKS regions
* Fixes a possible crash when record names are extremely long
* Fixes a regression in the `RiPP-like` detection rule causing some clusters to be undetected
* Fixes lassopeptides being omitted from CompaRiPPson database generation
* Improves JSON output size by removing noisy unused fields
* Improves help output
* Improves reporting for some invalid input errors
* Improves miscellaneous descriptions (including detection rules, logging, and HTML output)
* Adds an option to drop invalid records and continue processing remaining records (`--no-abort-on-invalid-records`)