### PR TITLE
clusterblast: remove raw diamond output files

### DIFF
--- a/antismash/modules/clusterblast/clusterblast.py
+++ b/antismash/modules/clusterblast/clusterblast.py
@@ -16,7 +16,6 @@ from .core import (
     parse_all_clusters,
     run_diamond_on_all_regions,
     score_clusterblast_output,
-    write_raw_clusterblastoutput,
 )
 from .data_structures import ReferenceCluster, Protein
 from .results import RegionResult, GeneralResults
@@ -40,8 +39,6 @@ def perform_clusterblast(options: ConfigType, record: Record,
     regions = record.get_regions()
     database = os.path.join(options.database_dir, 'clusterblast', 'proteins')
     blastoutput = run_diamond_on_all_regions(regions, database)
-
-    write_raw_clusterblastoutput(options.output_dir, blastoutput)
 
     clusters_by_number, _ = parse_all_clusters(blastoutput, record,
                                                min_seq_coverage=10,

--- a/antismash/modules/clusterblast/core.py
+++ b/antismash/modules/clusterblast/core.py
@@ -501,27 +501,6 @@ def internal_homology_blast(record: secmet.Record) -> Dict[int, List[List[str]]]
     return internalhomologygroups
 
 
-def write_raw_clusterblastoutput(output_dir: str, blast_output: str, prefix: str = "clusterblast") -> str:
-    """ Writes blast output to file
-
-        NOTE: the output filename will not change for different records, if
-              multiple records are in an input and the same output directory
-              is used, the file written here will be overwritten
-
-        Arguments:
-            output_dir: the path of the directory to store results
-            blast_output: the output of blast as a single string
-            search_type: the prefix of the filename to create
-
-        Returns:
-            the name of the file written
-    """
-    filename = f"{prefix}output.txt"
-    with open(os.path.join(output_dir, filename), "w", encoding="utf-8") as handle:
-        handle.write(blast_output)
-    return filename
-
-
 def parse_clusterblast_dict(queries: List[Query], clusters: Dict[str, ReferenceCluster],
                             cluster_label: str, allcoregenes: Set[str]
                             ) -> Tuple[Score, List[Tuple[int, int]], List[bool]]:

--- a/antismash/modules/clusterblast/known.py
+++ b/antismash/modules/clusterblast/known.py
@@ -20,7 +20,6 @@ from .core import (
     parse_all_clusters,
     run_diamond_on_all_regions,
     score_clusterblast_output,
-    write_raw_clusterblastoutput,
 )
 from .results import RegionResult, GeneralResults, write_clusterblast_output
 from .data_structures import MibigEntry, ReferenceCluster, Protein
@@ -117,8 +116,6 @@ def perform_knownclusterblast(options: ConfigType, record: Record,
     results = GeneralResults(record.id, search_type="knownclusterblast", data_version=version)
 
     blastoutput = run_diamond_on_all_regions(record.get_regions(), _get_datafile_path('proteins', options))
-    write_raw_clusterblastoutput(options.output_dir, blastoutput,
-                                 prefix="knownclusterblast")
     clusters_by_number, _ = parse_all_clusters(blastoutput, record,
                                                min_seq_coverage=40,
                                                min_perc_identity=45)

--- a/antismash/modules/clusterblast/sub.py
+++ b/antismash/modules/clusterblast/sub.py
@@ -23,7 +23,6 @@ from .core import (
     run_blast,
     score_clusterblast_output,
     write_fastas_with_all_genes,
-    write_raw_clusterblastoutput,
 )
 from .results import RegionResult, GeneralResults
 from .data_structures import ReferenceCluster, Protein
@@ -159,7 +158,6 @@ def perform_subclusterblast(options: ConfigType, record: Record, clusters: Dict[
                                         partitions=options.cpus)
             run_clusterblast_processes(options)
             blastoutput = read_clusterblast_output(options)
-            write_raw_clusterblastoutput(options.output_dir, blastoutput, prefix="subclusterblast")
             # parse and score diamond results
             _, cluster_names_to_queries = blastparse(blastoutput, record,
                                                      min_seq_coverage=40,


### PR DESCRIPTION
These are generally misleading for people, who expect these to be the output of the analysis and not the raw hits. As such, it would be better if they were removed, especially given the file sizes that can be reached.