### PR TITLE
Misc fixes

### DIFF
--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -551,14 +551,10 @@ def create_rules(rule_files: list[str], signature_names: Set[str],
                  ) -> List[rule_parser.DetectionRule]:
     """ Creates DetectionRule instances from the default rules file
 
-        Updates existing_aliases with any aliases found.
-
         Args:
             rule_files: a list of paths to files containing cluster rules
             signature_names: the set of all known profile/signature names
             valid_categories: the set of all valid rule categories
-            existing_aliases: a dict of alias name to resulting tokens, updated with new values
-            existing_rules: a list of existing rules, if any
             multipliers: distance multipliers to apply to rules
 
         Returns:

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
 from Bio.Data import CodonTable, IUPACData
 from Bio.SeqFeature import SeqFeature
 
-from antismash.common.secmet import features
+import antismash  # for use in referring to Regions, which import this module
 from antismash.common.secmet.qualifiers import (
     GeneFunction,
     GeneFunctionAnnotations,
@@ -18,6 +18,7 @@ from antismash.common.secmet.qualifiers import (
     SecMetQualifier,
 )
 
+from .cds_motif import CDSMotif
 from ..errors import SecmetInvalidInputError
 from ..locations import (
     AfterPosition,
@@ -166,10 +167,10 @@ class CDSFeature(Feature):
         self._nrps_pks = NRPSPKSQualifier(self.location.strand)
 
         self._modules: List[Module] = []
-        self.motifs: List[features.CDSMotif] = []
+        self.motifs: List[CDSMotif] = []
 
         # runtime-only data
-        self.region: Optional[features.Region] = None
+        self.region: Optional[antismash.common.secmet.features.Region] = None
         self.unique_id: Optional[str] = None  # set only when added to a record
 
     @property

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -31,6 +31,7 @@ from antismash.config import (
     update_config,
 )
 from antismash.common import errors, logs, record_processing, serialiser
+from antismash.common.errors import AntismashInputError
 from antismash.common.module_results import ModuleResults, DetectionResults
 from antismash.common.path import get_full_path
 from antismash.common.secmet import Record
@@ -324,11 +325,11 @@ def prepare_output_directory(name: str, input_file: str) -> None:
 
     if os.path.exists(name):
         if not os.path.isdir(name):
-            raise RuntimeError("Output directory {name!r} exists and is not a directory")
+            raise AntismashInputError("Output directory {name!r} exists and is not a directory")
         # not empty (apart from a possible input dir), and not reusing its results
         if not input_file.endswith(".json") and \
                 list(filter(_ignore_patterns, glob.glob(os.path.join(name, "*")))):
-            raise RuntimeError("Output directory contains other files, aborting for safety")
+            raise AntismashInputError("Output directory contains other files, aborting for safety")
 
         # --reuse
         logging.debug("Removing existing region genbank files")

--- a/antismash/modules/lassopeptides/__init__.py
+++ b/antismash/modules/lassopeptides/__init__.py
@@ -15,7 +15,7 @@ from antismash.config import ConfigType
 from antismash.config.args import ModuleArgs
 
 from .config import get_config as local_config
-from .specific_analysis import specific_analysis, LassoResults
+from .specific_analysis import specific_analysis as run_analysis, LassoResults
 from .html_output import generate_html, will_handle
 
 NAME = "lassopeptides"
@@ -90,4 +90,4 @@ def run_on_record(record: Record, results: LassoResults, _options: ConfigType) -
     """ Finds all precursors within lassopeptide clusters """
     if results and isinstance(results, LassoResults):
         return results
-    return specific_analysis(record)
+    return run_analysis(record)

--- a/antismash/outputs/html/__init__.py
+++ b/antismash/outputs/html/__init__.py
@@ -5,6 +5,7 @@
 
 """
 
+import argparse
 import glob
 import logging
 import os
@@ -46,6 +47,11 @@ def get_arguments() -> ModuleArgs:
                     action='store_true',
                     default=False,
                     help="Use compact view by default for overview page.")
+    args.add_option("--html-ncbi-context",
+                    dest="html_ncbi_context",
+                    action=argparse.BooleanOptionalAction,
+                    default=False,
+                    help="Show NCBI genomic context links for genes (default: %(default)s).")
     return args
 
 

--- a/antismash/outputs/html/js.py
+++ b/antismash/outputs/html/js.py
@@ -413,4 +413,4 @@ def get_description(record: Record, feature: CDSFeature, type_: str,
         ec_numbers = ",".join(ec_number_qual)
     return template.render(feature=feature, ec_numbers=ec_numbers, go_notes=go_notes,
                            asf_notes=asf_notes, pfam_notes=pfam_notes, tigr_notes=tigr_notes,
-                           record=record, urls=urls)
+                           record=record, urls=urls, add_ncbi_context=options.html_ncbi_context)

--- a/antismash/outputs/html/templates/cds_detail.html
+++ b/antismash/outputs/html/templates/cds_detail.html
@@ -71,7 +71,9 @@
 </div>
 <div class="focus-urls">
  {{build_blastp_link(feature.get_name(), "NCBI BlastP on this gene")}}<br>
+ {% if add_ncbi_context %}
  <a href="{{urls['context']}}" target="_new">View genomic context</a><br>
+ {% endif %}
  {% if urls['mibig'] %}
   <a href="{{urls['mibig']}}" target="_new">MiBIG Hits</a><br>
  {% endif %}


### PR DESCRIPTION
A collection of small fixes, the important ones being:
- NCBI genomic context links are no longer present by default, since they weren't relevant for many inputs. For them to appear they need to be explicitly enabled with `--html-ncbi-context`.
- Lasspeptide precursors that were in an overlapping neighbourhood of two separate lassopeptide protoclusters no longer crash with a duplicate name

The remainder are small changes for documentation, lint errors, and making some non-deterministic multiprocess testing more reliable.