### PR TITLE
Tweaks for ClusterCompare

### DIFF
--- a/antismash/detection/sideloader/__init__.py
+++ b/antismash/detection/sideloader/__init__.py
@@ -20,7 +20,7 @@ from .html_output import generate_html, will_handle
 
 NAME = "sideloader"
 SHORT_DESCRIPTION = "Side-loaded annotations"
-DETECTION_STAGE = DetectionStage.AREA_FORMATION
+DETECTION_STAGE = DetectionStage.FULL_GENOME
 
 
 def _parse_arg(option: str) -> SideloadSimple:

--- a/antismash/detection/sideloader/data_structures.py
+++ b/antismash/detection/sideloader/data_structures.py
@@ -241,3 +241,9 @@ class SideloadedResults(DetectionResults):
 
     def get_predicted_protoclusters(self) -> List[Protocluster]:
         return [proto.to_secmet() for proto in self.protoclusters]
+
+    def add_to_record(self, record: Record) -> None:
+        for subregion in self.subregions:
+            record.add_subregion(subregion.to_secmet())
+        for protocluster in self.protoclusters:
+            record.add_protocluster(protocluster.to_secmet())

--- a/antismash/modules/cluster_compare/html_output.py
+++ b/antismash/modules/cluster_compare/html_output.py
@@ -41,7 +41,14 @@ def generate_html(region_layer: RegionLayer, results: ClusterCompareResults,
             tooltip += f"<br>Click on an accession to open that entry in the {db_results.name} database."
         variant_results = db_results.by_region.get(region_layer.get_region_number(), {})
         divs: List[Tuple[str, str, Markup]] = []
-        for variant, result in sorted(variant_results.items()):
+
+        # for the MIBiG DB specifically, always show region to region by default
+        if label == "MIBiG":
+            pairs = sorted(variant_results.items(), key=lambda name: (1 if name == "RegionToRegion" else 0, name))
+        else:
+            pairs = sorted(variant_results.items())
+
+        for variant, result in pairs:
             scores = result.scores_by_region[:DISPLAY_LIMIT]
             if not scores:
                 continue


### PR DESCRIPTION
Two issues related to subregions caused poor results in ClusterCompare when comparing against MIBiG hits:

1. CDS features with hits to rule detection profiles were not annotated when only in a sideloaded subregion and not a protocluster. This was due to sideloaded annotations being added _after_ the detection ran. This caused ClusterCompare to be missing components when the region in question had a subregion (e.g. all of the MIBiG antiSMASH-generated pages).
The fix was moving the sideloaded detection to the "full genome" stage prior to the "area formation stage".

2. The "Protocluster to Region" view for the ClusterCompare visualisation deliberately omits subregions since they aren't protoclusters. The "Region to Region" view is more accurate in that case. Since all antiSMASH-generated MIBiG pages have subregions, this could cause some confusion.
The fix for that is making MIBiG-specific comparisons default to "Region to Region" instead of "Protocluster to Region".