### PR TITLE
secmet: fix CDS feature name generation breaking CSS/HTML output

### DIFF
--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -273,9 +273,9 @@ class CDSFeature(Feature):
         gene = leftovers.pop("gene", [None])[0]
         if not (gene or protein_id or locus_tag):
             if "pseudo" in leftovers or "pseudogene" in leftovers:
-                gene = "pseudo%s_%s"
+                gene = "pseudo%d_%d"
             else:
-                gene = "cds%s_%s"
+                gene = "cds%d_%d"
             gene = gene % (bio_feature.location.start, bio_feature.location.end)
         name = locus_tag or protein_id or gene
 

--- a/antismash/common/secmet/features/test/test_cds_feature.py
+++ b/antismash/common/secmet/features/test/test_cds_feature.py
@@ -185,6 +185,19 @@ class TestCDSBiopythonConversion(unittest.TestCase):
                 new = CDSFeature.from_biopython(bio, record=record)
                 assert new.translation == cds.translation
 
+    def test_bad_name_generation(self):
+        # a CDS with no identifiers but with a pseudo(gene) qualifier
+        # used the coordinates, which is very awkward if it's an ambiguous position
+        bio = SeqFeature(FeatureLocation(BeforePosition(6), 9, 1), "CDS")
+        bio.qualifiers["pseudo"] = True
+        bio.qualifiers["translation"] = "M"
+        cds = CDSFeature.from_biopython(bio)
+        assert cds.get_name() == "pseudo6_9"
+
+        bio.qualifiers.pop("pseudo")
+        cds = CDSFeature.from_biopython(bio)
+        assert cds.get_name() == "cds6_9"
+
 
 class TestCDSProteinLocation(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
In cases where a CDS feature had no identifiers (`locus_tag`, `gene`, `protein_id`), names are autogenerated using the location. When the location had ambiguous positions, the resulting name included the string representation of that position, e.g. `cds<123_456`, which causes issues in HTML/CSS.

This change removes the ambiguous marker from the name, resulting in `cds123_456`. This may collide with other unidentified CDS features at the same coordinates without ambiguous positions, but that is an issue best solved by correcting the annotations before they hit antiSMASH.