### PR TITLE
lanthipeptide: avoid hitting too long a gene even if it has a precursor domain

### DIFF
--- a/antismash/modules/lanthipeptides/specific_analysis.py
+++ b/antismash/modules/lanthipeptides/specific_analysis.py
@@ -607,6 +607,9 @@ def find_lan_a_features(area_feature: CDSCollection) -> List[CDSFeature]:
         if len(feature.translation) < MAX_PRECURSOR_LENGTH:
             lan_a_features.append(feature)
             continue
+        # if it has known precursor domains, that's also of interest if it's vaguely the right size
+        if len(feature.translation) > MAX_PRECURSOR_LENGTH * 1.25:
+            continue
         if feature.sec_met and set(feature.sec_met.domain_ids).intersection(KNOWN_PRECURSOR_DOMAINS):
             lan_a_features.append(feature)
 


### PR DESCRIPTION
Fixes rare cases of genes that merge precursors and LANC-likes which resulted in prepeptide cores of 1000+ aminos.