### PR TITLE
Small fixes and improvements

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,6 +6,7 @@ disable=too-few-public-methods
 [MESSAGES CONTROL]
 # raising 'from' is almost entirely false positives
 disable=raise-missing-from
+fail-on=unused-variable,comparison-with-itself,self-assigning-variable
 
 [TYPECHECK]
 ignored-classes=Config,TestCase,Namespace

--- a/antismash/common/all_orfs.py
+++ b/antismash/common/all_orfs.py
@@ -149,7 +149,11 @@ def create_feature_from_location(record: Record, location: FeatureLocation,
         label = 'allorf_{start:0{digits}}_{end:0{digits}}'.format(
             digits=digits, start=(location.start + 1), end=location.end
         )
-    feature = CDSFeature(location, str(record.get_aa_translation_from_location(location)),
+    translation = str(record.get_aa_translation_from_location(location))
+    # always start with methionine for CDS features, even if it had an alternate start codon
+    if translation[0] != "M":
+        translation = "M" + translation[1:]
+    feature = CDSFeature(location, translation,
                          locus_tag=label, protein_id=label, gene=label)
     feature.created_by_antismash = True
     return feature

--- a/antismash/common/comparippson/analysis.py
+++ b/antismash/common/comparippson/analysis.py
@@ -13,7 +13,6 @@ from antismash.common.html_renderer import (
     FileTemplate,
     Markup,
     RIPP_CLASSES,
-    spanned_sequence,
 )
 from antismash.common.subprocessing import execute
 from antismash.config import ConfigType
@@ -107,17 +106,13 @@ class MultiDBResults(JsonConvertible):
         if query not in self.by_query:
             return Markup("")
 
-        if colour_subset:
+        if colour_subset is not None:
             for char in colour_subset:
                 if char not in RIPP_CLASSES:
                     expected = "".join(RIPP_CLASSES)
                     raise ValueError(f"Unknown character(s) '{char}' in subset of '{expected}'")
-
-        def colour_sequence(core: str) -> Markup:
-            if colour_subset is None:
-                return spanned_sequence(core, class_mapping=RIPP_CLASSES)
-            subset = {char: RIPP_CLASSES[char] for char in colour_subset}
-            return spanned_sequence(core, class_mapping=subset)
+        else:
+            colour_subset = "".join(RIPP_CLASSES)
 
         template = FileTemplate(path.get_full_path(__file__, "templates", "generic.html"))
         chunks = []
@@ -146,7 +141,7 @@ class MultiDBResults(JsonConvertible):
             # sort by descending similarity, descending group size, and ascending name, in that order
             # pylint:disable=cell-var-from-loop
             groups.sort(key=lambda g: (-g[0].similarity, -len(hits), db.build_identifier_for_hit(g[0])))
-            chunks.append(template.render(coloured_ripp_sequence=colour_sequence,
+            chunks.append(template.render(colour_subset=colour_subset,
                                           name=display_name, db=db, groups=groups))
             # pylint:enable=cell-var-from-loop
         return Markup("".join(chunks))

--- a/antismash/common/comparippson/templates/generic.html
+++ b/antismash/common/comparippson/templates/generic.html
@@ -8,13 +8,13 @@
 {% macro description(hit) -%}
  <span class="comparippson-description">{{ db.build_description_for_hit(hit) }}</span>
 {%- endmacro %}
-{% macro segment_line(segment) -%}
+{% macro segment_line(segment, colour_subset) -%}
        <div class="comparippson-coordinate">{{ segment.start }}</div>
-       <div class="comparippson-sequence">{{ coloured_ripp_sequence(segment.sequence) }}</div>
+       <div class="comparippson-sequence">{{ coloured_ripp_sequence(segment.sequence, colour_subset=colour_subset) }}</div>
        <div class="comparippson-coordinate">{{ segment.end }}</div>
 {%- endmacro -%}
 
-{%- macro create_hit_block(hit, tail, tail_list) -%}
+{%- macro create_hit_block(hit, tail, tail_list, colour_subset) -%}
     <div class="comparippson-container">
      <span class="comparippson-similarity">{{ "%.1f" % (hit.similarity*100) }}%</span>
      <span class="comparippson-link">{{ link(hit) }}
@@ -28,11 +28,11 @@
       {{ collapser_end() }}{% else %}:{% endif %}</span>
      {{ description(hit) }}
      <div class="comparippson-alignment">
-       {{ segment_line(hit.query) }}
+       {{ segment_line(hit.query, colour_subset) }}
        <div class="comparippson-coordinate"></div>
-       <div class="comparippson-midline">{{ hit.get_consensus(space="\u00A0") }}</div>
+       <div class="comparippson-midline">{{ hit.get_consensus_html(colour_subset=colour_subset) }}</div>
        <div class="comparippson-coordinate"></div>
-       {{ segment_line(hit.reference) }}
+       {{ segment_line(hit.reference, colour_subset) }}
      </div>
    </div>
 {%- endmacro -%}
@@ -45,14 +45,14 @@
   {%- else -%}
   <div class="comparippson-block">
     {% for hit, tail, tail_list in groups[:display_limit] -%}
-     {{ create_hit_block(hit, tail, tail_list) }}
+     {{ create_hit_block(hit, tail, tail_list, colour_subset) }}
     {%- endfor %}
   </div>
   {%- if groups | length > display_limit -%}
   <div class="comparippson-block comparippson-extension">
    with {{ groups | length - display_limit }} more sequence matches {{ collapser_start("comparippson-worse-hits", "none") }}
     {% for hit, tail, tail_list in groups[display_limit:] -%}
-     {{ create_hit_block(hit, tail, tail_list) }}
+     {{ create_hit_block(hit, tail, tail_list, colour_subset) }}
     {% endfor -%}
    {{ collapser_end() }}
   </div>

--- a/antismash/common/hmm_rule_parser/categories.py
+++ b/antismash/common/hmm_rule_parser/categories.py
@@ -1,0 +1,106 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+""" A collection of classes and functions for handling rule categories
+"""
+
+from dataclasses import dataclass
+import json
+from typing import Any, IO, Optional, Type, TypeVar, Union
+
+TRuleCategory = TypeVar("TRuleCategory", bound="RuleCategory")  # pylint: disable=invalid-name
+
+
+@dataclass
+class RuleCategory:
+    """A collection of information about a particular rule category"""
+    name: str
+    description: str
+    version: int = 1
+    parent: Optional["RuleCategory"] = None
+
+    @classmethod
+    def from_json(cls: Type[TRuleCategory], name: str,
+                  entry: dict[str, Union[str, int]],
+                  existing_categories: dict[str, TRuleCategory]) -> TRuleCategory:
+        """Regenerates a RuleCategory instance from a JSON representation"""
+
+        try:
+            description: str = str(entry["description"])  # cast to make mypy happy
+            version: int = int(entry["version"])  # cast to make mypy happy
+        except KeyError as err:
+            raise ValueError(f"missing required rule metadata key '{err}'")
+
+        parent: Optional[RuleCategory] = None
+        if "parent" in entry:
+            parent = existing_categories[str(entry["parent"])]
+
+        if version != 1:
+            raise ValueError(f"Unknown rule category version {version}")
+
+        return cls(name, description, version, parent=parent)
+
+
+def _parse_categories(data: dict[str, Any]) -> list[RuleCategory]:
+    """ Parses categories out from a JSON-like dictionary structure
+
+        Arguments:
+            data: the raw JSON data
+
+        Returns:
+            a dictionary mapping category name to RuleCategory instance
+    """
+    # split entries into two sets, those without parents, then those with parents
+    top_level = {}
+    children = {}
+    for name, metadata in data.items():
+        if "parent" in metadata:
+            if metadata["parent"] not in data:
+                raise ValueError(f"category {name!r} refers to unknown category {metadata['parent']!r}")
+            children[name] = metadata
+        else:
+            top_level[name] = metadata
+
+    categories: dict[str, RuleCategory] = {}
+
+    # run on the top level first, to ensure that they exist to be referenced
+    for group in [top_level, children]:
+        for name, metadata in group.items():
+            categories[name] = RuleCategory.from_json(name, metadata, existing_categories=categories)
+
+    return list(categories.values())
+
+
+_PARSED_FILES: dict[str, list[RuleCategory]] = {}
+
+
+def parse_category_file(handle: Union[str, IO]) -> list[RuleCategory]:
+    """ Parses categories out from a JSON-like dictionary structure
+
+        Arguments:
+            data: the raw JSON data
+
+        Returns:
+            a dictionary mapping category name to RuleCategory instance
+    """
+    # if called before, just return the cached data
+    if isinstance(handle, str):
+        filename = handle
+    else:
+        filename = handle.name
+
+    if filename in _PARSED_FILES:
+        return _PARSED_FILES[filename]
+
+    # not cached, generate
+    if isinstance(handle, str):
+        with open(filename, "r", encoding="utf-8") as real_handle:
+            data = json.load(real_handle)
+    else:
+        data = json.load(handle)
+
+    categories = _parse_categories(data)
+    # and cache for future calls
+    _PARSED_FILES[filename] = categories
+
+    return categories

--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -1174,6 +1174,8 @@ class Parser:  # pylint: disable=too-few-public-methods
         """    CONDITIONS = CONDITION {BINARY_OP CONDITIONS}*;
         """
         conditions: List[Union[Conditions, TokenTypes]] = []
+        if self.current_token is None:
+            raise self._build_syntax_error("Unexpected end of rule, expected conditions")
         lvalue = self._parse_single_condition(allow_cds)
         append_lvalue = True  # capture the lvalue if it's the only thing
         while self.current_token and self.current_token.type in [TokenTypes.AND,

--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -58,7 +58,6 @@ RELATED section of at least one rule.
 Rule can optionally specify an SUPERIORS flag with a list of other rule identifiers
 to which the current rule is considered inferior to. If an inferior rule does
 not cover more than one or more of its superiors, then it will be discarded.
-A rule which is inferior to another rule cannot be superior to a third rule.
 Duplicate ids in the list will cause an error.
 
 Simple replacment aliases can be defined and used like so

--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -204,7 +204,7 @@ class TokenTypes(IntEnum):
     MINIMUM = 7
     CDS = 8
     AND = 9
-    OR = 10  # pylint thinks it's too short, so pylint: disable=invalid-name
+    OR = 10
     NOT = 11
     INT = 12
     COMMA = 13
@@ -331,7 +331,7 @@ class Tokeniser:  # pylint: disable=too-few-public-methods
         self.current_symbol.clear()
 
 
-class Token:  # pylint: disable=too-few-public-methods
+class Token:
     """ Keeps the token details, the text, where it is in the total text block,
         and what type it is """
     def __init__(self, token_text: str, line_number: int, position: int,
@@ -402,7 +402,7 @@ class Details:
         return f"Details(cds={self.cds}, possibilities={self.possibilities})"
 
 
-class ConditionMet:  # pylint: disable=too-few-public-methods
+class ConditionMet:
     """ A container for tracking whether a condition was satisfied along with
         what specific subsections of the condition were matched
     """
@@ -892,7 +892,7 @@ class ExampleRecord:
 
 
 # a typedef, even positions will be a Conditions instance, odd will be TokenTypes
-ConditionList = List[Union[Conditions, TokenTypes]]  # pylint: disable=invalid-name
+ConditionList = list[Union[Conditions, TokenTypes]]
 
 # tokens that mark the start and/or end of a RULE
 _STARTERS = [TokenTypes.RULE, TokenTypes.DEFINE]

--- a/antismash/common/hmm_rule_parser/test/test_categories.py
+++ b/antismash/common/hmm_rule_parser/test/test_categories.py
@@ -1,0 +1,66 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+# for test files, silence irrelevant and noisy pylint warnings
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,consider-using-with
+
+from io import StringIO
+import json
+import unittest
+
+from antismash.common.hmm_rule_parser.categories import (
+    _PARSED_FILES,
+    _parse_categories,
+    parse_category_file,
+)
+
+
+class TestCategoryParsing(unittest.TestCase):
+    def setUp(self):
+        self.data = {
+            "A": {"description": "some desc", "version": 1},
+            "B": {"description": "some other desc", "version": 1},
+        }
+
+    def tearDown(self):
+        _PARSED_FILES.clear()
+
+    def test_no_parents(self):
+        cats = {cat.name: cat for cat in _parse_categories(self.data)}
+        for name, value in self.data.items():
+            assert cats[name].description == value["description"]
+            assert cats[name].version == value["version"]
+            assert cats[name].name == name
+            assert cats[name].parent is None
+        assert len(cats) == len(self.data)
+
+    def test_missing_parents(self):
+        parent = "Z"
+        assert parent not in self.data  # should also be missing
+        self.data["A"]["parent"] = parent
+        with self.assertRaisesRegex(ValueError, "refers to unknown category"):
+            _parse_categories(self.data)
+
+    def test_with_parents(self):
+        self.data["A"]["parent"] = "B"
+        cats = {cat.name: cat for cat in _parse_categories(self.data)}
+        for name, value in self.data.items():
+            assert cats[name].description == value["description"]
+            assert cats[name].version == value["version"]
+        assert cats["A"].parent == cats["B"]
+        assert cats["B"].parent is None
+
+    def test_caching(self):
+        def make_fake_handle():
+            handle = StringIO(json.dumps(self.data))
+            handle.name = "test"  # this exists on real files
+            return handle
+
+        assert not _PARSED_FILES
+        parsed = parse_category_file(make_fake_handle())
+        assert len(parsed) == 2
+        assert len(_PARSED_FILES) == 1
+        reparsed = parse_category_file(make_fake_handle())
+        assert len(_PARSED_FILES) == 1
+        assert reparsed is parsed
+        assert len(parsed) == 2  # check it doesn't duplicate

--- a/antismash/common/hmm_rule_parser/test/test_rule_parser.py
+++ b/antismash/common/hmm_rule_parser/test/test_rule_parser.py
@@ -434,6 +434,10 @@ class RuleParserTest(unittest.TestCase):
         with self.assertRaises(rule_parser.RuleSyntaxError):
             self.parse("RULE name CATEGORY category RELATED")
 
+    def test_empty_conditions(self):
+        with self.assertRaisesRegex(rule_parser.RuleSyntaxError, "expected conditions"):
+            self.parse(format_as_rule("A", 10, 10, ""))
+
     def test_missing_group_close(self):
         with self.assertRaises(rule_parser.RuleSyntaxError):
             self.parse(format_as_rule("A", 10, 10, "(a or b"))

--- a/antismash/common/html_renderer.py
+++ b/antismash/common/html_renderer.py
@@ -138,7 +138,8 @@ def collapser_start(target: str, level: str = "all") -> Markup:
 
 
 def spanned_sequence(sequence: str, class_mapping: Dict[str, str],
-                     substitutions: Dict[str, str] = None) -> Markup:
+                     substitutions: Dict[str, str] = None,
+                     positional_classes: dict[int, str] = None) -> Markup:
     """ Builds an HTML fragment with spans for each character, if a character is
         present in the class mapping, the span will be given that class.
         Substitutions for characters can also be provided in the same way.
@@ -148,17 +149,20 @@ def spanned_sequence(sequence: str, class_mapping: Dict[str, str],
             sequence: the sequence string to build from
             class_mapping: a dictionary mapping sequence character to HTML class
             substitutions: a dictionary mapping sequence character to another string
+            positional_classes: a dictionary mapping sequence index to any additional HTML classes to insert
 
         Returns:
             an HTML fragment as a Markup instance
     """
+    if positional_classes is None:
+        positional_classes = {}
     substitutions = substitutions or {}
     for class_label in class_mapping.values():
         if not class_label.replace("-", "").isalnum():
             raise ValueError(f"invalid character in HTML class: {class_label}")
     spans = []
-    for char in sequence:
-        char_class = class_mapping.get(char)
+    for i, char in enumerate(sequence):
+        char_class = " ".join((class_mapping.get(char, ""), positional_classes.get(i, ""))).strip()
         extra = ""
         if char_class:
             extra = f' class="{char_class}"'
@@ -167,7 +171,7 @@ def spanned_sequence(sequence: str, class_mapping: Dict[str, str],
 
 
 def coloured_ripp_sequence(sequence: str, dehydrate: bool = False, colour_subset: str = None,
-                           ) -> Markup:
+                           positional_classes: dict[int, str] = None) -> Markup:
     """ Builds an HTML fragment with spans for each character, using a predefined
         set of span classes and substitutions.
 
@@ -175,6 +179,7 @@ def coloured_ripp_sequence(sequence: str, dehydrate: bool = False, colour_subset
             sequence: the sequence string to build from
             dehydrate: whether to substitute in dehydrations (e.g. "T" -> "Dbh")
             colour_subset: a subset of normally coloured RiPP characters to restrict colouring to
+            positional_classes: a dictionary mapping sequence index to any additional HTML classes to insert
 
         Returns:
             an HTML fragment as a Markup instance
@@ -184,8 +189,9 @@ def coloured_ripp_sequence(sequence: str, dehydrate: bool = False, colour_subset
     else:
         classes = RIPP_CLASSES
     if not dehydrate:
-        return spanned_sequence(sequence, classes)
-    return spanned_sequence(sequence, classes, substitutions=RIPP_SUBSTITUTIONS)
+        return spanned_sequence(sequence, classes, positional_classes=positional_classes)
+    return spanned_sequence(sequence, classes, substitutions=RIPP_SUBSTITUTIONS,
+                            positional_classes=positional_classes)
 
 
 def collapser_end() -> Markup:

--- a/antismash/common/html_renderer.py
+++ b/antismash/common/html_renderer.py
@@ -166,20 +166,26 @@ def spanned_sequence(sequence: str, class_mapping: Dict[str, str],
     return Markup("".join(spans))
 
 
-def coloured_ripp_sequence(sequence: str, dehydrate: bool = False) -> Markup:
+def coloured_ripp_sequence(sequence: str, dehydrate: bool = False, colour_subset: str = None,
+                           ) -> Markup:
     """ Builds an HTML fragment with spans for each character, using a predefined
         set of span classes and substitutions.
 
         Arguments:
             sequence: the sequence string to build from
             dehydrate: whether to substitute in dehydrations (e.g. "T" -> "Dbh")
+            colour_subset: a subset of normally coloured RiPP characters to restrict colouring to
 
         Returns:
             an HTML fragment as a Markup instance
     """
+    if colour_subset is not None:
+        classes = {c: RIPP_CLASSES[c] for c in colour_subset}
+    else:
+        classes = RIPP_CLASSES
     if not dehydrate:
-        return spanned_sequence(sequence, RIPP_CLASSES)
-    return spanned_sequence(sequence, RIPP_CLASSES, substitutions=RIPP_SUBSTITUTIONS)
+        return spanned_sequence(sequence, classes)
+    return spanned_sequence(sequence, classes, substitutions=RIPP_SUBSTITUTIONS)
 
 
 def collapser_end() -> Markup:

--- a/antismash/common/module_results.py
+++ b/antismash/common/module_results.py
@@ -51,7 +51,7 @@ class ModuleResults:
         raise NotImplementedError()
 
 
-class DetectionResults(ModuleResults):  # keeping abstract is deliberate, pylint: disable=abstract-method
+class DetectionResults(ModuleResults):
     """ Stores results for detection modules.
 
         get_predicted_protoclusters() should be overridden if the module predicts clusters

--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -243,7 +243,7 @@ def ensure_cds_info(genefinding: Callable[[Record, Any], None], sequence: Record
     """
     if sequence.skip:
         return sequence
-    options = get_config()
+    options = get_config(no_defaults=True)
     if len(options) == 0:  # inside a parallel function where config doesn't pickle correctly
         new = Config(kwargs)
         assert isinstance(new, ConfigType)

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -228,7 +228,7 @@ class CDSFeature(Feature):
         # finally, any alternate start codon should be changed to methionine
         if translation[0] != "M":
             translation = "M" + translation[1:]
-        self._translation = translation  # pylint: disable=attribute-defined-outside-init
+        self._translation = translation
 
     @property
     def modules(self) -> Tuple[Module, ...]:

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -225,6 +225,9 @@ class CDSFeature(Feature):
             raise ValueError(f"invalid translation characters: {invalid}")
         if not _is_valid_translation_length(translation, self.location):
             raise ValueError(f"translation longer than location allows: {len(translation) * 3} > {len(self.location)}")
+        # finally, any alternate start codon should be changed to methionine
+        if translation[0] != "M":
+            translation = "M" + translation[1:]
         self._translation = translation  # pylint: disable=attribute-defined-outside-init
 
     @property

--- a/antismash/common/secmet/features/cds_motif.py
+++ b/antismash/common/secmet/features/cds_motif.py
@@ -12,7 +12,7 @@ from .domain import Domain, generate_protein_location_from_qualifiers
 from .feature import Feature, FeatureLocation, Location, pop_locus_qualifier
 
 T = TypeVar("T", bound="CDSMotif")
-ExternalT = TypeVar("ExternalT", bound="ExternalCDSMotif")  # pylint: disable=invalid-name
+ExternalT = TypeVar("ExternalT", bound="ExternalCDSMotif")
 
 
 class CDSMotif(Domain):

--- a/antismash/common/secmet/features/cdscollection.py
+++ b/antismash/common/secmet/features/cdscollection.py
@@ -144,7 +144,7 @@ class CDSCollection(Feature):
         contig_edge = leftovers.pop("contig_edge", [""])[0] == "True"
         if not feature:
             feature = cls(bio_feature.location, bio_feature.type)
-            feature._contig_edge = contig_edge  # pylint: disable=protected-access
+            feature._contig_edge = contig_edge
 
         # grab parent optional qualifiers
         super().from_biopython(bio_feature, feature=feature, leftovers=leftovers, record=record)

--- a/antismash/common/secmet/features/protocluster.py
+++ b/antismash/common/secmet/features/protocluster.py
@@ -15,7 +15,7 @@ from ..qualifiers.t2pks import T2PKSQualifier
 from ..qualifiers.gene_functions import GeneFunction
 
 T = TypeVar("T", bound="Protocluster")
-S = TypeVar("S", bound="SideloadedProtocluster")  # pylint: disable=invalid-name
+S = TypeVar("S", bound="SideloadedProtocluster")
 
 
 class Protocluster(CDSCollection):

--- a/antismash/common/secmet/features/subregion.py
+++ b/antismash/common/secmet/features/subregion.py
@@ -11,7 +11,7 @@ from .cdscollection import CDSCollection
 from .feature import FeatureLocation, Feature
 
 T = TypeVar("T", bound="SubRegion")
-S = TypeVar("S", bound="SideloadedSubRegion")  # pylint: disable=invalid-name
+S = TypeVar("S", bound="SideloadedSubRegion")
 
 
 class SubRegion(CDSCollection):

--- a/antismash/common/secmet/features/test/test_cds_feature.py
+++ b/antismash/common/secmet/features/test/test_cds_feature.py
@@ -56,11 +56,24 @@ class TestCDSFeature(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "translation too long"):
             CDSFeature(loc, locus_tag="test", translation="A" * MAX_TRANSLATION_LENGTH)
 
+    def test_methionine_starts(self):
+        """ All gene translations should start with methionine, even if using
+            an alternate start codon
+        """
+        translation = "LAGIC"
+        expected = "MAGIC"
+        # via constructor
+        cds = CDSFeature(FeatureLocation(0, 15, 1), locus_tag="test", translation=translation)
+        assert cds.translation == expected
+        # and via setting the property
+        cds.translation = translation
+        assert cds.translation == expected
+
 
 class TestCDSBiopythonConversion(unittest.TestCase):
     def setUp(self):
         self.cds = CDSFeature(FeatureLocation(0, 12, 1),
-                              translation="A"*4,
+                              translation="MAAA",
                               locus_tag="loctag",
                               gene="gene",
                               protein_id="prot_id")
@@ -77,7 +90,7 @@ class TestCDSBiopythonConversion(unittest.TestCase):
         assert bio.qualifiers["locus_tag"] == ["loctag"]
         assert bio.qualifiers["gene"] == ["gene"]
         assert bio.qualifiers["protein_id"] == ["prot_id"]
-        assert bio.qualifiers["translation"] == ["A"*4]
+        assert bio.qualifiers["translation"] == ["MAAA"]
 
         regen = CDSFeature.from_biopython(bio)
         assert regen.location == self.cds.location

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -19,7 +19,7 @@ from Bio.SeqFeature import (
 
 from .errors import SecmetInvalidInputError
 
-Location = Union[CompoundLocation, FeatureLocation]  # pylint: disable=invalid-name
+Location = Union[CompoundLocation, FeatureLocation]
 
 
 def convert_protein_position_to_dna(start: int, end: int, location: Location) -> Tuple[int, int]:

--- a/antismash/common/secmet/qualifiers/gene_functions.py
+++ b/antismash/common/secmet/qualifiers/gene_functions.py
@@ -42,7 +42,7 @@ class GeneFunction(Enum):
         raise ValueError(f"Unknown gene function label: {label}")
 
 
-class _GeneFunctionAnnotation:  # pylint: disable=too-few-public-methods
+class _GeneFunctionAnnotation:
     """ A single instance of an annotation. """
     slots = ["function", "tool", "description", "product"]
 

--- a/antismash/common/secmet/qualifiers/nrps_pks.py
+++ b/antismash/common/secmet/qualifiers/nrps_pks.py
@@ -31,7 +31,7 @@ class NRPSPKSQualifier:
 
         Can be used directly as a qualifier for Biopython's SeqFeature.
     """
-    class Domain:  # pylint: disable=too-few-public-methods
+    class Domain:
         """ Contains information about a NRPS/PKS domain, including predictions
             made by modules.
 

--- a/antismash/common/secmet/qualifiers/prepeptide_qualifiers.py
+++ b/antismash/common/secmet/qualifiers/prepeptide_qualifiers.py
@@ -33,7 +33,7 @@ class LanthiQualifier(RiPPQualifier):
     """ A qualifier for lanthipeptide-specific annotations """
     __slots__ = ["lan_bridges", "aminovinyl_group", "chlorinated", "oxygenated", "lactonated"]
 
-    def __init__(self, lan_bridges: int, rodeo_score: int,  # pylint: disable=too-many-arguments
+    def __init__(self, lan_bridges: int, rodeo_score: int,
                  aminovinyl_group: bool, chlorinated: bool, oxygenated: bool,
                  lactonated: bool) -> None:
         super().__init__(rodeo_score)
@@ -81,7 +81,7 @@ class ThioQualifier(RiPPQualifier):
     """ A qualifier for thiopeptide-specific annotations """
     __slots__ = ["amidation", "macrocycle", "core_features", "mature_weights"]
 
-    def __init__(self, rodeo_score: int, amidation: bool, macrocycle: str,  # pylint: disable=too-many-arguments
+    def __init__(self, rodeo_score: int, amidation: bool, macrocycle: str,
                  core_features: str, mature_weights: List[float]) -> None:
         super().__init__(rodeo_score)
         self.amidation = amidation
@@ -119,7 +119,7 @@ class ThioQualifier(RiPPQualifier):
 
 class LassoQualifier(RiPPQualifier):
     """ A qualifier for lassopeptide-specific annotations """
-    def __init__(self, rodeo_score: int, num_bridges: int,  # pylint: disable=too-many-arguments
+    def __init__(self, rodeo_score: int, num_bridges: int,
                  macrolactam: str, cut_mass: float, cut_weight: float) -> None:
         super().__init__(rodeo_score)
         self.num_bridges = num_bridges

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -747,7 +747,7 @@ class Record:
         if str(taxon) == "bacteria":
             transl_table = 11  # bacterial, archea, plant plastid code
         record = cls(transl_table=transl_table)
-        record._record = seq_record  # pylint: disable=protected-access
+        record._record = seq_record
         # because is_circular() can't be used reliably at this stage due to fasta files
         can_be_circular = taxon == "bacteria"
         try:
@@ -918,7 +918,7 @@ class Record:
 
         return Seq(string_version)
 
-    def get_cds_features_within_regions(self) -> List[CDSFeature]:  # pylint: disable=invalid-name
+    def get_cds_features_within_regions(self) -> list[CDSFeature]:
         """ Returns all CDS features in the record that are located within a
             region of interest
         """

--- a/antismash/common/serialiser.py
+++ b/antismash/common/serialiser.py
@@ -21,13 +21,14 @@ from antismash.common.secmet.locations import location_from_string
 # Schema version changes:
 # 1: initial state
 # 2: added field: records.areas
+# 3: added field to records.areas.protoclusters objects: category
 
 
 class AntismashResults:
     """ A single repository of all results of an antismash run, including input
         filename, records and individual module results
     """
-    SCHEMA_VERSION = 2
+    SCHEMA_VERSION = 3
 
     # the key must accept all the schemas in values as valid
     # this will typically only be useful for backwards compatibility
@@ -181,6 +182,7 @@ def gather_record_areas(record: Record) -> List[Dict[str, Any]]:
         protoclusters_by_obj = {proto: i for i, proto in enumerate(region.get_unique_protoclusters())}
         for proto, i in protoclusters_by_obj.items():
             region_json["protoclusters"][i] = {
+                "category": proto.product_category,
                 "start": proto.location.start,
                 "end": proto.location.end,
                 "core_start": proto.core_location.start,

--- a/antismash/common/subprocessing/hmmpfam.py
+++ b/antismash/common/subprocessing/hmmpfam.py
@@ -14,7 +14,7 @@ _THREADING_SUPPORT = True
 
 
 def run_hmmpfam2(query_hmmfile: str, target_sequence: str, extra_args: List[str] = None
-                 ) -> List[SearchIO._model.query.QueryResult]:  # pylint: disable=protected-access
+                 ) -> list[SearchIO._model.query.QueryResult]:
     """ Run hmmpfam2 over the provided HMM file and fasta input
 
         Arguments:

--- a/antismash/common/subprocessing/hmmscan.py
+++ b/antismash/common/subprocessing/hmmscan.py
@@ -28,7 +28,7 @@ def _find_error(output: list[str]) -> str:
 
 
 def run_hmmscan(target_hmmfile: str, query_sequence: str, opts: List[str] = None,
-                results_file: str = None) -> List[SearchIO._model.query.QueryResult]:  # pylint: disable=protected-access
+                results_file: str = None) -> list[SearchIO._model.query.QueryResult]:
     """ Runs hmmscan on the inputs and return a list of QueryResults
 
         Arguments:

--- a/antismash/common/test/test_html_renderer.py
+++ b/antismash/common/test/test_html_renderer.py
@@ -154,12 +154,12 @@ class TestSequences(unittest.TestCase):
                 assert f"<span>{char}</span>" in result
                 assert f'">{char}</span>' not in result
 
-    def test_combination_substitution_positional(self):
+    def test_combination_classes_positional(self):
         sequence = "ABC"
         positional = {1: "pos"}
-        substitutions = {"B": "sub"}
-        result = renderer.spanned_sequence(sequence, substitutions, positional_classes=positional)
-        assert '<span class="sub pos">B</span>' in result
+        mapping = {"B": "map"}
+        result = renderer.spanned_sequence(sequence, mapping, positional_classes=positional)
+        assert '<span class="map pos">B</span>' in result
 
     def test_ripps_dehydration(self):
         result = renderer.coloured_ripp_sequence("TISC", dehydrate=True)

--- a/antismash/common/test/test_html_renderer.py
+++ b/antismash/common/test/test_html_renderer.py
@@ -142,6 +142,25 @@ class TestSequences(unittest.TestCase):
         c_chunk = '<span>456</span>'
         assert result == f"{a_chunk}{b_chunk}{c_chunk}"
 
+    def test_positional(self):
+        sequence = "01234"
+        positional = {1: "one", 4: "four"}
+        result = renderer.spanned_sequence(sequence, {}, positional_classes=positional)
+        for key, val in positional.items():
+            assert f"<span>{key}</span>" not in result
+            assert f'<span class="{val}">{key}</span>' in result
+        for char in sequence:
+            if int(char) not in positional:
+                assert f"<span>{char}</span>" in result
+                assert f'">{char}</span>' not in result
+
+    def test_combination_substitution_positional(self):
+        sequence = "ABC"
+        positional = {1: "pos"}
+        substitutions = {"B": "sub"}
+        result = renderer.spanned_sequence(sequence, substitutions, positional_classes=positional)
+        assert '<span class="sub pos">B</span>' in result
+
     def test_ripps_dehydration(self):
         result = renderer.coloured_ripp_sequence("TISC", dehydrate=True)
         assert result == "".join([

--- a/antismash/common/test/test_serialiser.py
+++ b/antismash/common/test/test_serialiser.py
@@ -100,7 +100,8 @@ class TestAreas(unittest.TestCase):
 
     def test_complex(self):
         protos = [
-            helpers.DummyProtocluster(core_start=3, core_end=22, neighbourhood_range=1, product='a'),
+            helpers.DummyProtocluster(core_start=3, core_end=22, neighbourhood_range=1,
+                                      product='a', product_category="cat"),
             helpers.DummyProtocluster(core_start=33, core_end=48, neighbourhood_range=2, product='b'),
         ]
         candidates = [
@@ -123,6 +124,8 @@ class TestAreas(unittest.TestCase):
         assert res["products"] == [p.product for p in protos]
         assert res["subregions"] == []
         assert len(res["protoclusters"]) == 2
+        for real, converted in zip(protos, list(res["protoclusters"].values())):
+            assert converted["category"] == real.product_category
         assert list(res["protoclusters"]) == [0, 1]
         assert res["protoclusters"][1]["product"] == protos[1].product
         assert len(res["candidates"]) == 2

--- a/antismash/config/__init__.py
+++ b/antismash/config/__init__.py
@@ -99,9 +99,22 @@ def update_config(values: Union[Dict[str, Any], Namespace]) -> ConfigType:
     return config
 
 
-def get_config() -> ConfigType:
-    """ Returns the current config """
-    config = Config()
+def get_config(no_defaults: bool = False) -> ConfigType:
+    """ Returns the current config. If the current config is empty, a default set
+        will be created.
+
+        Arguments:
+            no_defaults: if True, no defaults will be created in the case of not
+                         yet being set
+
+        Returns:
+            the current config
+    """
+    config: Union[Config, ConfigType] = Config()  # mypy doesn't like the rest of this otherwise
+    assert isinstance(config, ConfigType)
+    # if it's completely, build a default for easier use as a library, especially for executables
+    if len(config) < 1 and not no_defaults:
+        config = build_config([])
     assert isinstance(config, ConfigType)
     return config
 

--- a/antismash/config/__init__.py
+++ b/antismash/config/__init__.py
@@ -22,8 +22,6 @@ from antismash.custom_typing import AntismashModule, ConfigType
 from .args import build_parser, AntismashParser
 from .loader import load_config_from_file
 
-from .executables import find_executable_path
-
 _USER_FILE_NAME = os.path.expanduser('~/.antismash7.cfg')
 _INSTANCE_FILE_NAME = os.path.abspath(os.path.join(os.path.dirname(__file__), 'instance.cfg'))
 

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -243,14 +243,14 @@ Options
         return tuple(self._actions)
 
 
-class FullPathAction(argparse.Action):  # pylint: disable=too-few-public-methods
+class FullPathAction(argparse.Action):
     """ An argparse.Action to ensure provided paths are absolute. """
     def __call__(self, parser: argparse.ArgumentParser, namespace: argparse.Namespace,
                  values: Any, option_string: str = None) -> None:
         setattr(namespace, self.dest, os.path.abspath(str(values)))
 
 
-class MultipleFullPathAction(argparse.Action):  # pylint: disable=too-few-public-methods
+class MultipleFullPathAction(argparse.Action):
     """ An argparse.Action to ensure provided paths are absolute in a comma separated list. """
     def __call__(self, parser: argparse.ArgumentParser, namespace: argparse.Namespace,
                  values: Any, option_string: str = None) -> None:
@@ -323,7 +323,7 @@ class _SimpleArgs:
             assert isinstance(default, option_type)
         self._add_argument(self.options, name, *args, **kwargs)
 
-    def _add_argument(self, group: argparse._ArgumentGroup, name: str,  # pylint: disable=protected-access
+    def _add_argument(self, group: argparse._ArgumentGroup, name: str,
                       *args: Any, **kwargs: Any) -> None:
         self.skip_type_check = self.override
         # prevent the option name being considered destination by argparse

--- a/antismash/config/test/test_args.py
+++ b/antismash/config/test/test_args.py
@@ -101,6 +101,17 @@ class TestConfig(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "does not exist"):
             self.core_parser.parse_args(["--reuse-results", "non-existant"])
 
+    def test_defaults_on_fetch(self):
+        config = get_config()
+        assert len(config)
+        assert config.executables
+
+    def test_defaults_on_fetch_disabled(self):
+        config = get_config(no_defaults=True)
+        assert len(config) == 0
+        with self.assertRaises(AttributeError):
+            assert config.executables
+
 
 class TestExecutableArg(unittest.TestCase):
     def setUp(self):

--- a/antismash/detection/hmm_detection/__init__.py
+++ b/antismash/detection/hmm_detection/__init__.py
@@ -243,13 +243,15 @@ def prepare_data(logging_only: bool = False) -> List[str]:
     # the path to the markov model
     seeds_hmm = path.get_full_path(__file__, 'data', 'bgc_seeds.hmm')
     hmm_files = [os.path.join("data", sig.hmm_file) for sig in profiles]
+    # include the listing, since tools like wget will keep modified timestamps on the HMMs
+    description_file = path.get_full_path(__file__, 'data', 'hmmdetails.txt')
     outdated = False
     if not path.locate_file(seeds_hmm):
         logging.debug("%s: %s doesn't exist, regenerating", NAME, seeds_hmm)
         outdated = True
     else:
         seeds_timestamp = os.path.getmtime(seeds_hmm)
-        for component in hmm_files:
+        for component in hmm_files + [description_file]:
             if os.path.getmtime(component) > seeds_timestamp:
                 logging.debug("%s out of date, regenerating", seeds_hmm)
                 outdated = True

--- a/antismash/detection/hmm_detection/categories.py
+++ b/antismash/detection/hmm_detection/categories.py
@@ -1,88 +1,20 @@
 # License: GNU Affero General Public License v3 or later
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 
-""" Handle valid rule categories plus associated metadata
+""" A thin wrapper around antismash.common.hmm_rule_parser.categories to avoid
+    needing path information
 """
 
-from dataclasses import dataclass
-import json
-from typing import Any, Dict, List, Type, Optional, TypeVar, Union
+from antismash.common.path import get_full_path
+from antismash.common.hmm_rule_parser.categories import parse_category_file, RuleCategory
 
-from antismash.common import path
-
-TRuleCategory = TypeVar("TRuleCategory", bound="RuleCategory")
+_CATEGORIES: list[RuleCategory] = []
 
 
-@dataclass
-class RuleCategory:
-    """A collection of information about a particular rule category"""
-    name: str
-    description: str
-    version: int = 1
-    parent: Optional["RuleCategory"] = None
-
-    @classmethod
-    def from_json(cls: Type[TRuleCategory], name: str,
-                  entry: Dict[str, Union[str, int]],
-                  existing_categories: dict[str, TRuleCategory]) -> TRuleCategory:
-        """Regenerates a RuleCategory instance from a JSON representation"""
-
-        try:
-            description: str = str(entry["description"])  # cast to make mypy happy
-            version: int = int(entry["version"])  # cast to make mypy happy
-        except KeyError as err:
-            raise ValueError(f"missing required rule metadata key '{err}'")
-
-        parent: Optional[RuleCategory] = None
-        if "parent" in entry:
-            parent = existing_categories[str(entry["parent"])]
-
-        if version != 1:
-            raise ValueError(f"Unknown rule category version {version}")
-
-        return cls(name, description, version, parent=parent)
-
-
-def _parse_categories(data: dict[str, Any]) -> dict[str, RuleCategory]:
-    # split entries into two sets, those without parents, then those with parents
-    top_level = {}
-    children = {}
-    for name, metadata in data.items():
-        if "parent" in metadata:
-            if metadata["parent"] not in data:
-                raise ValueError(f"category {name!r} refers to unknown category {metadata['parent']!r}")
-            children[name] = metadata
-        else:
-            top_level[name] = metadata
-
-    categories: dict[str, RuleCategory] = {}
-
-    # run on the top level first, to ensure that they exist to be referenced
-    for group in [top_level, children]:
-        for name, metadata in group.items():
-            categories[name] = RuleCategory.from_json(name, metadata, existing_categories=categories)
-
-    return categories
-
-
-def get_rule_categories() -> List[RuleCategory]:
+def get_rule_categories() -> list[RuleCategory]:
     """Generate a list of rule categories from categories.json
     Only processes the file once per Python invocation, future calls access the cached data.
     """
-    # if called before, just return the cached data
-    existing = getattr(get_rule_categories, 'existing', None)
-    if existing is not None:
-        assert isinstance(existing, list)
-        return existing
-
-    # not cached, generate
-    category_mapping: dict[str, RuleCategory] = {}
-
-    with open(path.get_full_path(__file__, "data", "categories.json"), "r", encoding="utf-8") as handle:
-        category_mapping = _parse_categories(json.load(handle))
-
-    categories = list(category_mapping.values())
-    # and cache for future calls, and silence mypy warning as mypy can't handle this
-    get_rule_categories.existing = categories  # type: ignore
-
-    return categories
+    if not _CATEGORIES:
+        _CATEGORIES.extend(parse_category_file(get_full_path(__file__, "data", "categories.json")))
+    return _CATEGORIES

--- a/antismash/detection/hmm_detection/categories.py
+++ b/antismash/detection/hmm_detection/categories.py
@@ -6,7 +6,7 @@
 
 from dataclasses import dataclass
 import json
-from typing import Dict, List, Type, TypeVar, Union
+from typing import Any, Dict, List, Type, Optional, TypeVar, Union
 
 from antismash.common import path
 
@@ -19,10 +19,12 @@ class RuleCategory:
     name: str
     description: str
     version: int = 1
+    parent: Optional["RuleCategory"] = None
 
     @classmethod
     def from_json(cls: Type[TRuleCategory], name: str,
-                  entry: Dict[str, Union[str, int]]) -> TRuleCategory:
+                  entry: Dict[str, Union[str, int]],
+                  existing_categories: dict[str, TRuleCategory]) -> TRuleCategory:
         """Regenerates a RuleCategory instance from a JSON representation"""
 
         try:
@@ -31,10 +33,36 @@ class RuleCategory:
         except KeyError as err:
             raise ValueError(f"missing required rule metadata key '{err}'")
 
+        parent: Optional[RuleCategory] = None
+        if "parent" in entry:
+            parent = existing_categories[str(entry["parent"])]
+
         if version != 1:
             raise ValueError(f"Unknown rule category version {version}")
 
-        return cls(name, description, version)
+        return cls(name, description, version, parent=parent)
+
+
+def _parse_categories(data: dict[str, Any]) -> dict[str, RuleCategory]:
+    # split entries into two sets, those without parents, then those with parents
+    top_level = {}
+    children = {}
+    for name, metadata in data.items():
+        if "parent" in metadata:
+            if metadata["parent"] not in data:
+                raise ValueError(f"category {name!r} refers to unknown category {metadata['parent']!r}")
+            children[name] = metadata
+        else:
+            top_level[name] = metadata
+
+    categories: dict[str, RuleCategory] = {}
+
+    # run on the top level first, to ensure that they exist to be referenced
+    for group in [top_level, children]:
+        for name, metadata in group.items():
+            categories[name] = RuleCategory.from_json(name, metadata, existing_categories=categories)
+
+    return categories
 
 
 def get_rule_categories() -> List[RuleCategory]:
@@ -48,13 +76,12 @@ def get_rule_categories() -> List[RuleCategory]:
         return existing
 
     # not cached, generate
-    categories: List[RuleCategory] = []
+    category_mapping: dict[str, RuleCategory] = {}
 
     with open(path.get_full_path(__file__, "data", "categories.json"), "r", encoding="utf-8") as handle:
-        category_json = json.load(handle)
-        for name, metadata in category_json.items():
-            categories.append(RuleCategory.from_json(name, metadata))
+        category_mapping = _parse_categories(json.load(handle))
 
+    categories = list(category_mapping.values())
     # and cache for future calls, and silence mypy warning as mypy can't handle this
     get_rule_categories.existing = categories  # type: ignore
 

--- a/antismash/detection/hmm_detection/cluster_rules/strict.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/strict.txt
@@ -492,8 +492,9 @@ RULE aminocoumarin
 RULE NI-siderophore
     CATEGORY other
     DESCRIPTION NRPS-independent IucA/IucC-like siderophores
+    EXAMPLE NCBI CP001096.1 2834779-2852134 rhodopetrobactin  # https://doi.org/10.1111/1462-2920.14078
     CUTOFF 20
-    NEIGHBOURHOOD 5
+    NEIGHBOURHOOD 14  # for rhodopetrobactin
     CONDITIONS IucA_IucC
 
 RULE ectoine

--- a/antismash/detection/hmm_detection/test/test_hmm_detection.py
+++ b/antismash/detection/hmm_detection/test/test_hmm_detection.py
@@ -427,36 +427,3 @@ class TestMultipliers(unittest.TestCase):
         ], modules=[core])
         with self.assertRaisesRegex(RuntimeError, "neighbourhood multiplier .* incompatible"):
             core.regenerate_previous_results(as_json, self.record, options)
-
-
-class TestCategoryParsing(unittest.TestCase):
-    def setUp(self):
-        self.data = {
-            "A": {"description": "some desc", "version": 1},
-            "B": {"description": "some other desc", "version": 1},
-        }
-
-    def test_no_parents(self):
-        cats = core.categories._parse_categories(self.data)
-        for name, value in self.data.items():
-            assert cats[name].description == value["description"]
-            assert cats[name].version == value["version"]
-            assert cats[name].name == name
-            assert cats[name].parent is None
-        assert len(cats) == len(self.data)
-
-    def test_missing_parents(self):
-        parent = "Z"
-        assert parent not in self.data  # should also be missing
-        self.data["A"]["parent"] = parent
-        with self.assertRaisesRegex(ValueError, "refers to unknown category"):
-            core.categories._parse_categories(self.data)
-
-    def test_with_parents(self):
-        self.data["A"]["parent"] = "B"
-        cats = core.categories._parse_categories(self.data)
-        for name, value in self.data.items():
-            assert cats[name].description == value["description"]
-            assert cats[name].version == value["version"]
-        assert cats["A"].parent == cats["B"]
-        assert cats["B"].parent is None

--- a/antismash/detection/nrps_pks_domains/domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/domain_identification.py
@@ -22,6 +22,7 @@ from antismash.common.secmet.features import (
 )
 from antismash.common.secmet.locations import FeatureLocation
 from antismash.config import get_config
+from antismash.detection.nrps_pks_domains.modular_domain import ModularDomain
 
 from .module_identification import (
     build_modules_for_cds,
@@ -436,6 +437,7 @@ def generate_domain_features(gene: CDSFeature, domains: List[HMMResult]) -> Dict
             new_feature.domain = mapping
         else:
             new_feature.domain = name
+            new_feature.subtypes = domain.detailed_names[1:]
         new_feature.locus_tag = gene.locus_tag or gene.get_name()
         new_feature.detection = "hmmscan"
         new_feature.database = "nrpspksdomains.hmm"
@@ -449,7 +451,6 @@ def generate_domain_features(gene: CDSFeature, domains: List[HMMResult]) -> Dict
 
         new_feature.domain_id = "nrpspksdomains_" + domain_name
         new_feature.label = domain_name
-        new_feature.subtypes = domain.detailed_names[1:]
 
         new_features[domain] = new_feature
     return new_features

--- a/antismash/detection/nrps_pks_domains/test/test_modules.py
+++ b/antismash/detection/nrps_pks_domains/test/test_modules.py
@@ -256,6 +256,16 @@ class TestModule(unittest.TestCase):
         assert module.is_trans_at()
         assert module.is_complete()
 
+        # without matching subtype is fine if the matching docking domain is present
+        module = build_module([PKS_START, "Trans-AT_docking", CP])
+        assert module.is_trans_at()
+        assert module.is_complete()
+
+        # but the loader must still be missing
+        module = build_module([PKS_START, PKS_LOAD, "Trans-AT_docking", CP])
+        assert not module.is_trans_at()
+        assert module.is_complete()  # still complete, just a little strange
+
     def test_trailing_modifiers(self):
         error = "modification domain after carrier protein"
         # not allowed for NRPSs and PKSs

--- a/antismash/modules/active_site_finder/analysis.py
+++ b/antismash/modules/active_site_finder/analysis.py
@@ -8,15 +8,15 @@
 """
 
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 from antismash.common import secmet
 
 from .common import ActiveSiteAnalysis
 
 # these are type aliases, not constants
-SinglePairing = Tuple[secmet.features.Domain, str]  # pylint: disable=invalid-name
-MultiplePairing = Tuple[secmet.features.Domain, List[str]]  # pylint: disable=invalid-name
+SinglePairing = tuple[secmet.features.Domain, str]
+MultiplePairing = tuple[secmet.features.Domain, list[str]]
 
 
 def run_all_analyses(record: secmet.Record) -> List[MultiplePairing]:

--- a/antismash/modules/lassopeptides/templates/details.html
+++ b/antismash/modules/lassopeptides/templates/details.html
@@ -1,3 +1,7 @@
+{%- set colour_subset = "C" -%}
+{%- macro coloured_sequence(sequence) -%}
+    {{coloured_ripp_sequence(sequence, colour_subset=colour_subset)}}
+{%- endmacro -%}
 <div class="details">
     <div class="heading">
       <span>Lasso peptide predictions</span>
@@ -21,9 +25,9 @@
            <div class="ripp-segment-sequence">{{ motif.leader }}</div>
          {% endfor %}
            <div class="ripp-segment-type">{% if motifs | length > 1%}Shared full core{% else %}Full core{% endif %}:</div>
-           <div class="ripp-segment-sequence">{{ coloured_ripp_sequence(motifs[0].core) }}</div>
+           <div class="ripp-segment-sequence">{{ coloured_sequence(motifs[0].core) }}</div>
            <div class="ripp-segment-type">Putative macrolactam:</div>
-           <div class="ripp-segment-sequence">{{ coloured_ripp_sequence(motifs[0].detailed_information.macrolactam) }}</div>
+           <div class="ripp-segment-sequence">{{ coloured_sequence(motifs[0].detailed_information.macrolactam) }}</div>
          {% for motif in motifs %}
           {% if motif.tail %}
            {% set motif_name = motif.get_name().rsplit("_", 1)[0] %}
@@ -34,7 +38,7 @@
            <div class="ripp-segment-sequence"><span class="cut">{{ motif.tail }}</span></div>
           {% endif %}
          {% endfor %}
-         {{ comparippson_results.get_html_for_query(motifs[0].get_name().rsplit("_", 1)[0]) }}
+         {{ comparippson_results.get_html_for_query(motifs[0].get_name().rsplit("_", 1)[0], colour_subset=colour_subset) }}
         </div>
        {% endfor %}
     {% endfor %}

--- a/antismash/modules/lassopeptides/test/integration_lasso.py
+++ b/antismash/modules/lassopeptides/test/integration_lasso.py
@@ -75,7 +75,7 @@ class IntegrationLasso(unittest.TestCase):
         self.assertAlmostEqual(motif.detailed_information.cut_mass, 2090.8, delta=1)
         self.assertAlmostEqual(motif.detailed_information.cut_weight, 2092.4, delta=1)
         self.assertEqual(motif.detailed_information.num_bridges, 2)
-        self.assertEqual(motif.leader, "VLISTTNGQGTPMTSTDELYEAPELIEIGDYAELTR")
+        self.assertEqual(motif.leader, "MLISTTNGQGTPMTSTDELYEAPELIEIGDYAELTR")
         self.assertEqual(motif.core, "CVWGGDCTDFLGCGTAWICV")
         assert motif.detailed_information.macrolactam == "CVWGGDCTD"
         self.assertEqual(motif.tail, "")

--- a/antismash/modules/nrps_pks/orderfinder.py
+++ b/antismash/modules/nrps_pks/orderfinder.py
@@ -346,7 +346,6 @@ def find_possible_orders(cds_features: List[CDSFeature], start_cds: Optional[CDS
     if end_cds:
         while end_cds in tails:
             end_cds = tails[end_cds]
-        end_cds = end_cds
 
     cds_to_order = []
     for cds in cds_features:

--- a/antismash/modules/nrps_pks/orderfinder.py
+++ b/antismash/modules/nrps_pks/orderfinder.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional, Tuple
 
 from antismash.common import brawn, path, utils
 from antismash.common.secmet import CDSFeature, Module, Record
+from antismash.detection.nrps_pks_domains.modular_domain import ModularDomain
 
 from .html_output import will_handle
 from .results import CandidateClusterPrediction, modify_substrate
@@ -192,7 +193,14 @@ def generate_substrates_order(geneorder: List[CDSFeature], consensus_predictions
             if not monomer:
                 continue
             monomers.append(monomer)
-            components.append((substrate, monomer, [domain.domain or "" for domain in module.domains]))
+            domain_names = []
+            for domain in module.domains:
+                assert isinstance(domain, ModularDomain)
+                if domain.domain == "MT" and domain.domain_subtype:
+                    domain_names.append(domain.domain_subtype)
+                    continue
+                domain_names.append(domain.domain or "")
+            components.append((substrate, monomer, domain_names))
 
         if monomers:
             monomers_by_cds.append(f"({' - '.join(monomers)})")

--- a/antismash/modules/nrps_pks/test/data/nrps_pred2_Y16952.txt
+++ b/antismash/modules/nrps_pks/test/data/nrps_pred2_Y16952.txt
@@ -1,9 +1,0 @@
-#sequence-id<tab>8A-signature<tab>stachelhaus-code<tab>3class-pred<tab>large-class-pred<tab>small-class-pred<tab>single-class-pred<tab>nearest stachelhaus code<tab>NRPS1pred-large-class-pred<tab>NRPS2pred-large-class-pred<tab>outside applicability domain?<tab>coords<tab>pfam-score
-nrpspksdomains_bpsA_A1	L--SFDASLFEMYLLTGGDRNMYGPTEATMCATW	DAFYLGMMCK	hydrophobic-aliphatic	N/A	val,leu,ile,abu,iva	leu	leu	orn,lys,arg	orn,horn	0	0:0	0.000000e+00
-nrpspksdomains_bpsA_A2	LAHAFDTIVSEMKAVAAGEINAYGPTETTICATM	DTSKVAAICK	hydrophobic-aromatic	phe,trp,phg,tyr,bht	tyr,bht	bht	bht	phe,trp,phg,tyr,bht	tyr,bht	0	0:0	0.000000e+00
-nrpspksdomains_bpsA_A3	YHCSFDLTVTATKALLGGEVNEYGPTEATVGCVE	DLTKLGEVGK	hydrophilic	asp,asn,glu,gln,aad	asp,asn	asn	asn	asp,asn,glu,gln,aad	asp,asn	0	0:0	0.000000e+00
-nrpspksdomains_bpsB_A1	L--AFDISLFEVHLLTGGDRHLYGPTEATLCATW	DIFHLGLLCK	hydrophobic-aliphatic	ser,thr,dhpg,hpg	dhpg,hpg	hpg	hpg	orn,lys,arg	orn,horn	0	0:0	0.000000e+00
-nrpspksdomains_bpsB_A2	L--AFDASLVEVHLLTGGDRQLYGPTEITLCATW	DAVHLGLLCK	hydrophobic-aliphatic	ser,thr,dhpg,hpg	dhpg,hpg	hpg	hpg	orn,lys,arg	orn,horn	0	0:0	0.000000e+00
-nrpspksdomains_bpsB_A3	LAHSFDAIVSEMTVLTGGEIQAYGPTETTICSTM	DASTLGAICK	hydrophobic-aromatic	phe,trp,phg,tyr,bht	tyr,bht	bht	bht	phe,trp,phg,tyr,bht	tyr,bht	0	0:0	0.000000e+00
-nrpspksdomains_bpsC_A1	L--AFDPSLYAVHLEIGGDRNTYGPTETTLCATW	DPYHEGTLCK	hydrophobic-aliphatic	ser,thr,dhpg,hpg	dhpg,hpg	dhpg	dhpg	orn,lys,arg	orn,horn	0	0:0	0.000000e+00
-nrpspksdomains_bpsD_A1	LDHAFDAAVAEPTLLVAGEINAYGPTEATVAVTA	DAATLAAVAK	hydrophobic-aromatic	phe,trp,phg,tyr,bht	tyr,bht	tyr	tyr	phe,trp,phg,tyr,bht	tyr,bht	0	0:0	0.000000e+00

--- a/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
+++ b/antismash/modules/nrps_pks/test/integration/integration_nrps_pks.py
@@ -189,6 +189,7 @@ class IntegrationNRPSPKS(unittest.TestCase):
         # and the NRPS/PKS results for the candidate should have the right polymer
         region_results = results.region_predictions[region.get_region_number()]
         assert region_results[0].polymer == "(Me-Cys)"
+        assert region_results[0].smiles == "NC(C(C)S)C(=O)O"
 
     def test_get_a_dom_signatures(self):
         filename = path.get_full_path(__file__, 'data', 'dom_signatures.txt')

--- a/antismash/modules/pfam2go/pfam2go.py
+++ b/antismash/modules/pfam2go/pfam2go.py
@@ -30,7 +30,7 @@ class GeneOntology:  # pylint: disable=too-few-public-methods
         return self.id
 
 
-class GeneOntologies:  # pylint: disable=too-few-public-methods
+class GeneOntologies:
     """A collection of all Gene Ontology terms (as GeneOntology objects) for a Pfam ID."""
     def __init__(self, pfam: str, gos: List[GeneOntology]) -> None:
         self.pfam = str(pfam)

--- a/antismash/modules/sactipeptides/templates/details.html
+++ b/antismash/modules/sactipeptides/templates/details.html
@@ -1,3 +1,4 @@
+{%- set colour_subset = "C" -%}
 <div class="details">
     <div class="heading">
       <span>Sactipeptide predictions</span>
@@ -21,8 +22,8 @@
            <div class="ripp-segment-sequence">{{ motif.leader }}</div>
          {% endfor %}
            <div class="ripp-segment-type">{% if motifs | length > 1%}Shared core{% else %}Core{% endif %}:</div>
-           <div class="ripp-segment-sequence">{{ core }}</div>
-         {{ comparippson_results.get_html_for_query(motifs[0].get_name().rsplit("_", 1)[0], colour_subset="C") }}
+           <div class="ripp-segment-sequence">{{ coloured_ripp_sequence(core, colour_subset=colour_subset) }}</div>
+         {{ comparippson_results.get_html_for_query(motifs[0].get_name().rsplit("_", 1)[0], colour_subset=colour_subset) }}
         </div>
        {% endfor %}
     {% endfor %}

--- a/antismash/modules/thiopeptides/test/integration_thiopeptides.py
+++ b/antismash/modules/thiopeptides/test/integration_thiopeptides.py
@@ -132,7 +132,7 @@ class TestIntegration(unittest.TestCase):
         self.assertAlmostEqual(1934.6, prepeptide.monoisotopic_mass, places=1)
         self.assertAlmostEqual(1936.0, prepeptide.molecular_weight, places=1)
         assert prepeptide.leader == "MVKSIIKARESGRFYETKYLKGGEEMKEQKELKNEEFELDVEFLDLDEVSAIPETTA"
-        assert other.leader == "LDVEFLDLDEVSAIPETTA"
+        assert other.leader == "MDVEFLDLDEVSAIPETTA"
         assert prepeptide.core == "SSGTSSCSASSTCGSSSCCGSC"
         assert other.core == prepeptide.core
         assert not prepeptide.detailed_information.macrocycle
@@ -162,5 +162,5 @@ class TestIntegration(unittest.TestCase):
         prepeptide = results.motifs[0]
         self.assertAlmostEqual(1408.6, prepeptide.monoisotopic_mass, places=1)
         self.assertAlmostEqual(1409.5, prepeptide.molecular_weight, places=1)
-        assert prepeptide.leader == "LPDITQYTAAGTSTLSTESSVLSASCP"
+        assert prepeptide.leader == "MPDITQYTAAGTSTLSTESSVLSASCP"
         assert prepeptide.core == "TSTASTYTSMSSVS"

--- a/antismash/modules/tta/tta.py
+++ b/antismash/modules/tta/tta.py
@@ -16,7 +16,7 @@ from antismash.common.secmet.features import Feature, FeatureLocation
 from antismash.common.module_results import ModuleResults
 from antismash.config import ConfigType, get_config
 
-Codon = Tuple[int, int]  # keeping as a type style, so # pylint: disable=invalid-name
+Codon = Tuple[int, int]
 
 
 class TTAResults(ModuleResults):

--- a/antismash/outputs/html/css/style.scss
+++ b/antismash/outputs/html/css/style.scss
@@ -1355,7 +1355,13 @@ ul.dropdown-options {
 
         .comparippson-midline {
             @extend .serif;
-            color: gray;
+            span {
+                opacity: 0.5;  // less important than the bracketing lines above/below
+            }
+            .near-match-cycle {
+                opacity: 1;  // undo the opacity above
+                font-weight: 600;  // matches the cys/dha/dhb weighting
+            }
         }
     }
 }

--- a/antismash/outputs/html/templates/header.html
+++ b/antismash/outputs/html/templates/header.html
@@ -19,6 +19,7 @@
         <li><a href="{{options.output_basename}}.zip">Download all results</a></li>
         {% endif %}
           <li><a href="{{options.output_basename}}.gbk">Download GenBank summary file</a></li>
+          <li><a href="{{options.output_basename}}.json">Download JSON results file</a></li>
         {% if options.logfile and options.download_logfile() != None %}
           <li><a href="{{options.download_logfile()}}">Download log file</a></li>
         {% endif %}

--- a/antismash/outputs/html/templates/regions.html
+++ b/antismash/outputs/html/templates/regions.html
@@ -7,7 +7,7 @@
  <div class="region-grid">
   <div class = "content">
     <div class ="description-container">
-      <div class="heading"> {{record.seq_record.name}} - Region {{region.get_region_number()}} - {{region.get_product_string()}} {{help_tooltip(svg_tooltip, "region_svg")}}</div>
+      <div class="heading"> {{record.id}} - Region {{region.get_region_number()}} - {{region.get_product_string()}} {{help_tooltip(svg_tooltip, "region_svg")}}</div>
       <div class="region-download">
         <a href = {{ '%s.region%03d.gbk' % (record.id, region.get_region_number()) }}>Download region GenBank file</a>
       </div>


### PR DESCRIPTION
A large collection of small things, some slightly more significant than others.

### Output:
- JSON results now include calculated clusterblast similarity scores, instead of users needing to derive it from the rest of the results
- JSON results for protoclusters now include the product category
- adds a link in the HTML download options to download the JSON results specifically
- CompaRiPPson now uses the same colouring for consensus sequences as the rest of that RiPP class does in reported sequences (mismatches between two colours will just be bolded, see below)
![image](https://github.com/antismash/antismash/assets/1700735/cffd9850-455c-42f8-9c71-bd10ccae25f4)
- lasso- and sactipeptides now only colour cysteines, as the others being coloured weren't really relevant to those classes
- the record identifier in HTML regions now explicitly uses the versioned identifier


### Tweaks:
- bumps the neighbourhood size of the `NI-siderophore` rule to fully contain BGC0000940 
- all generated gene translations for genes with alternate start codons now start with methionine 
- `bgc_seeds.hmm` now rebuilds if the `hmmdetails.txt` file is updated, due to issues with `wget` keeping older file modification timestamps, which led to some confusion as to why it wasn't updated
- PKS modules without a Trans-AT specific subtype in the ketosynthase are now considered complete if they *also* contain an AT-docking domain
- moved `RuleCategory` definitions and parsing from `detection.hmm_detection` to `common.rule_parser` as part of aiming for more easily specified alternate rulesets
- allows `antismash.common.subprocessing` functions to run without first running `antismash.config.build_config()`, using defaults for the system (for use as a library that needs to specify custom executable paths, `build_config(args...)` is still required)

### Fixes:
- fixed a regression causing NRPS/PKS modules with methylation domains to not correctly methylate the substrate
- removes some out of date restrictions in documentation for the rule parser

For future development, the following pylint messages are now considered failures rather than just warnings: `unused-variable` ,`comparison-with-itself`, and `self-assigning-variable`.