### PR TITLE
chore: bump minimum python version to 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ class PyTest(TestCommand):
 
 setup(
     name="antismash",
-    python_requires='>=3.7',
+    python_requires='>=3.9',
     version=read_version(),
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     package_data={


### PR DESCRIPTION
Somehow this was missing in the changes to 7.0, but we've been using Python 3.9 features for quite a while now.

Should fix #641 