### PR TITLE
Small tweaks

### DIFF
--- a/antismash/common/serialiser.py
+++ b/antismash/common/serialiser.py
@@ -32,8 +32,11 @@ class AntismashResults:
 
     # the key must accept all the schemas in values as valid
     # this will typically only be useful for backwards compatibility
+    # typically different schema versions will have different detection rules,
+    # so this won't really be relevant for reusing results between runs
     COMPATIBLE_SCHEMAS = defaultdict(set, {
-        2: {1},
+        2: {1},  # records.areas isn't used
+        3: {2, 1},  # a subset of records.areas changed, but still isn't used
     })
 
     def __init__(self, input_file: str, records: List[Record],

--- a/antismash/detection/cluster_hmmer/__init__.py
+++ b/antismash/detection/cluster_hmmer/__init__.py
@@ -108,8 +108,6 @@ def run_on_record(record: Record, results: Optional[hmmer.HmmerResults],
 
     logging.info('Running cluster PFAM search')
 
-    features = []
-    for region in record.get_regions():
-        features.extend(list(region.cds_children))
+    features = record.get_cds_features_within_regions()
     database = os.path.join(options.database_dir, 'pfam', database_version, 'Pfam-A.hmm')
     return hmmer.run_hmmer(record, features, MAX_EVALUE, MIN_SCORE, database, "clusterhmmer")

--- a/antismash/detection/tigrfam/__init__.py
+++ b/antismash/detection/tigrfam/__init__.py
@@ -88,9 +88,7 @@ def run_on_record(record: Record, results: Optional[TIGRFamResults],
     if results:
         return results
 
-    features = []
-    for region in record.get_regions():
-        features.extend(list(region.cds_children))
+    features = record.get_cds_features_within_regions()
     tigr_db = os.path.join(options.database_dir, "tigrfam", "TIGRFam.hmm")
     hmmer_results = hmmer.run_hmmer(record, features, MAX_EVALUE, MIN_SCORE, tigr_db,
                                     "tigrfam", filter_overlapping=False)

--- a/antismash/modules/nrps_pks/data/aaSMILES.txt
+++ b/antismash/modules/nrps_pks/data/aaSMILES.txt
@@ -52,7 +52,7 @@ pPro N1CC(CCC)CC1C(=O)O # 4-propyl-proline
 aad NC(CCCC(=O)O)C(=O)O # 2-amino-adipic acid
 abu NC(C(C))C(=O)O # 2-amino-butyric acid
 bmt NC(C(O)C(C)CC=CC)C(=O)O # 4-butenyl-4-methyl threonine
-cap NC1=NCCC(N1)C(N)C(=O)O # capreomycidine
+cap NC(C1CCN=C(N1)N)C(=O)O # capreomycidine
 dab NC(CCN)C(=O)O # 2,4-diaminobutyric acid
 dht NC(C(=O)C)C(=O)O # dehydro-threonine/2,3-dehydroaminobutyric acid
 hiv OC(C(C)C)C(=O)O # 2-hydroxyisovalerate


### PR DESCRIPTION
Both TigrFAM and ClusterHMMer used very silly ways of generating feature lists, these have been changed to use the functionality provided by the `Record` class. The results aren't affected.

As the JSON results serialiser changes introduced in c2d08646 were just a small addition that regenerate, the compatible schema list has been bumped. This won't likely have much affect on most use cases of actual results reuse as rulesets have changed, but there are some edge cases where it's useful.

The SMILES for the `cap` substrate have been rearranged so the backbone ordering is consistent with other substrates.