### PR TITLE
HTML generation optimisation

### DIFF
--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -78,7 +78,7 @@ class Record:
                  ]
 
     def __init__(self, seq: Union[Seq, str] = "", *,
-                 transl_table: int = 1,
+                 transl_table: int = 1, gc_content: float = -1.,
                  **kwargs: Any,
                  ) -> None:
         # prevent paths from being used as a sequence
@@ -126,7 +126,7 @@ class Record:
         self._region_numbering: Dict[Region, int] = {}
 
         self._transl_table = int(transl_table)
-        self._gc_content: float = -1.
+        self._gc_content: float = gc_content
 
     def __getattr__(self, attr: str) -> Any:
         # passthroughs to the original SeqRecord

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -74,7 +74,8 @@ class Record:
                  "_candidate_clusters", "_candidate_clusters_numbering",
                  "_subregions", "_subregion_numbering",
                  "_regions", "_region_numbering", "_antismash_domains_by_tool",
-                 "_antismash_domains_by_cds_name"]
+                 "_antismash_domains_by_cds_name", "_gc_content",
+                 ]
 
     def __init__(self, seq: Union[Seq, str] = "", transl_table: int = 1, **kwargs: Any) -> None:
         # prevent paths from being used as a sequence
@@ -122,6 +123,7 @@ class Record:
         self._region_numbering: Dict[Region, int] = {}
 
         self._transl_table = int(transl_table)
+        self._gc_content: float = -1.
 
     def __getattr__(self, attr: str) -> Any:
         # passthroughs to the original SeqRecord
@@ -1015,9 +1017,11 @@ class Record:
         """ Calculate the GC content of the record's sequence """
         if not self.seq:
             raise ValueError("Cannot calculate GC content of empty sequence")
-        counter = Counter(str(self.seq))
-        gc_count = counter['G'] + counter['C'] + counter['g'] + counter['c']
-        return gc_count / len(self)
+        if self._gc_content < 0:  # not cached
+            counter = Counter(str(self.seq))
+            gc_count = counter['G'] + counter['C'] + counter['g'] + counter['c']
+            self._gc_content = gc_count / len(self)
+        return self._gc_content
 
     def strip_antismash_annotations(self) -> None:
         """ Removes all antismash features and annotations from the record """

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -77,7 +77,10 @@ class Record:
                  "_antismash_domains_by_cds_name", "_gc_content",
                  ]
 
-    def __init__(self, seq: Union[Seq, str] = "", transl_table: int = 1, **kwargs: Any) -> None:
+    def __init__(self, seq: Union[Seq, str] = "", *,
+                 transl_table: int = 1,
+                 **kwargs: Any,
+                 ) -> None:
         # prevent paths from being used as a sequence
         assert not set("./\\").issubset(set(seq)), "Invalid sequence provided"
         if isinstance(seq, str):
@@ -727,7 +730,7 @@ class Record:
 
     @classmethod
     def from_biopython(cls: Type[T], seq_record: SeqRecord, taxon: str,
-                       discard_antismash_features: bool = False) -> T:
+                       discard_antismash_features: bool = False, **kwargs: Any) -> T:
         """ Constructs a new Record instance from a biopython SeqRecord,
             also replaces biopython SeqFeatures with Feature subclasses
 
@@ -748,7 +751,7 @@ class Record:
         transl_table = 1  # standard
         if str(taxon) == "bacteria":
             transl_table = 11  # bacterial, archea, plant plastid code
-        record = cls(transl_table=transl_table)
+        record = cls(seq=seq_record.seq, transl_table=transl_table, **kwargs)
         record._record = seq_record
         # because is_circular() can't be used reliably at this stage due to fasta files
         can_be_circular = taxon == "bacteria"

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -429,6 +429,13 @@ class TestRecord(unittest.TestCase):
             assert rec.get_gc_content() == gc_content  # value should not change
             assert not patched.called  # and the calculation shouldn't have run again
 
+    def test_gc_setting(self):
+        rec = Record("A", gc_content=0.3)
+        # the arg is trusted, even if it's wrong
+        assert rec._gc_content == 0.3
+        # and since it's already set, the getter should return it
+        assert rec.get_gc_content() == 0.3
+
 
 class TestCDSFetchByLocation(unittest.TestCase):
     def setUp(self):

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -77,6 +77,13 @@ class TestConversion(unittest.TestCase):
         assert type_counts["cluster"] == len(record.get_protoclusters())
         assert type_counts["aSDomain"] == len(record.get_antismash_domains())
 
+    def test_conversion_with_kwargs(self):
+        bio = Record(seq=Seq("ACGT")).to_biopython()
+        other_values = {"first": 5., "second": "value"}
+        with patch.object(record_pkg.SeqRecord, "__init__", return_value=None) as patched_bio:
+            Record.from_biopython(bio, "taxon", **other_values)
+            patched_bio.assert_called_once_with(bio.seq, **other_values)
+
     def test_protein_sequences_caught(self):
         before = list(Bio.SeqIO.parse(get_path_to_nisin_genbank(), "genbank"))[0]
 

--- a/antismash/common/test/test_serialiser.py
+++ b/antismash/common/test/test_serialiser.py
@@ -141,8 +141,7 @@ class TestAreas(unittest.TestCase):
         assert not res["protoclusters"]
 
         # lastly, check all this is properly embedded in the final JSON
-        bio = record.to_biopython()
-        full = serialiser.dump_records([bio], [{}], [record])
+        full = serialiser.dump_records([{}], [record])
         assert full[0]["areas"] == results
 
 

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -449,10 +449,20 @@ def write_outputs(results: serialiser.AntismashResults, options: ConfigType) -> 
 
     if html.is_enabled(options):
         logging.debug("Creating results page")
+        start = time.time()
         html.write(results.records, module_results_per_record, options, get_all_modules())
+        # use an average of times for html
+        duration = time.time() - start / len(results.records)
+        for val in results.timings_by_record.values():
+            val[html.__name__] = duration
 
     logging.debug("Creating results SVGs")
+    start = time.time()
     svg.write(options, module_results_per_record)
+    # again, use an average of times
+    duration = (time.time() - start) / len(results.records)
+    for val in results.timings_by_record.values():
+        val[svg.__name__] = duration
 
     # convert records to biopython
     bio_records = [record.to_biopython() for record in results.records]

--- a/antismash/outputs/html/templates/regions.html
+++ b/antismash/outputs/html/templates/regions.html
@@ -2,6 +2,7 @@
 
 {% for record in records %}
 {% set results = results_by_record_id[record.id] %}
+{% set show_tta = tta_name in results and record.get_gc_content() >= options.tta_threshold %}
 {% for region in record.regions %}
 <div class="page" id='{{region.anchor_id}}' style="display: none;">
  <div class="region-grid">
@@ -47,7 +48,7 @@
                 <rect x=0 y=2 height=4 width=8 class="svgene-resistance"></rect>
             </svg>
         {% endcall %}
-        {% if tta_name in results and record.get_gc_content() >= options.tta_threshold %}
+        {% if show_tta %}
             {% call le.symbol_legend('legend-tta-codon', 'TTA codons') %}
                 <svg viewbox="0 0 6 6">
                     <polyline class="svgene-tta-codon" points="3,0 0,6 6,6 3,0">


### PR DESCRIPTION
Around 25% of the time spent in HTML generation, including when using `--reuse`, was spent calculating the GC content of records. This was largely due to repeatedly calculating it in a loop over regions within the record within the HTML template that generates each region view.

Even after moving the repetition out of the loop, it's still a repeated calculation, as the TTA module will use it along with the HTML output module. To fix this, `Record` now caches the value after it's been calculated once.

To go even further, this doesn't even need to be calculated at all when using `--reuse` if the value is kept in the JSON results. That's fixed by adding a `gc_content` field to the JSON records, and the required infrastructure to pass that through to `Record`'s init and also `from_biopython()`.

As a last bonus, the HTML and SVG generation time is now included in the debug logging of module timings.