### PR TITLE
Combine detection information into a single "Ruleset"

### DIFF
--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -966,7 +966,7 @@ class Parser:  # pylint: disable=too-few-public-methods
             rule.cutoff = int(rule.cutoff * multipliers.cutoff)
             rule.neighbourhood = int(rule.neighbourhood * multipliers.neighbourhood)
             if rule.name in self.rules_by_name:
-                raise ValueError("Multiple rules specified for the same rule name")
+                raise ValueError(f"Multiple rules specified for the same rule name: {rule.name}")
             self.rules_by_name[rule.name] = rule
             self.rules.append(rule)
         if self.current_token:

--- a/antismash/common/hmm_rule_parser/structures.py
+++ b/antismash/common/hmm_rule_parser/structures.py
@@ -61,7 +61,7 @@ class DynamicProfile(Signature):
         return self._callable(record)
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class Multipliers:
     """ Multipliers for use in scaling appropriate values within rules. """
     cutoff: float = 1.0

--- a/antismash/common/hmm_rule_parser/test/helpers.py
+++ b/antismash/common/hmm_rule_parser/test/helpers.py
@@ -8,6 +8,7 @@
 
 import os
 
+from antismash.common.hmm_rule_parser.cluster_prediction import Ruleset
 from antismash.common.signature import get_signature_profiles
 
 
@@ -23,3 +24,13 @@ def check_hmm_signatures(signature_file, hmm_dir):
                     name = line.split()[-1]
         assert name
         assert name == sig.name, f"{name} != {sig.name}"
+
+
+def create_ruleset(rules, *, categories=None, hmm_profiles=None, seeds="dummy_seeds", tool="test_tool",
+                   dynamic_profiles=None, equivalence_groups=None):
+    if categories is None:
+        categories = {rule.category for rule in rules}
+    return Ruleset(tuple(rules), hmm_profiles or {}, seeds, categories,
+                   tool=tool, dynamic_profiles=dynamic_profiles or {},
+                   equivalence_groups=equivalence_groups or set(),
+                   )

--- a/antismash/common/hmm_rule_parser/test/test_categories.py
+++ b/antismash/common/hmm_rule_parser/test/test_categories.py
@@ -21,6 +21,7 @@ class TestCategoryParsing(unittest.TestCase):
             "A": {"description": "some desc", "version": 1},
             "B": {"description": "some other desc", "version": 1},
         }
+        _PARSED_FILES.clear()
 
     def tearDown(self):
         _PARSED_FILES.clear()

--- a/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
@@ -4,6 +4,7 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,too-many-public-methods
 
+from dataclasses import FrozenInstanceError
 import unittest
 from unittest.mock import patch
 
@@ -178,6 +179,15 @@ class TestMultipliers(unittest.TestCase):
         # make sure the multipliers were used
         assert multiplied.cutoff == rule.cutoff * multipliers.cutoff
         assert multiplied.neighbourhood == rule.neighbourhood * multipliers.neighbourhood
+
+    def test_multipliers_unchangeable(self):
+        multipliers = structures.Multipliers(1, 5)
+        assert multipliers.cutoff == 1
+        assert multipliers.neighbourhood == 5
+        with self.assertRaises(FrozenInstanceError):
+            multipliers.cutoff = 1
+        with self.assertRaises(FrozenInstanceError):
+            multipliers.neighbourhood = 5
 
 
 class TestDomainAnnotations(unittest.TestCase):

--- a/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
@@ -13,6 +13,8 @@ from antismash.common.secmet.qualifiers.gene_functions import GeneFunction
 from antismash.common.secmet.test.helpers import DummyProtocluster
 from antismash.common.test.helpers import DummyRecord, DummyCDS, FakeHSPHit
 
+from .helpers import create_ruleset
+
 
 class DummyConditions(rule_parser.Conditions):
     """ so a DetectionRule can be created without failing its internal checks """
@@ -143,11 +145,8 @@ class TestDynamic(unittest.TestCase):
         # build a dummy rule that will search for this hit
         condition = rule_parser.SingleCondition(False, "a_finder")
         rule = rule_parser.DetectionRule("test-name", "Other", 5000, 5000, condition)
-        with patch.object(cluster_prediction, "create_rules", return_value=[rule]):
-            results = cluster_prediction.detect_protoclusters_and_signatures(
-                record, None, None, [None], set("Other"), None, "test_tool",
-                dynamic_profiles={profile.name: profile}
-            )
+        ruleset = create_ruleset([rule], categories=set("Other"), dynamic_profiles={profile.name: profile})
+        results = cluster_prediction.detect_protoclusters_and_signatures(record, ruleset, "test_tool")
         assert results
         assert results.cds_by_cluster
         assert results.protoclusters
@@ -157,23 +156,13 @@ class TestDynamic(unittest.TestCase):
         results.annotate_cds_features()
         assert cdses[0].sec_met.domains[0].name == "a_finder"
 
-    def test_overlap_names(self):
-        record = DummyRecord(features=[DummyCDS()])
-        profile = structures.DynamicProfile("dummy", "desc", lambda record: {})
-        with patch.object(cluster_prediction, "get_signature_profiles", return_value=[profile]):
-            with self.assertRaisesRegex(ValueError, "profiles overlap"):
-                cluster_prediction.detect_protoclusters_and_signatures(
-                    record, None, None, [None], set("Other"), None, "test_tool",
-                    dynamic_profiles={profile.name: profile}
-                )
-
 
 class TestMultipliers(unittest.TestCase):
     def test_create_rules(self):
         text = "RULE A CATEGORY Cat CUTOFF 10 NEIGHBOURHOOD 5 CONDITIONS A"
         # with default multipliers
         with patch("builtins.open", unittest.mock.mock_open(read_data=text)):
-            rule = cluster_prediction.create_rules("dummy.file", {"A"}, {"Cat"}, {})[0]
+            rule = cluster_prediction.create_rules(["dummy.file"], {"A"}, {"Cat"})[0]
         assert rule.cutoff == 10_000
         assert rule.neighbourhood == 5_000
 
@@ -183,33 +172,12 @@ class TestMultipliers(unittest.TestCase):
             neighbourhood=0.5,
         )
         with patch("builtins.open", unittest.mock.mock_open(read_data=text)):
-            multiplied = cluster_prediction.create_rules("dummy.file", {"A"}, {"Cat"}, {},
+            multiplied = cluster_prediction.create_rules(["dummy.file"], {"A"}, {"Cat"},
                                                          multipliers=multipliers,
                                                          )[0]
         # make sure the multipliers were used
         assert multiplied.cutoff == rule.cutoff * multipliers.cutoff
         assert multiplied.neighbourhood == rule.neighbourhood * multipliers.neighbourhood
-
-    @patch.object(cluster_prediction, "get_signature_profiles", return_value={})
-    def test_multplier_propagation(self, _patched_sig):
-        record = DummyRecord()
-        record.add_cds_feature(DummyCDS())
-        args = [record, "dummy.sigs", "dummy.seeds", ["dummy.rules"], {"cat"},
-                "dummy.filter", "tool"]
-        multipliers = cluster_prediction.Multipliers(
-            cutoff=0.1,
-            neighbourhood=2.0,
-        )
-        kwargs = {
-            "multipliers": multipliers,
-        }
-        with patch.object(cluster_prediction, "create_rules",
-                          side_effect=RuntimeError("stop here")) as patched_create:
-            with self.assertRaisesRegex(RuntimeError, "stop here"):
-                cluster_prediction.detect_protoclusters_and_signatures(*args, **kwargs)
-            # make sure the multipliers made it all the way to rule creation
-            _, actual_kwargs = patched_create.call_args
-            assert actual_kwargs["multipliers"] == multipliers
 
 
 class TestDomainAnnotations(unittest.TestCase):

--- a/antismash/common/signature.py
+++ b/antismash/common/signature.py
@@ -10,21 +10,22 @@ from .path import get_full_path
 
 class Signature:
     """Secondary metabolite signature"""
-    def __init__(self, name: str, _type: str, description: str, cutoff: int, path: str) -> None:
+    def __init__(self, name: str, _type: str, description: str, cutoff: int, path: str, seed_count: int = 0) -> None:
         self.name = name
         self.type = _type
         self.description = description
         self.cutoff = cutoff
         self.path = path
+        self.seed_count = seed_count
 
 
 class HmmSignature(Signature):
     """ A container holding information on a HMM signature """
-    def __init__(self, name: str, description: str, cutoff: int, hmm_path: str) -> None:
+    def __init__(self, name: str, description: str, cutoff: int, hmm_path: str, seed_count: int = 0) -> None:
         self.hmm_file = hmm_path
         if cutoff < 0:
             raise ValueError(f"Signature cutoffs cannot be negative: {cutoff}")
-        super().__init__(name, 'model', description, cutoff, self.hmm_file)
+        super().__init__(name, 'model', description, cutoff, self.hmm_file, seed_count)
 
 
 def get_signature_profiles(detail_file: str) -> List[HmmSignature]:
@@ -50,8 +51,18 @@ def get_signature_profiles(detail_file: str) -> List[HmmSignature]:
             except ValueError:
                 bad_lines.append(line)
                 continue
+            num_seeds = -1
+            # then find and read the seeds
+            with open(get_full_path(detail_file, filename), "r", encoding="utf-8") as handle:
+                lines = handle.readlines()
+            for line in lines:
+                if line.startswith('NSEQ '):
+                    num_seeds = int(line[6:].strip())
+                    break
+            if num_seeds == -1:
+                raise ValueError(f"Unknown number of seeds for hmm file: {filename}")
             profiles.append(HmmSignature(name, desc, int(cutoff),
-                                         get_full_path(detail_file, filename)))
+                                         get_full_path(detail_file, filename), num_seeds))
 
     if bad_lines:
         raise ValueError("Invalid lines in HMM detail file (first 10):\n%s" % "\n".join(bad_lines[:10]))

--- a/antismash/detection/hmm_detection/__init__.py
+++ b/antismash/detection/hmm_detection/__init__.py
@@ -232,8 +232,9 @@ def run_on_record(record: Record, previous_results: Optional[HMMDetectionResults
 
     multipliers = Multipliers()
     if options.taxon == "fungi":
-        multipliers.cutoff = options.hmmdetection_fungal_cutoff_multiplier
-        multipliers.neighbourhood = options.hmmdetection_fungal_neighbourhood_multiplier
+        multipliers = Multipliers(options.hmmdetection_fungal_cutoff_multiplier,
+                                  options.hmmdetection_fungal_neighbourhood_multiplier,
+                                  )
 
     ruleset = get_ruleset(options)
     results = detect_protoclusters_and_signatures(record, ruleset)

--- a/antismash/detection/hmm_detection/test/integration_hmm_detection.py
+++ b/antismash/detection/hmm_detection/test/integration_hmm_detection.py
@@ -6,9 +6,7 @@
 
 import json
 import unittest
-from unittest.mock import patch
 
-from antismash.common.hmm_rule_parser import cluster_prediction
 from antismash.common.secmet import Record
 from antismash.common.secmet.test.helpers import DummySubRegion
 from antismash.common.test.helpers import get_path_to_nisin_genbank
@@ -22,13 +20,17 @@ class TestSubregionAnnotations(unittest.TestCase):
 
     def tearDown(self):
         destroy_config()
+        hmm_detection._RULESETS.clear()
 
-    @patch.object(cluster_prediction, "create_rules", return_value=[])
-    def test_subregions_annotated(self, _patched_rules):
+    def test_subregions_annotated(self):
         record = Record.from_genbank(get_path_to_nisin_genbank())[0]
         record.strip_antismash_annotations()
         assert not record.get_regions()
         assert not record.get_subregions()
+         # this next hack requires that the ruleset cache is cleared in the test teardown
+         # because it's nuking the default ruleset that all following tests (not just this file)
+         # will use
+        hmm_detection.get_ruleset(self.options)._rules = []
 
         results = hmm_detection.run_on_record(record, None, self.options)
         assert not results.get_predicted_protoclusters()

--- a/antismash/detection/hmm_detection/test/test_hmm_detection.py
+++ b/antismash/detection/hmm_detection/test/test_hmm_detection.py
@@ -374,13 +374,12 @@ class TestRuleExtenders(unittest.TestCase):
         pkg = hmm_detection  # to avoid quite a bit of repetition below
         sigs = [pkg.HmmSignature(name, "", 0, "") for name in ["A", self.extender_name, "X"]]
         with patch.object(pkg, "get_signature_profiles", return_value=sigs):
-            with patch.object(pkg, "get_sequence_counts", return_value={sig.name: 1 for sig in sigs}):
-                with patch.object(pkg, "find_hmmer_hits", return_value=self.results_by_id):
-                    with patch.object(pkg, "create_rules", return_value=rules):
-                        return pkg.detect_protoclusters_and_signatures(
-                            self.record, "dummy_sig", "dummy_seeds", ["dummy_rules"], {"Cat"},
-                            "dummy_filter", "dummy_tool"
-                        )
+            with patch.object(pkg, "find_hmmer_hits", return_value=self.results_by_id):
+                with patch.object(pkg, "create_rules", return_value=rules):
+                    return pkg.detect_protoclusters_and_signatures(
+                        self.record, "dummy_sig", "dummy_seeds", ["dummy_rules"], {"Cat"},
+                        "dummy_filter", "dummy_tool"
+                    )
 
     def add_hit(self, cds_name, hit_name):
         hit = FakeHSPHit(hit_name, cds_name, 0, 10, 50, 0)


### PR DESCRIPTION
This is a collection of code cleanup, performance optimisations, and flexibility.

The code has been cleaned up and more easily navigated by bundling all relevant options into a `Ruleset` class; these include the rules themselves, the categories and signature information those rules refer to, and so on.

For fragmented inputs or inputs of many genomes, the rule parser caches these new `Ruleset` instances, meaning any particular combination of rules and multipliers will only ever have to be parsed once globally instead of once per contig. This won't help single well assembled chromosomes, but should help uses like metagenomic and fungal inputs.

As for extra flexibility, by taking advantage of the `Ruleset`s bundling things, it's trivial to add a limitation via code or the command line on which rules will be run:
- `--hmmdetection-limit-to-rule-names` takes a comma-separated list of case-sensitive rule names, and only rules within this list will be considered for protocluster detection
- `--hmmdetection-limit-to-rule-categories` takes a comma-separated list of case-sensitive rule categories, and only rules belonging to those categories will be considered

In case of both options being provided, the intersection of the two will be used.

Even when rules are limited, all default profiles will still be used.