### PR TITLE
Dependency version upgrades

### DIFF
--- a/antismash/common/gff_parser.py
+++ b/antismash/common/gff_parser.py
@@ -175,22 +175,22 @@ def generate_details_from_subfeature(sub_feature: SeqFeature,
     end = sub_feature.location.end.real
     if MODIFY_LOCATIONS_BY_PHASE:
         phase = int(sub_feature.qualifiers.get('phase', [0])[0])
-        if sub_feature.strand == 1:
+        if sub_feature.location.strand == 1:
             start += phase
         else:
             end -= phase
     try:
-        locations.append(FeatureLocation(start, end, strand=sub_feature.strand))
+        locations.append(FeatureLocation(start, end, strand=sub_feature.location.strand))
     except ValueError as err:
         raise AntismashInputError(str(err)) from err
     # Make sure CDSs lengths are multiple of three. Otherwise extend to next full codon.
     # This only applies for translation.
     modulus = (end - start) % 3
-    if modulus and sub_feature.strand == 1:
+    if modulus and sub_feature.location.strand == 1:
         end += 3 - modulus
-    elif modulus and sub_feature.strand == -1:
+    elif modulus and sub_feature.location.strand == -1:
         start -= 3 - modulus
-    trans_locations.append(FeatureLocation(start, end, strand=sub_feature.strand))
+    trans_locations.append(FeatureLocation(start, end, strand=sub_feature.location.strand))
     # For split features (CDSs), the final feature will have the same qualifiers as the children ONLY if
     # they're the same, i.e.: all children have the same "protein_ID" (key and value).
     for qual in sub_feature.qualifiers:

--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -185,7 +185,8 @@ class Ruleset:
     equivalence_groups: dataclasses.InitVar[GenericSets] = None
     filter_file: dataclasses.InitVar[str] = None
 
-    def __post_init__(self, equivalence_groups: list[set[str]] = None, filter_file: str = None) -> None:
+    def __post_init__(self, equivalence_groups: Iterable[Union[set[str], frozenset[str]]] = None,
+                      filter_file: str = None) -> None:
         # add an additional field to allow fetching rules by name
         self._rules_by_name = {rule.name: rule for rule in self.rules}
         # if there were duplicate names, then report them

--- a/antismash/common/secmet/features/candidate_cluster/structures.py
+++ b/antismash/common/secmet/features/candidate_cluster/structures.py
@@ -12,7 +12,9 @@ from Bio.SeqFeature import SeqFeature
 from ..cdscollection import CDSCollection
 from ..protocluster import Protocluster, SideloadedProtocluster
 from ..feature import FeatureLocation, Feature
-from ...locations import combine_locations
+from ...locations import (
+    combine_locations,
+)
 
 T = TypeVar("T", bound="CandidateCluster")
 
@@ -64,7 +66,7 @@ class CandidateCluster(CDSCollection):
         self._kind = kind
         self.smiles_structure = smiles
         self.polymer = polymer
-        self._core_location = None
+        self._core_location: Optional[FeatureLocation] = None
 
     def __repr__(self) -> str:
         return f"CandidateCluster({self.location}, {self.kind}, {self.products})"

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -7,7 +7,7 @@ import logging
 from typing import Iterable, List, Optional, Sequence, Tuple, Union
 
 from Bio.SeqFeature import (
-    AbstractPosition,
+    Position,
     AfterPosition,
     BeforePosition,
     CompoundLocation,
@@ -286,7 +286,7 @@ def location_contains_other(outer: Location, inner: Location) -> bool:
 def location_from_string(data: str) -> Location:
     """ Converts a string, e.g. [<1:6](-), to a FeatureLocation or CompoundLocation
     """
-    def parse_position(string: str) -> AbstractPosition:
+    def parse_position(string: str) -> Position:
         """ Converts a positiong from a string into a Position subclass """
         if string[0] == '<':
             return BeforePosition(int(string[1:]))

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -42,6 +42,9 @@ from .features import CDSCollection
 from .features.candidate_cluster import create_candidates_from_protoclusters
 
 from .locations import (
+    CompoundLocation,
+    FeatureLocation,
+    Location,
     location_bridges_origin,
     split_origin_bridging_location,
     combine_locations,
@@ -482,7 +485,7 @@ class Record:
         features.extend(self.get_modules())
         return features
 
-    def get_cds_features_within_location(self, location: FeatureLocation,
+    def get_cds_features_within_location(self, location: Location,
                                          with_overlapping: bool = False) -> List[CDSFeature]:
         """ Returns all CDS features within the given location
 
@@ -494,7 +497,7 @@ class Record:
             Returns:
                 a list of CDSFeatures, ordered by earliest position in feature location
         """
-        def find_start_in_list(location: FeatureLocation, features: List[CDSFeature],
+        def find_start_in_list(location: Location, features: list[CDSFeature],
                                include_overlaps: bool) -> int:
             """ Find the earliest feature that starts before the location
                 (and ends before, if include_overlaps is True)

--- a/antismash/common/secmet/test/helpers.py
+++ b/antismash/common/secmet/test/helpers.py
@@ -6,6 +6,8 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=protected-access,missing-docstring
 
+from Bio.Seq import Seq
+
 from ..features import (
     AntismashDomain,
     CDSFeature,
@@ -122,7 +124,7 @@ class DummyRecord(Record):
         if features:
             max_feature_coordinate = max(feature.location.end for feature in features)
             seq = seq * max(1, max_feature_coordinate // len(seq))
-        super().__init__(seq, transl_table=11 if taxon == 'bacteria' else 1)
+        super().__init__(Seq(seq), transl_table=11 if taxon == 'bacteria' else 1)
         if features:
             for feature in features:
                 self.add_feature(feature)

--- a/antismash/common/subprocessing/blast.py
+++ b/antismash/common/subprocessing/blast.py
@@ -4,8 +4,23 @@
 """ A collection of functions for running ncbi-blast+ commands.
 """
 
+import warnings
+
 from tempfile import NamedTemporaryFile
 from typing import Any, IO, List
+
+# handle biopython 1.80 and 1.81 always giving a deprecation warning, regardless of
+# whether the deprecated part is used
+# this issue was removed in 1.82, but 1.82 caused other problems at time of writing
+from Bio import BiopythonDeprecationWarning
+with warnings.catch_warnings(record=True) as emitted:
+    from Bio.SearchIO.BlastIO import BlastTabParser
+    # only one warning is expected
+    assert len(emitted) == 1
+    # it specifically needs to be a biopython deprecration warning
+    assert issubclass(emitted[0].category, BiopythonDeprecationWarning)
+    # and it needs to be referring to the "_legacy" section
+    assert "Bio.SearchIO._legacy' module for parsing BLAST plain text" in str(emitted[0].message), emitted[0]
 
 from .base import execute, get_config, RunResult, SearchIO
 
@@ -57,7 +72,7 @@ def run_blastp(target_blastp_database: str, query_sequence: str,
                            query_sequence[:100]))
     filename = results_file or handle.name
     with open(filename, encoding="utf-8") as read_handle:
-        parsed = list(SearchIO.parse(read_handle, 'blast-tab'))
+        parsed = list(BlastTabParser(read_handle))
     handle.close()
     return parsed
 

--- a/antismash/common/test/test_gff_parser.py
+++ b/antismash/common/test/test_gff_parser.py
@@ -5,19 +5,21 @@
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,consider-using-with
 
 from unittest import TestCase
-from Bio.SeqFeature import CompoundLocation, SeqFeature
+from Bio.SeqFeature import SeqFeature
+from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
 from antismash.common import errors, gff_parser, path
+from antismash.common.secmet.locations import CompoundLocation
 
 
 class GffParserTest(TestCase):
     def setUp(self):
         self.gff_file = path.get_full_path(__file__, "data", "test_gff.gff")
         self.single_entry = False
-        contig1 = SeqRecord(seq="A"*2000)
+        contig1 = SeqRecord(seq=Seq("A"*2000))
         contig1.id = "CONTIG_1"
-        contig2 = SeqRecord(seq="A"*2000)
+        contig2 = SeqRecord(seq=Seq("A"*2000))
         contig2.id = "CONTIG_2"
         self.sequences = [contig1, contig2]
 

--- a/antismash/common/test/test_record_processing.py
+++ b/antismash/common/test/test_record_processing.py
@@ -74,7 +74,7 @@ class TestParseRecords(unittest.TestCase):
         # pretend there's two inputs, and that the first has an error
         # with the ignore invalid option turned on, the valid input should still come back
         dummy_error = record_processing.SecmetInvalidInputError("some reason")
-        dummy_inputs = [SeqRecord("ACGT", id="bad"), SeqRecord("TGCA", id="good")]
+        dummy_inputs = [SeqRecord(Seq("ACGT"), id="bad"), SeqRecord(Seq("TGCA"), id="good")]
         expected_outputs = [dummy_error, Record.from_biopython(dummy_inputs[1], taxon="bacteria")]
         for value in [False, True]:
             with mock.patch.object(record_processing, "_strict_parse", return_value=dummy_inputs):
@@ -90,7 +90,7 @@ class TestParseRecords(unittest.TestCase):
 
     def test_all_invalid_and_ignored(self):
         dummy_error = record_processing.SecmetInvalidInputError("some reason")
-        dummy_inputs = [SeqRecord("ACGT", id="bad")]
+        dummy_inputs = [SeqRecord(Seq("ACGT"), id="bad")]
         with mock.patch.object(Record, "from_biopython", side_effect=dummy_error):
             with mock.patch.object(record_processing, "_strict_parse", return_value=dummy_inputs):
                 with self.assertRaisesRegex(AntismashInputError, "no valid records"):
@@ -274,9 +274,8 @@ class TestPreprocessRecords(unittest.TestCase):
 
     def test_shotgun(self):
         filepath = path.get_full_path(__file__, "data", "wgs.gbk")
-        records = record_processing.parse_input_sequence(filepath)
         with self.assertRaisesRegex(AntismashInputError, "incomplete whole genome shotgun records are not supported"):
-            record_processing.pre_process_sequences(records, self.options, self.genefinding)
+            record_processing.parse_input_sequence(filepath)
 
     def test_duplicate_record_ids(self):
         records = self.read_double_nisin()

--- a/antismash/detection/cassis/__init__.py
+++ b/antismash/detection/cassis/__init__.py
@@ -417,7 +417,7 @@ def create_subregions(anchor: str, cluster_preds: List[ClusterPrediction],
         else:
             new_feature.qualifiers["note"] = [f"alternative prediction ({i}) for anchor gene {anchor}"]
 
-        new_feature = SubRegion.from_biopython(new_feature)
-        subregions.append(new_feature)
+        subregion = SubRegion.from_biopython(new_feature)
+        subregions.append(subregion)
 
     return subregions

--- a/antismash/detection/sideloader/test/test_general.py
+++ b/antismash/detection/sideloader/test/test_general.py
@@ -6,6 +6,8 @@
 
 import unittest
 
+from Bio.Seq import Seq
+
 from antismash.common.errors import AntismashInputError
 from antismash.common.test.helpers import DummyCDS, DummyRecord
 from antismash.detection.sideloader import general, _parse_arg
@@ -37,7 +39,7 @@ class TestSimple(unittest.TestCase):
         assert not result.subregions
 
         record = make_record("AcC", 30)
-        record.seq = "A" * 100
+        record.seq = Seq("A" * 100)
         result = general.load_single_record_annotations([], record, _parse_arg("AcC:1-50"))
         assert not result.protoclusters
         assert len(result.subregions) == 1

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -164,7 +164,7 @@ def verify_options(options: ConfigType, modules: List[AntismashModule]) -> bool:
     if not errors_found:
         return True
 
-    logging.error("Incompatible options detected:\n  %s", "\n  ".join(errors))
+    logging.error("Incompatible options detected:\n  %s", "\n  ".join(errors_found))
     for error in errors_found:
         print(error)  # still commandline args, so don't use logging
     return False

--- a/antismash/modules/tta/test/test_tta.py
+++ b/antismash/modules/tta/test/test_tta.py
@@ -72,24 +72,24 @@ class TtaTest(unittest.TestCase):
         fw_tta, rv_tta = features[0], features[1]
         self.assertEqual(fw_tta.location.start, 3)
         self.assertEqual(fw_tta.location.end, 6)
-        self.assertEqual(fw_tta.strand, 1)
+        self.assertEqual(fw_tta.location.strand, 1)
 
         self.assertEqual(rv_tta.location.start, 15)
         self.assertEqual(rv_tta.location.end, 18)
-        self.assertEqual(rv_tta.strand, -1)
+        self.assertEqual(rv_tta.location.strand, -1)
 
     def test_feature_creation(self):
         fw_loc = FeatureLocation(210, 300, strand=1)
         fw_feature = SeqFeature(fw_loc, type='CDS')
         results = tta.tta.TTAResults('dummy', gc_content=1, threshold=0.65)
         ret = results.new_feature_from_other(fw_feature, 12)
-        self.assertEqual(ret.strand, 1)
+        self.assertEqual(ret.location.strand, 1)
         self.assertEqual(ret.location.start, 222)
         self.assertEqual(ret.location.end, 225)
 
         rv_loc = FeatureLocation(210, 300, strand=-1)
         rv_feature = SeqFeature(rv_loc, type='CDS')
         ret = results.new_feature_from_other(rv_feature, 12)
-        self.assertEqual(ret.strand, -1)
+        self.assertEqual(ret.location.strand, -1)
         self.assertEqual(ret.location.start, 285)
         self.assertEqual(ret.location.end, 288)

--- a/antismash/modules/tta/tta.py
+++ b/antismash/modules/tta/tta.py
@@ -45,12 +45,12 @@ class TTAResults(ModuleResults):
 
     def new_feature_from_other(self, feature: Feature, offset: int) -> Feature:
         """Create a misc_feature entry for a TTA codon on a given feature"""
-        if feature.strand == 1:
+        if feature.location.strand == 1:
             start = feature.location.start + offset
         else:
             start = feature.location.end - offset - 3
 
-        return self.new_feature_from_basics(start, feature.strand)
+        return self.new_feature_from_basics(start, feature.location.strand)
 
     def to_json(self) -> Dict[str, Any]:
         """ Construct a JSON representation of this instance """

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ ignore_missing_imports=True
 warn_unused_ignores=True
 exclude=/setup\.py$|test/|external/
 follow_imports=silent
+no_implicit_optional=False
 
 [coverage:report]
 exclude_lines =

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ tests_require = [
     'pytest >= 7.2.0, < 8',
     'coverage',
     'pylint == 3.0.2',
-    'mypy == 0.982',  # for consistent type checking
+    'mypy == 1.9.0',  # for consistent type checking
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ class PyTest(TestCommand):
 
 setup(
     name="antismash",
-    python_requires='>=3.9',
+    python_requires='>=3.11',
     version=read_version(),
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ long_description = read('README.md')
 install_requires = [
     'brawn',
     'numpy',
-    'biopython == 1.78',
+    'biopython == 1.81',
     'helperlibs',
     'jinja2',
     'joblib',
@@ -26,7 +26,7 @@ install_requires = [
     'markupsafe >= 2.0',
     'nrpys >= 0.1.1',
     'pysvg-py3',
-    'bcbio-gff == 0.7.0',  # 0.7.1 is incompatible with biopython 1.78
+    'bcbio-gff == 0.7.1',
     'libsass >= 0.22',
     'matplotlib',
     'scipy',


### PR DESCRIPTION
- Bumps minimum python version from 3.9 to 3.11 to allow for new features which simplify future development (e.g. the `Self` type).
- Bumps `mypy` from 0.982 to 1.9.0, along with associated fixes for existing types
- Bumps `biopython` from 1.78 to 1.81, along with associated fixes
- Bumps `bcbio-gff` from 0.70 to 0.71 (which required a biopython newer than 1.78), fixing some issues with GFF inputs
