### PR TITLE
Misc fixes

### DIFF
--- a/antismash/__main__.py
+++ b/antismash/__main__.py
@@ -4,7 +4,6 @@
 # A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
 """Run the antiSMASH pipeline"""
 
-import logging
 import os
 import sys
 from typing import List, Optional
@@ -113,7 +112,7 @@ def main(args: List[str]) -> int:
     except antismash.common.errors.AntismashInputError as err:
         if not str(err):
             raise
-        logging.error(str(err))
+        print("ERROR:", str(err), file=sys.stderr)
         return 1
 
     return 0

--- a/antismash/common/subprocessing/test/test_diamond.py
+++ b/antismash/common/subprocessing/test/test_diamond.py
@@ -20,10 +20,39 @@ def test_diamond_version(mock_run_diamond):
     mock_run_diamond.assert_called_once_with("version", use_default_opts=False)
 
 
-@patch("antismash.common.subprocessing.diamond.run_diamond", return_value=DummyResult("lots of useless text"))
-def test_diamond_makedb(mock_run_diamond):
+@patch.object(diamond, "run_diamond", return_value=DummyResult("lots of useless text"))
+@patch.object(diamond, "run_diamond_version", return_value="diamond version X.Y.Z")
+def test_diamond_makedb(_mocked_version, mock_run_diamond):
     subprocessing.run_diamond_makedb("fake.dmnd", "fake.fasta")
-    mock_run_diamond.assert_called_once_with("makedb", ["--db", "fake.dmnd", "--in", "fake.fasta"])
+    assert mock_run_diamond.call_count == 1
+    assert mock_run_diamond.call_args.kwargs == {"use_default_opts": True}
+    assert mock_run_diamond.call_args[0] == ("makedb", ["--db", "fake.dmnd", "--in", "fake.fasta"])
+
+
+@patch.object(diamond, "TemporaryDirectory")
+def test_diamond_tmpdir_bug(mocked_tempdir):
+    temp_dir = "some_temp_dir"
+    mocked_tempdir.return_value.__enter__.return_value = temp_dir
+    # make sure the mock works before continuing, since it's a bit complicated
+    with diamond.TemporaryDirectory() as temp:
+        assert temp == temp_dir
+
+    def run(version):
+        with patch.object(diamond, "execute") as mocked_execute:
+            with patch.object(diamond, "run_diamond_version", return_value=version):
+                subprocessing.run_diamond_makedb("fake.dmnd", "fake.fasta")
+                assert mocked_execute.call_count == 1
+                args = mocked_execute.call_args[0][0]
+        return args
+
+    # known good boundaries and some odd formats that can't be predicted
+    for version in ["0.9.3", "2.0.4", "2.1.7", "vX.Y.Z"]:
+        args_used = run(version)
+        assert "--tmpdir" in args_used
+    # known bad boundaries
+    for version in ["2.1.0", "2.1.4", "2.1.6"]:
+        args_used = run(version)
+        assert "--tmpdir" not in args_used
 
 
 class TestDiamondDatabaseChecks(unittest.TestCase):

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -30,7 +30,7 @@ from antismash.config import (
     get_config,
     update_config,
 )
-from antismash.common import logs, record_processing, serialiser
+from antismash.common import errors, logs, record_processing, serialiser
 from antismash.common.module_results import ModuleResults, DetectionResults
 from antismash.common.path import get_full_path
 from antismash.common.secmet import Record
@@ -683,7 +683,11 @@ def run_antismash(sequence_file: Optional[str], options: ConfigType) -> int:
 
     with logs.changed_logging(logfile=options.logfile, verbose=options.verbose,
                               debug=options.debug):
-        result = _run_antismash(sequence_file, options)
+        try:
+            result = _run_antismash(sequence_file, options)
+        except errors.AntismashInputError as err:
+            logging.error(str(err))
+            raise
     return result
 
 

--- a/antismash/modules/smcog_trees/trees.py
+++ b/antismash/modules/smcog_trees/trees.py
@@ -18,6 +18,7 @@ from Bio.Phylo.NewickIO import NewickError
 import brawn
 from helperlibs.wrappers.io import TemporaryDirectory
 import matplotlib
+from matplotlib import pyplot
 
 from antismash.common import path, fasta, subprocessing
 from antismash.common.secmet import CDSFeature
@@ -155,9 +156,9 @@ def draw_tree(input_number: int, output_dir: str, tag: str) -> str:
 
     Phylo.draw(tree, do_show=False, label_colors=label_colors,
                label_func=lambda node: str(node).replace("|", " "))
-    fig = matplotlib.pyplot.gcf()
+    fig = pyplot.gcf()
     fig.set_size_inches(20, (tree.count_terminals() / 3))
-    matplotlib.pyplot.axis('off')
+    pyplot.axis('off')
     fig.savefig(tree_filename, bbox_inches='tight')
-    matplotlib.pyplot.close(fig)
+    pyplot.close(fig)
     return tree_filename

--- a/antismash/test/test_antismash.py
+++ b/antismash/test/test_antismash.py
@@ -7,10 +7,14 @@
 from argparse import Namespace
 import logging
 import os
+from tempfile import NamedTemporaryFile
 import unittest
 from unittest.mock import call, patch
 
-from antismash import main
+import pytest
+
+from antismash import __main__ as outer, config, main
+from antismash.common.errors import AntismashInputError
 from antismash.common.test.helpers import DummyRecord
 from antismash.config import build_config, destroy_config, get_config
 from antismash.config.args import build_parser
@@ -120,6 +124,60 @@ class TestAntismash(unittest.TestCase):
 
         res = main.canonical_base_filename("foo.1_example.gbff.gz", "out", options)
         assert res == expected
+
+
+class TestErrorsInLogfile(unittest.TestCase):
+    def setUp(self):
+        destroy_config()
+
+    def tearDown(self):
+        destroy_config()
+
+    # in a TestCase, the pytest capture system can't be used for a 'test_*' method
+    # this solves the problem by storing it locally
+    @pytest.fixture(autouse=True)
+    def capture(self, capsys):
+        self.outputs = capsys  # pylint: disable=attribute-defined-outside-init
+
+    @patch.object(outer.os.path, "isfile", return_value=True)
+    @patch.object(outer, "get_git_version", return_value="deadbeef")
+    def test_error_logging_to_file(self, *_):
+        error_message = "bad"
+        with NamedTemporaryFile() as logfile:
+            logfile_path = logfile.name
+            # trick the input path checking by pointing it to the (empty) log file
+            args = [logfile_path, "--logfile", logfile_path]
+            options = build_config(args, isolated=True)
+            with patch.object(main, "_run_antismash", side_effect=AntismashInputError(error_message)) as runner:
+                # avoid constructing a non-isolated config
+                with patch.object(config.AntismashParser, "parse_args", return_value=options):
+                    assert build_config(args).logfile == logfile_path
+                    assert get_config(args).logfile == logfile_path
+
+                # finally, run the actual function being tested
+                result = outer.main(args)
+
+                # the run should count as a failure
+                assert result == 1
+                # the mocked inner call should have been run, with the options setting a logfile
+                assert runner.call_count == 1
+                assert runner.call_args == ((logfile_path, options),)
+            # read the temporary log file before it's deleted
+            with open(logfile_path, encoding="utf-8") as handle:
+                log_lines = handle.read().splitlines()
+
+        def check_message(line):
+            assert line.startswith("ERROR") and line.endswith(error_message)
+
+        # the error should be logged
+        assert len(log_lines) == 1
+        check_message(log_lines[0])
+
+        # and also printed to stderr, since the logfile would hide it from the terminal
+        printed = self.outputs.readouterr()  # fetches stdout/stderr via pytest
+        check_message(printed.err.strip())
+        # and nothing should have gone to stdout
+        assert not printed.out
 
 
 @patch.object(logging, 'debug')

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ install_requires = [
     'helperlibs',
     'jinja2',
     'joblib',
-    'jsonschema',
+    'jsonschema==4.11.0',
     'markupsafe >= 2.0',
     'nrpys >= 0.1.1',
     'pysvg-py3',


### PR DESCRIPTION
The final log message for a run that failed due to invalid inputs was outside the context in which logging was set up, this meant that log files never received this last, rather important, message.

I've added three more small fixes to this PR:
- `jsonschema` version is now pinned until some deprecations are handled
- uses of `matplotlib.pyplot` have been changed to be more agnostic of packages versions (including python versions)
- works around a bug in some versions of diamond

The diamond bug is that the subcommand `makedb` considered the use of  `--tmpdir` to be an error, and it affected versions 2.1.0 to 2.1.6. Handling has been added to ensure that `run_diamond_makedb()` avoids that parameter when those versions are in use.  This is particularly annoying in Debian 12/bookworm, for which the current diamond package is 2.1.3.