### PR TITLE
Enforce ignored files not being present in pull requests

### DIFF
--- a/.github/workflows/unwanted_files.yml
+++ b/.github/workflows/unwanted_files.yml
@@ -1,0 +1,35 @@
+name: "Check for unwanted files"
+
+on: [pull_request]
+
+jobs:
+  file_existence:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout changes
+        uses: actions/checkout@v4
+        with:
+          path: changes
+
+      - name: Checkout default branch's .gitignore
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: original
+          sparse-checkout: .gitignore
+
+      - name: Check for unwanted files
+        run: |
+          set +e
+          cp original/.gitignore changes/.gitignore
+          cd changes
+          ignored_files=$(git ls-files -ci --exclude-standard)
+
+          for filename in $ignored_files; do
+            echo "::error file=$filename::$filename should not be committed"
+          done
+
+          if [ ! -z "$ignored_files" ]; then
+            exit 1
+          fi
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ nisin/*
 !antismash/databases/README
 !.github/
 !antismash/
+# some of the ignored filetypes will be required for testing interactions with those files
+!antismash/common/subprocessing/test/data/*
+# the docker container files should always be kept
+!docker


### PR DESCRIPTION
Adds a pull request check (trivially extendable to include pushes as well) that finds and lists any files that match ignore filters.

To avoid bypassing this (intentionally or accidentally) via first modifying `.gitignore`, the default branch's `.gitignore` will be used over the one in the pull request itself.