### PR TITLE
Add extension options for detection rules

### DIFF
--- a/antismash/common/hmm_rule_parser/test/test_rule_parser.py
+++ b/antismash/common/hmm_rule_parser/test/test_rule_parser.py
@@ -632,6 +632,17 @@ class RuleParserTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "duplicates a signature"):
             self.parse(text)
 
+    def test_extenders(self):
+        text = format_as_rule("A", 10, 10, "other")
+        # extenders must be an explicit CDS condition
+        # not is fine if within a cds condition, otherwise it's no good
+        for extenders in ["a and b", "a or b", "a and not b"]:
+            rule = self.parse(f"{text} EXTENDERS cds({extenders})").rules[0]
+            assert str(rule.extenders) == f"cds({extenders})"
+
+            with self.assertRaisesRegex(rule_parser.RuleSyntaxError, "expected 'cds' after 'extenders'"):
+                _ = self.parse(f"{text} EXTENDERS {extenders}").rules[0]
+
 
 class TokenTest(unittest.TestCase):
     def test_alpha(self):

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -107,6 +107,39 @@ def build_location_from_others(locations: Sequence[Location]) -> FeatureLocation
     return location
 
 
+def get_distance_between_locations(first: Location, second: Location, wrap_point: int = None) -> int:
+    """ Returns the shortest distance between the two given features, crossing
+        the origin if provided.
+
+        Overlapping features are considered to have zero distance.
+
+        Arguments:
+            first: the first location
+            second: the second location
+            wrap_point: the point at which locations can wrap, if given
+
+        Returns:
+            the distance between the two locations
+    """
+    if locations_overlap(first, second):
+        return 0
+    offset = 0
+    if wrap_point:
+        offset = wrap_point
+    variants = [
+        abs(first.start - second.end + offset),
+        abs(first.end - second.start + offset),
+        abs(second.start - first.end + offset),
+        abs(second.end - first.start + offset)
+    ]
+    distance = min(variants)
+    if wrap_point:
+        distance %= wrap_point
+        distance = min(distance, get_distance_between_locations(first, second))
+    assert distance >= 0
+    return distance
+
+
 def location_bridges_origin(location: Location, allow_reversing: bool = False) -> bool:
     """ Determines if a CompoundLocation would cross the origin of a record.
 

--- a/antismash/common/secmet/test/helpers.py
+++ b/antismash/common/secmet/test/helpers.py
@@ -119,6 +119,9 @@ class DummyRecord(Record):
     "class for generating a Record like data structure"
     def __init__(self, features=None, seq='AGCTACGT', taxon='bacteria',
                  record_id=None):
+        if features:
+            max_feature_coordinate = max(feature.location.end for feature in features)
+            seq = seq * max(1, max_feature_coordinate // len(seq))
         super().__init__(seq, transl_table=11 if taxon == 'bacteria' else 1)
         if features:
             for feature in features:

--- a/antismash/detection/hmm_detection/cluster_rules/strict.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/strict.txt
@@ -32,7 +32,7 @@ RULE transAT-PKS
     DESCRIPTION Trans-AT polyketide
     EXAMPLE NCBI CP006259.1 382565-499230 kirromycin
     EXAMPLE NCBI CP001511.1 5000-30000 toblerol
-    CUTOFF 45  # kirromycin (CP006259) has a range of ~42kb
+    CUTOFF 20
     NEIGHBOURHOOD 20
     CONDITIONS cds(PKS_AT and not ANY_KS)
                and (
@@ -40,6 +40,7 @@ RULE transAT-PKS
                 # handle CP001511 5k-30k as per https://doi.org/10.1002/ange.201709056
                 or cds(tra_KS and PP-binding)
                )
+    EXTENDERS cds(ANY_KS and not PKS_AT)
 
 RULE hglE-KS
     CATEGORY PKS

--- a/antismash/detection/hmm_detection/test/test_hmm_detection.py
+++ b/antismash/detection/hmm_detection/test/test_hmm_detection.py
@@ -326,7 +326,7 @@ class HmmDetectionTest(unittest.TestCase):
         assert data_dir_contents == details_files
 
 
-class TestRuleDetectionExtenders(unittest.TestCase):
+class TestRuleExtenders(unittest.TestCase):
     def setUp(self):
         self.rule_name = "MetaboliteA"
         cutoff = 2000
@@ -360,9 +360,10 @@ class TestRuleDetectionExtenders(unittest.TestCase):
         self.add_hit("X1", self.extender_name)
 
     def detect(self, add_extenders):
+        # the X signature/requirement is present just to make a valid CDS condition
         rule_text = self.rule_text
         if add_extenders:
-            rule_text += f" EXTENDERS {self.extender_name}"
+            rule_text += f" EXTENDERS cds({self.extender_name} and not X)"
         rules = rule_parser.Parser(rule_text, {"A", self.extender_name}, {"Cat"}).rules
         assert len(rules) == 1
         if not add_extenders:
@@ -371,7 +372,7 @@ class TestRuleDetectionExtenders(unittest.TestCase):
             assert rules[0].extenders
 
         pkg = hmm_detection  # to avoid quite a bit of repetition below
-        sigs = [pkg.HmmSignature(name, "", 0, "") for name in ["A", self.extender_name]]
+        sigs = [pkg.HmmSignature(name, "", 0, "") for name in ["A", self.extender_name, "X"]]
         with patch.object(pkg, "get_signature_profiles", return_value=sigs):
             with patch.object(pkg, "get_sequence_counts", return_value={sig.name: 1 for sig in sigs}):
                 with patch.object(pkg, "find_hmmer_hits", return_value=self.results_by_id):


### PR DESCRIPTION
Introduces new syntax for a detection rule section: `EXTENDERS <CDSCondition>`

The example use case is kirromycin, which is a TransAT-PKS. The current rule is
```
RULE transAT-PKS
    CATEGORY PKS
    DESCRIPTION Trans-AT polyketide
    EXAMPLE NCBI CP006259.1 382565-499230 kirromycin
    EXAMPLE NCBI CP001511.1 5000-30000 toblerol
    CUTOFF 45  # kirromycin (CP006259) has a range of ~42kb
    NEIGHBOURHOOD 20
    CONDITIONS cds(PKS_AT and not ANY_KS)
               and (
                cds(ATd and ANY_KS)
                # handle CP001511 5k-30k as per https://doi.org/10.1002/ange.201709056
                or cds(tra_KS and PP-binding)
               )
```
Previously, the cutoff for this rule had to be enlarged to 45kb to reach all the KS-containing CDSes. Some newer, more extreme cases were found where the distance from the last transAT module was 131kb away from the CDS with the AT domain. Making the cutoff that large would be problematic, so this alternative system was created to solve it.

By adding the line `EXTENDERS cds(ANY_KS and not PKS_AT)` to the rule (and lowering the cutoff to 20kb), this requires that the initial rule requirements are still necessary, but that the resulting protocluster's core location will now be iteratively extended for every CDS that satisfies `cds(ANY_KS and not PKS_AT)` within the cutoff distance from the initial core location. With this setup, both kirromycin and the 131kb long protoclusters are found correctly.


At the moment, these extension options are limited to a single CDS condition, as the extension check works only on a single CDS at a time (otherwise the existing rule style would work just as well). At some point in the future, this restriction could be lifted.

Another future possibility would be a similar `BLOCKERS` section, which would prevent any extension beyond any matching gene and could potentially also be applied to core rules. That's a discussion to be had at a later date.