### PR TITLE
Misc optimations and cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+
+# *, meaning every part of the repo, is owned by the whole
+# team so they're the default reviewers
+* @antismash/antismash-developers

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,12 @@ pip-egg-info/*
 
 # generated during make test
 nisin/*
+/*/
+/*.gb*
+/*.gff
+/*.fa
 
 # keep these, even in locations that are ignored
 !antismash/databases/README
+!.github/
+!antismash/

--- a/.pylintrc
+++ b/.pylintrc
@@ -6,7 +6,7 @@ disable=too-few-public-methods
 [MESSAGES CONTROL]
 # raising 'from' is almost entirely false positives
 disable=raise-missing-from
-fail-on=unused-variable,comparison-with-itself,self-assigning-variable
+fail-on=unused-import,unused-variable,comparison-with-itself,self-assigning-variable
 
 [TYPECHECK]
 ignored-classes=Config,TestCase,Namespace

--- a/antismash/common/secmet/features/abstract.py
+++ b/antismash/common/secmet/features/abstract.py
@@ -1,0 +1,57 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+""" Abstract classes/interfaces for various feature types, allowing circular imports to be avoided
+"""
+
+from abc import ABC as AbstractClass, abstractmethod
+
+from Bio.SeqRecord import SeqRecord
+
+from .feature import Feature
+
+
+class AbstractRegion(Feature, AbstractClass):
+    """ An interface for Region features, with additional methods that will be required.
+        Child collections are represented as simple Features here instead of CDSCollections,
+        to avoid circularity with CDSFeatures. Any concrete implementation of the class will
+        need to swap in the more accurate cases.
+    """
+
+    @property
+    @abstractmethod
+    def detection_rules(self) -> list[str]:
+        """ Returns a list of unique detection rules collected from all
+            contained CandidateClusters
+        """
+
+    @abstractmethod
+    def get_region_number(self) -> int:
+        """ Returns the region's numeric ID, only guaranteed to be consistent
+            when the same clusters and subregions are defined in the parent record
+        """
+
+    @abstractmethod
+    def get_product_string(self) -> str:
+        """ Returns a string of all unique products collected from all child collections
+        """
+
+    @property
+    @abstractmethod
+    def products(self) -> list[str]:
+        """ Returns a list of unique products collected from all child containers
+        """
+
+    @property
+    @abstractmethod
+    def product_categories(self) -> set[str]:
+        """ Returns a list of unique product categories collected from all child collections
+        """
+
+    @abstractmethod
+    def write_to_genbank(self, filename: str = None, directory: str = None,
+                         record: SeqRecord = None,
+                         ) -> None:
+        """ Writes a genbank file containing only the information contained
+            within the Region.
+        """

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar
 from Bio.Data import CodonTable, IUPACData
 from Bio.SeqFeature import SeqFeature
 
-import antismash  # for use in referring to Regions, which import this module
 from antismash.common.secmet.qualifiers import (
     GeneFunction,
     GeneFunctionAnnotations,
@@ -28,6 +27,7 @@ from ..locations import (
 )
 from .feature import Feature, pop_locus_qualifier
 from .module import Module
+from .abstract import AbstractRegion  # not the concrete class, because that's a circular dependency
 
 _VALID_TRANSLATION_CHARS = set(IUPACData.extended_protein_letters)
 T = TypeVar("T", bound="CDSFeature")
@@ -170,7 +170,7 @@ class CDSFeature(Feature):
         self.motifs: List[CDSMotif] = []
 
         # runtime-only data
-        self.region: Optional[antismash.common.secmet.features.Region] = None
+        self.region: Optional[AbstractRegion] = None
         self.unique_id: Optional[str] = None  # set only when added to a record
 
     @property

--- a/antismash/common/secmet/features/cdscollection.py
+++ b/antismash/common/secmet/features/cdscollection.py
@@ -23,7 +23,9 @@ class CDSCollection(Feature):
         A location is required and may extend beyond any CDSFeatures contained
         by the CDSCollection, but cannot be smaller than any CDS added.
     """
-    __slots__ = ["_parent_record", "_contig_edge", "_cdses", "_children", "_parent"]
+    __slots__ = ["_parent_record", "_contig_edge", "_cdses", "_children", "_parent",
+                 "_cds_cache", "_cds_cache_dirty",
+                 ]
 
     def __init__(self, location: FeatureLocation, feature_type: str,
                  child_collections: Sequence["CDSCollection"] = None) -> None:
@@ -31,6 +33,8 @@ class CDSCollection(Feature):
         self._parent_record: Any = None  # should be Record but will cause circular dependencies
         self._contig_edge = False
         self._cdses: Dict[CDSFeature, None] = OrderedDict()
+        self._cds_cache: tuple[CDSFeature, ...]
+        self._cds_cache_dirty: bool = True
         self._children = child_collections
         self._parent: Optional["CDSCollection"] = None
         if self._children:
@@ -122,6 +126,7 @@ class CDSCollection(Feature):
         if not cds.is_contained_by(self):
             raise ValueError("CDS added is not contained by collection")
         self._cdses[cds] = None
+        self._cds_cache_dirty = True
         if not self._children:
             return
         for child in self._children:
@@ -132,7 +137,10 @@ class CDSCollection(Feature):
     def cds_children(self) -> Tuple[CDSFeature, ...]:
         """ Returns the CDSFeatures that have been added to this collection,
             in the order they were added """
-        return tuple(self._cdses)
+        if self._cds_cache_dirty:
+            self._cds_cache = tuple(self._cdses)
+            self._cds_cache_dirty = False
+        return self._cds_cache
 
     @classmethod
     def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,

--- a/antismash/common/secmet/features/region.py
+++ b/antismash/common/secmet/features/region.py
@@ -12,6 +12,7 @@ from Bio.SeqFeature import SeqFeature
 from Bio.SeqRecord import SeqRecord
 from helperlibs.bio import seqio
 
+from .abstract import AbstractRegion
 from .cdscollection import CDSCollection, CDSFeature
 from .protocluster import Protocluster, SideloadedProtocluster
 from .feature import Feature, FeatureLocation
@@ -27,7 +28,7 @@ from ..locations import (
 T = TypeVar("T", bound="Region")
 
 
-class Region(CDSCollection):
+class Region(CDSCollection, AbstractRegion):
     """ A feature that represents a region of interest made up of overlapping
         CandidateCluster features and/or SubRegion features.
 

--- a/antismash/common/secmet/features/test/test_cdscollection.py
+++ b/antismash/common/secmet/features/test/test_cdscollection.py
@@ -11,6 +11,18 @@ from antismash.common.secmet.test.helpers import DummyCDS, DummyRecord
 
 
 class TestCDSCollection(unittest.TestCase):
+    def test_cds_caching(self):
+        collection = CDSCollection(FeatureLocation(0, 200, 1), "dummy")
+        assert not collection.cds_children
+        collection.add_cds(DummyCDS(10, 40, strand=1))
+        original = collection.cds_children
+        assert len(original) == 1
+        assert collection.cds_children is original  # same object, since no change
+        collection.add_cds(DummyCDS(110, 140, strand=-1))
+        updated = collection.cds_children
+        assert len(updated) == 2
+        assert updated is not original
+
     def test_parent_linkage(self):
         child = CDSCollection(FeatureLocation(20, 40), feature_type="test", child_collections=[])
         assert child.parent is None

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -280,7 +280,7 @@ def location_contains_other(outer: Location, inner: Location) -> bool:
         return all(location_contains_other(outer, part) for part in inner.parts)
     if isinstance(outer, CompoundLocation):
         return any(location_contains_other(part, inner) for part in outer.parts)
-    return inner.start in outer and inner.end - 1 in outer
+    return outer.start <= inner.start <= inner.end <= outer.end
 
 
 def location_from_string(data: str) -> Location:

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -314,6 +314,17 @@ class TestRecord(unittest.TestCase):
         # ok, since ends aren't inclusive
         record.add_region(Region(subregions=[SubRegion(FeatureLocation(0, 10), "test")]))
 
+    def test_cds_caching(self):
+        record = Record("A" * 100)
+        record.add_cds_feature(DummyCDS(10, 40, strand=1))
+        original = record.get_cds_features()
+        assert len(original) == 1
+        assert record.get_cds_features() is original  # same object, since no change
+        record.add_cds_feature(DummyCDS(110, 140, strand=-1))
+        updated = record.get_cds_features()
+        assert len(updated) == 2
+        assert updated is not original
+
     def test_cds_protocluster_linkage(self):
         record = Record("A"*200)
         for start, end in [(50, 100), (10, 90), (0, 9), (150, 200)]:

--- a/antismash/modules/nrps_pks/nrpys.py
+++ b/antismash/modules/nrps_pks/nrpys.py
@@ -373,6 +373,8 @@ class PredictorSVMResult(Prediction):
         """ Generates a PredictorSVMResult from an nrpys.ADomain """
         aa34 = a_domain.aa34
         aa10 = a_domain.aa10
+        assert len(aa10) == 10, aa10
+        assert len(aa34) > 10, aa34
 
         stachelhaus_matches: list[StachelhausMatch] = []
         seen: set[str] = set()


### PR DESCRIPTION
Optimisations:
* Location containment checks were using the biopython `__contains__`, which is slower than just checking bounds
* `Record` and `CDSCollection` instances rebuilt their `CDSFeature` sets every time they were fetched, they now cache the results, with the cache being marked dirty whenever a new CDS is added

Cleanup:
* Included output directories and any typical input files within the root of the repo to the list of ignored files
* Upgrades pylint's `unused-import` warnings to errors
* Adds an assertion to try to catch a very rare case of 34AA signatures being shown instead of 10AA Stachelhaus signatures