### PR TITLE
common: ensure that pressed HMM database files are not empty

### DIFF
--- a/antismash/common/pfamdb.py
+++ b/antismash/common/pfamdb.py
@@ -208,7 +208,7 @@ def ensure_database_pressed(filepath: str, return_not_raise: bool = False) -> Li
             return [msg]
         raise ValueError(msg)
 
-    if path.is_outdated(components, filepath):
+    if path.is_outdated(components, filepath) or any(os.path.getsize(comp) == 0 for comp in components):
         logging.info("%s components missing or obsolete, re-pressing database", filepath)
         if "hmmpress" not in get_config().executables:
             msg = f"Failed to hmmpress {filepath!r}: cannot find executable for hmmpress"


### PR DESCRIPTION
If `hmmpress` is terminated early, the broken database will pass `ensure_database_pressed` because all four `.h3x` files are immediately created. This leads to a `RuntimeError` during analysis.

Now, `ensure_database_pressed` checks that `h3x` file size is greater than zero.