### PR TITLE
antiSMASH-DB fixes/updates

### DIFF
--- a/antismash/modules/clusterblast/svg_builder.py
+++ b/antismash/modules/clusterblast/svg_builder.py
@@ -290,7 +290,7 @@ class Cluster:
                  description: str, features: Union[List[Protein], List[secmet.CDSFeature]], rank: int,
                  cluster_type: str, hits: int = 0, strand: int = 1, prefix: str = "general") -> None:
         self.region_number = region_number
-        self.ref_cluster_number = ref_cluster_number.lstrip('c')
+        self.ref_cluster_number = ref_cluster_number.lstrip('c').replace("<", "").replace(">", "")
         self.accession = accession
         self.description = description.replace("_", " ")
         self.cluster_type = cluster_type

--- a/antismash/outputs/html/templates/cds_detail.html
+++ b/antismash/outputs/html/templates/cds_detail.html
@@ -71,6 +71,7 @@
 </div>
 <div class="focus-urls">
  {{build_blastp_link(feature.get_name(), "NCBI BlastP on this gene")}}<br>
+ <span class="asdb-linkout link-like wildcard-container" data-locus="{{feature.get_name()}}" data-wildcard-attrs="data-seq" data-seq="{{replace_with('translation')}}">Blast against antiSMASH-database</span><br>
  {% if add_ncbi_context %}
  <a href="{{urls['context']}}" target="_new">View genomic context</a><br>
  {% endif %}


### PR DESCRIPTION
Fixes #666 by removing ambiguous location markers from SVGs and links.

Adds a new link in the gene details panel of HTML output that blasts the gene against the antiSMASH-DB (version 4.0 only).