### PR TITLE
common.json: fix JSON conversion of subclasses of stdlib types

### DIFF
--- a/antismash/common/comparippson/data/build_data.py
+++ b/antismash/common/comparippson/data/build_data.py
@@ -7,10 +7,11 @@
 import argparse
 from dataclasses import dataclass
 import glob
-import json
 import os
 import sys
 from typing import Any, Dict, List
+
+from antismash.common import json
 
 
 @dataclass
@@ -249,14 +250,14 @@ def write_data(entries: List[Entry], metadata: Metadata, version: str,
         handle.write("{\n")
         # write the core DB info as single line per value
         for key, value in vars(metadata).items():
-            handle.write(f' "{key}": {json.dumps(value, ensure_ascii=False)},\n')
+            handle.write(f' "{key}": {json.dumps(value)},\n')
         handle.write(f' "version": "{version}",\n')
         # entries opening
         handle.write(' "entries": {\n')
         # all the individual entries, one per line
         entry_lines = []
         for entry in entries:
-            entry_lines.append(f'  "{entry.counter}": {json.dumps(entry.to_json(), ensure_ascii=False)}')
+            entry_lines.append(f'  "{entry.counter}": {json.dumps(entry.to_json())}')
         handle.write(",\n".join(entry_lines))
         # entries closing
         handle.write('\n }\n')

--- a/antismash/common/comparippson/databases.py
+++ b/antismash/common/comparippson/databases.py
@@ -17,15 +17,14 @@
 
 from dataclasses import dataclass, field
 import glob
-import json
 import os
 from typing import Any, Dict, List
 
+from antismash.common import json
 from antismash.common.html_renderer import Markup
+from antismash.common.comparippson.data_structures import Hit
 from antismash.common.path import find_latest_database_version
 from antismash.config import ConfigType, get_config
-
-from .data_structures import Hit
 
 
 @dataclass

--- a/antismash/common/comparippson/test/test_analysis.py
+++ b/antismash/common/comparippson/test/test_analysis.py
@@ -6,11 +6,10 @@
 
 import glob
 from io import StringIO
-import json
 import unittest
 from unittest.mock import patch
 
-from antismash.common import comparippson
+from antismash.common import comparippson, json
 from antismash.common.comparippson import analysis, databases
 from antismash.common.comparippson.databases import (
     ComparippsonDatabase as Database,

--- a/antismash/common/hmm_rule_parser/categories.py
+++ b/antismash/common/hmm_rule_parser/categories.py
@@ -5,8 +5,10 @@
 """
 
 from dataclasses import dataclass
-import json
 from typing import Any, IO, Optional, Type, TypeVar, Union
+
+from antismash.common import json
+
 
 TRuleCategory = TypeVar("TRuleCategory", bound="RuleCategory")  # pylint: disable=invalid-name
 

--- a/antismash/common/hmm_rule_parser/test/test_categories.py
+++ b/antismash/common/hmm_rule_parser/test/test_categories.py
@@ -5,7 +5,6 @@
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,consider-using-with
 
 from io import StringIO
-import json
 import unittest
 
 from antismash.common.hmm_rule_parser.categories import (
@@ -13,6 +12,7 @@ from antismash.common.hmm_rule_parser.categories import (
     _parse_categories,
     parse_category_file,
 )
+from antismash.common import json
 
 
 class TestCategoryParsing(unittest.TestCase):

--- a/antismash/common/json.py
+++ b/antismash/common/json.py
@@ -4,76 +4,154 @@
 """ JSON-friendly classes explicitly for use by the javascript drawing libraries
 """
 
-from typing import Any, Iterator, List, Optional, Tuple
+from dataclasses import dataclass, field
+from json import JSONDecodeError  # pylint: disable=unused-import  # for compatibility
+from typing import Any, Callable, IO, Optional, Self
 
+# pylint doesn't recognise any members of orjson, where mypy and pyflakes do
+# pylint: disable=no-name-in-module
+from orjson import (
+    loads,  # pylint: disable=unused-import  # used by others
+    OPT_NON_STR_KEYS as _OPT_CONVERT_NON_STR_KEYS,
+    OPT_SORT_KEYS as _OPT_SORT_KEYS,
+    OPT_INDENT_2 as _OPT_INDENT_2,
+    dumps as _dumps,
+)
+# pylint: enable=no-name-in-module
+
+
+from antismash.common.secmet.record import Seq
 from antismash.common.secmet.features import CDSFeature
 from antismash.common.secmet.qualifiers import NRPSPKSQualifier
 
 
-class JSONBase(dict):
+@dataclass
+class JSONBase:
     """ A base class for JSON-serialisable objects """
-    def __init__(self, keys: List[str]) -> None:
-        super().__init__()
-        self._keys = keys
-
-    def __getitem__(self, key: str) -> Any:
-        return getattr(self, key)
-
-    def items(self) -> Iterator[Tuple[str, Any]]:  # type: ignore
-        for key in self._keys:
-            yield (key, getattr(self, key))
-
-    def values(self) -> Iterator[Any]:  # type: ignore
-        for key in self._keys:
-            yield getattr(self, key)
-
-    def __len__(self) -> int:
-        return len(self._keys)
 
 
+def _base_convertor(obj: Any) -> Any:
+    # handles any conversion methods for classes that aren't default types or dataclasses
+    if isinstance(obj, Seq):
+        return str(obj)
+    if hasattr(obj, "to_json"):
+        return obj.to_json()
+    if hasattr(obj, "__json__"):
+        return obj.__json__()
+    # but if no conversion method is found, then an error must be raised for orjson (and stdlib json, for that matter)
+    raise TypeError
+
+
+def _convert_std_to_orson(*, sort_keys: bool = False, option: int = 0, indent: bool = True) -> int:
+    # always match stdlib JSON's default behaviour, where non-string keys are converted to string
+    option |= _OPT_CONVERT_NON_STR_KEYS
+    if sort_keys:
+        option |= _OPT_SORT_KEYS
+    if indent:
+        option |= _OPT_INDENT_2
+    return option
+
+
+def dump(obj: Any, handle: IO, *, default: Callable[[Any], Any] = _base_convertor, indent: bool = False,
+         sort_keys: bool = False, option: int = 0,
+         ) -> None:
+    """ Converts the given object to JSON and writes the resulting string to the given file handle
+
+        Arguments:
+            obj: the object to convert
+            handle: the file object to write to
+            default: an optional override of the usual class convertor handler for non-standard types
+            indent: a boolean indicating whether to use indents in the string conversion (always 2 spaces if used)
+            sort_keys: whether the child attributes should be sorted by key
+            option: an orjson option value (see orjson documentation for possible values)
+
+        Returns:
+            None
+    """
+    option = _convert_std_to_orson(indent=indent, sort_keys=sort_keys, option=option)
+    handle.write(dumps(obj, default=default, option=option))
+
+
+def dumps(obj: Any, *, default: Callable[[Any], Any] = _base_convertor, indent: bool = False,
+          sort_keys: bool = False, option: int = 0,
+          ) -> str:
+    """ Converts the given object to a JSON string
+
+        Arguments:
+            obj: the object to convert
+            default: an optional override of the usual class convertor handler for non-standard types
+            indent: a boolean indicating whether to use indents in the string conversion (always 2 spaces if used)
+            sort_keys: whether the child attributes should be sorted by key
+            option: an orjson option value (see orjson documentation for possible values)
+
+        Returns:
+            the string generated
+    """
+    option = _convert_std_to_orson(indent=indent, sort_keys=sort_keys, option=option)
+    return _dumps(obj, default=default, option=option).decode()
+
+
+def load(handle: IO) -> dict[str, Any]:
+    """ Reads in JSON text from the given file handle and returns the information using
+        standard types.
+
+        Arguments:
+            handle: the file handle to read from
+
+        Returns:
+            a dictionary mapping loaded key-value pairs
+    """
+    return loads(handle.read())
+
+
+@dataclass
 class JSONDomain(JSONBase):
     """ A JSON-serialisable object for simplifying domain datatypes throughout this file """
-    def __init__(self, domain: NRPSPKSQualifier.Domain, predictions: List[Tuple[str, str]], napdos_link: str,
-                 blast_link: str, sequence: str, dna: str, abbreviation: str, html_class: str) -> None:
-        super().__init__(['type', 'start', 'end', 'predictions', 'napdoslink',
-                          'blastlink', 'sequence', 'dna_sequence', 'abbreviation',
-                          'html_class'])
-        self.type = str(domain.full_type)
-        self.start = int(domain.start)
-        self.end = int(domain.end)
-        self.predictions = predictions
-        self.napdoslink = str(napdos_link)
-        self.blastlink = str(blast_link)
-        self.sequence = str(sequence)
-        self.dna_sequence = str(dna)
-        self.abbreviation = str(abbreviation)
-        self.html_class = str(html_class)
+    type: str
+    start: int
+    end: int
+    predictions: list[tuple[str, str]]
+    napdoslink: str
+    blastlink: str
+    sequence: str
+    dna: str
+    abbreviation: str
+    html_class: str
+
+    @classmethod
+    def from_domain(cls, domain: NRPSPKSQualifier.Domain, *args: Any) -> Self:
+        """ A helper for constructing an instance from an existing domain """
+        return cls(domain.full_type, domain.start, domain.end, *args)
 
 
+@dataclass
 class JSONModule(JSONBase):
     """ A JSON-serialisable object for simplifying NRPS/PKS module datatypes """
-    def __init__(self, start: int, end: int, complete: bool, iterative: bool, monomer: str,
-                 multi_cds: Optional[str] = None, match_id: Optional[str] = None) -> None:
-        super().__init__(["start", "end", "complete", "iterative", "monomer", "multi_cds", "match_id"])
-        self.start = start
-        self.end = end
-        self.complete = complete
-        self.iterative = iterative
-        self.monomer = monomer
-        self.multi_cds = multi_cds
-        self.match_id = match_id
+    start: int
+    end: int
+    complete: bool
+    iterative: bool
+    monomer: str
+    multi_cds: Optional[str] = None
+    match_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
         if bool(self.multi_cds) != bool(self.match_id):
             raise ValueError("multi_cds and match_id must both have values or both be None")
 
 
+@dataclass
 class JSONOrf(JSONBase):
     """ A JSON-serialisable object for simplifying ORF datatypes throughout this file """
-    def __init__(self, feature: CDSFeature) -> None:
-        super().__init__(["id", "sequence", "domains", "modules"])
-        self.sequence = feature.translation
-        self.id = feature.get_name()
-        self.domains: List[JSONDomain] = []
-        self.modules: List[JSONModule] = []
+    sequence: str
+    id: str
+    domains: list[JSONDomain] = field(default_factory=list)
+    modules: list[JSONModule] = field(default_factory=list)
+
+    @classmethod
+    def from_cds(cls, feature: CDSFeature) -> Self:
+        """ A helper for constructing an instance from an existing CDS feature """
+        return cls(feature.translation, feature.get_name())
 
     def add_domain(self, domain: JSONDomain) -> None:
         """ Add a JSONDomain to the list of domains in this ORF """

--- a/antismash/common/secmet/qualifiers/nrps_pks.py
+++ b/antismash/common/secmet/qualifiers/nrps_pks.py
@@ -4,6 +4,7 @@
 """ Annotations for NRPS/PKS domains """
 
 import bisect
+from dataclasses import dataclass, field
 from typing import Any, Dict, Iterator, List, Tuple
 
 from .secmet import _parse_format
@@ -31,6 +32,7 @@ class NRPSPKSQualifier:
 
         Can be used directly as a qualifier for Biopython's SeqFeature.
     """
+    @dataclass
     class Domain:
         """ Contains information about a NRPS/PKS domain, including predictions
             made by modules.
@@ -38,22 +40,19 @@ class NRPSPKSQualifier:
             feature_name is identical to that of the AntismashDomain that contains
             this same information
         """
-        __slots__ = ["name", "label", "start", "end", "evalue", "bitscore",
-                     "_predictions", "feature_name", "subtypes"]
+        name: str
+        label: str
+        start: int
+        end: int
+        evalue: float
+        bitscore: float
+        feature_name: str
+        subtypes: list[str] = field(default_factory=list)
+        _predictions: dict[str, str] = field(default_factory=dict)
 
-        def __init__(self, name: str, label: str, start: int, end: int,
-                     evalue: float, bitscore: float, feature_name: str, subtypes: List[str] = None) -> None:
-            self.label = str(label)
-            self.name = str(name)
-            self.start = int(start)
-            self.end = int(end)
-            self.evalue = float(evalue)
-            self.bitscore = float(bitscore)
-            if not feature_name:
-                raise ValueError("a Domain must belong to a feature, feature_name is required")
-            self.feature_name = str(feature_name)
-            self._predictions: Dict[str, str] = {}  # method to prediction name
-            self.subtypes: List[str] = subtypes or []
+        def __post_init__(self) -> None:
+            if not self.feature_name:
+                raise ValueError("a Domain must belong to a feature")
 
         def __lt__(self, other: "NRPSPKSQualifier.Domain") -> bool:
             return (self.start, self.end) < (other.start, other.end)

--- a/antismash/common/secmet/qualifiers/test/test_secmet.py
+++ b/antismash/common/secmet/qualifiers/test/test_secmet.py
@@ -4,8 +4,9 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
-import json
 import unittest
+
+from antismash.common import json
 
 from ..secmet import _parse_format, SecMetQualifier
 

--- a/antismash/common/serialiser.py
+++ b/antismash/common/serialiser.py
@@ -7,7 +7,6 @@
 
 import bz2
 from collections import defaultdict, OrderedDict
-import json
 import logging
 import os
 from typing import Any, Dict, IO, List, Union
@@ -16,6 +15,7 @@ from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, Reference
 from Bio.SeqRecord import SeqRecord
 
+from antismash.common import json
 from antismash.common.module_results import ModuleResults
 from antismash.common.secmet import Record
 from antismash.common.secmet.locations import location_from_string
@@ -303,7 +303,7 @@ def feature_to_json(feature: SeqFeature) -> Dict[str, Any]:
 def feature_from_json(data: Union[str, Dict]) -> SeqFeature:
     """ Converts a JSON representation of a feature into a SeqFeature """
     if isinstance(data, str):
-        data = json.loads(data, object_pairs_hook=OrderedDict)
+        data = json.loads(data)
     assert isinstance(data, dict)
     return SeqFeature(location=location_from_string(data["location"]),
                       type=data["type"],

--- a/antismash/common/test/test_hmmer.py
+++ b/antismash/common/test/test_hmmer.py
@@ -6,7 +6,6 @@
 
 from collections import defaultdict
 from dataclasses import FrozenInstanceError, dataclass
-import json
 import unittest
 
 from antismash.common.hmmer import (
@@ -15,6 +14,7 @@ from antismash.common.hmmer import (
     HmmerResults,
     remove_overlapping,
 )
+from antismash.common import json
 
 from .helpers import DummyRecord
 

--- a/antismash/common/test/test_hmmscan_refinement.py
+++ b/antismash/common/test/test_hmmscan_refinement.py
@@ -4,12 +4,11 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
-import json
 import unittest
 import warnings
 
+from antismash.common import json, path
 import antismash.common.hmmscan_refinement as refinement
-from antismash.common import path
 
 # Don't display the SearchIO experimental warning, we know this.
 with warnings.catch_warnings():

--- a/antismash/common/test/test_json.py
+++ b/antismash/common/test/test_json.py
@@ -1,0 +1,82 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+# for test files, silence irrelevant and noisy pylint warnings
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
+
+from io import StringIO
+import unittest
+
+from antismash.common import json
+from antismash.common.json import JSONOrf
+from antismash.common.test.helpers import DummyCDS
+
+
+class DummyClass:
+    def __init__(self, value):
+        self.value = value
+
+
+class TestConversions(unittest.TestCase):
+    def test_orf_conversion(self):
+        orf = JSONOrf.from_cds(DummyCDS(locus_tag="name"))
+        assert orf.id == "name"
+        for indent in [False, True]:  # catch the error of non-indenting in stdlib failing to convert
+            new = JSONOrf(**json.loads(json.dumps(orf, indent=indent)))
+            assert new == orf
+            assert new.id == orf.id
+
+    def test_class_without_conversion(self):
+        with self.assertRaisesRegex(TypeError, "not JSON serializable"):
+            json.dumps(DummyClass(5))
+
+    def test_class_with_explicit(self):
+        class WithExplicit(DummyClass):
+            def to_json(self):
+                return {"value": self.value}
+
+        instance = WithExplicit(6)
+        conversion = json.loads(json.dumps(instance))
+        assert conversion["value"] == instance.value
+
+    def test_class_with_dunder(self):
+        class WithDunder(DummyClass):
+            def __json__(self):
+                return {"value": self.value}
+
+        instance = WithDunder(7)
+        conversion = json.loads(json.dumps(instance))
+        assert conversion["value"] == instance.value
+
+    def test_indents(self):
+        instance = {"a": 2, "b": "val"}
+        default = json.dumps(instance)
+        assert default == '{"a":2,"b":"val"}'
+        indented = json.dumps(instance, indent=True)
+        assert indented == '{\n  "a": 2,\n  "b": "val"\n}'
+
+    def test_sorted(self):
+        instance = {"z": 2, "a": "val"}
+        default = json.dumps(instance)
+        assert default == '{"z":2,"a":"val"}'
+        sorted_result = json.dumps(instance, sort_keys=True)
+        assert sorted_result == '{"a":"val","z":2}'
+
+    def test_key_conversion(self):
+        # stdlib json conversion will convert non-string keys to strings
+        # the behaviour of the override must match
+        obj = {"str": 1, 7: 2}
+        converted = json.loads(json.dumps(obj))
+        assert converted == {"str": 1, "7": 2}
+
+    def test_dump(self):
+        handle = StringIO("")
+        obj = {"a": 1, "b": 2}
+        json.dump(obj, handle)
+        handle.seek(0)
+        assert handle.read() == json.dumps(obj)
+
+    def test_load(self):
+        obj = {"a": 1, "b": 2}
+        handle = StringIO(json.dumps(obj))
+        assert obj == json.load(handle)

--- a/antismash/detection/genefunctions/test/integration_smcogs.py
+++ b/antismash/detection/genefunctions/test/integration_smcogs.py
@@ -4,13 +4,12 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
-import json
 import unittest
 
 from helperlibs.bio import seqio
 
 import antismash
-from antismash.common import secmet
+from antismash.common import json, secmet
 from antismash.common.secmet.qualifiers import GeneFunction
 from antismash.common.test import helpers
 from antismash.config import build_config, destroy_config, get_config, update_config

--- a/antismash/detection/genefunctions/test/test_core.py
+++ b/antismash/detection/genefunctions/test/test_core.py
@@ -4,11 +4,11 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
-import json
 import unittest
 
 import antismash
 from antismash.common.hmmscan_refinement import HMMResult
+from antismash.common import json
 from antismash.common.secmet.qualifiers import GeneFunction
 from antismash.common.test.helpers import DummyRecord
 from antismash.config import build_config, destroy_config

--- a/antismash/detection/hmm_detection/test/integration_hmm_detection.py
+++ b/antismash/detection/hmm_detection/test/integration_hmm_detection.py
@@ -4,9 +4,9 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
-import json
 import unittest
 
+from antismash.common import json
 from antismash.common.secmet import Record
 from antismash.common.secmet.test.helpers import DummySubRegion
 from antismash.common.test.helpers import get_path_to_nisin_genbank

--- a/antismash/detection/hmm_detection/test/test_hmm_detection.py
+++ b/antismash/detection/hmm_detection/test/test_hmm_detection.py
@@ -6,7 +6,6 @@
 
 from argparse import Namespace
 import glob
-import json
 import importlib
 import os
 import pkgutil
@@ -15,7 +14,7 @@ from unittest.mock import patch
 
 from Bio.Seq import Seq
 
-from antismash.common import path
+from antismash.common import json, path
 from antismash.common.hmm_rule_parser import rule_parser, cluster_prediction as hmm_detection  # TODO: redo tests
 from antismash.common.hmm_rule_parser.test.helpers import check_hmm_signatures, create_ruleset
 from antismash.common.secmet import Record

--- a/antismash/detection/nrps_pks_domains/domain_drawing.py
+++ b/antismash/detection/nrps_pks_domains/domain_drawing.py
@@ -167,8 +167,10 @@ def _parse_domain(record: Record, domain: NRPSPKSQualifier.Domain,
             break
     assert dna_sequence
     css, abbreviation = get_css_class_and_abbreviation(domain.name)
-    return JSONDomain(domain, predictions, napdoslink, blastlink, domainseq, dna_sequence,
-                      abbreviation, css)
+    return JSONDomain.from_domain(
+        domain, predictions, napdoslink, blastlink, domainseq, dna_sequence,
+        abbreviation, css,
+    )
 
 
 def _build_module_js(module: Module, cds: CDSFeature, match_ids: dict[tuple[str, ...], str],
@@ -217,7 +219,7 @@ def generate_js_domains(region: Region, record: Record) -> Dict[str, Union[str, 
     for feature in region.cds_children:
         if not feature.nrps_pks:
             continue
-        js_orf = JSONOrf(feature)
+        js_orf = JSONOrf.from_cds(feature)
         for domain in feature.nrps_pks.domains:
             js_orf.add_domain(_parse_domain(record, domain, feature))
 

--- a/antismash/detection/nrps_pks_domains/test/test_modules.py
+++ b/antismash/detection/nrps_pks_domains/test/test_modules.py
@@ -4,10 +4,9 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,too-many-public-methods
 
-import json
 import unittest
 
-from antismash.common import path
+from antismash.common import json, path
 from antismash.common.test.helpers import DummyHMMResult
 from antismash.common.secmet.test.helpers import DummyCDS
 from antismash.detection import nrps_pks_domains

--- a/antismash/detection/sideloader/loader.py
+++ b/antismash/detection/sideloader/loader.py
@@ -3,12 +3,12 @@
 
 """ Functions to load a JSON file and validate it against a JSON schema """
 
-import json
 import os
 from typing import Any, Dict
 
 import jsonschema
 
+from antismash.common import json
 from antismash.common.errors import AntismashInputError
 
 

--- a/antismash/detection/sideloader/test/test_loading.py
+++ b/antismash/detection/sideloader/test/test_loading.py
@@ -4,10 +4,9 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,too-many-public-methods
 
-import json
 import unittest
 
-from antismash.common import errors, path
+from antismash.common import errors, json, path
 from antismash.detection.sideloader import general, loader
 
 GOOD_FILE = path.get_full_path(__file__, "data", "good.json")
@@ -22,7 +21,7 @@ class TestValidation(unittest.TestCase):
 
     def test_bad_json(self):
         test_file = path.get_full_path(__file__, "data", "bad.json")
-        with self.assertRaisesRegex(errors.AntismashInputError, "Expecting ',' delimiter"):
+        with self.assertRaisesRegex(errors.AntismashInputError, "not valid JSON"):
             loader.load_validated_json(test_file, general._SCHEMA_FILE)
 
 

--- a/antismash/detection/sideloader/test/test_structures.py
+++ b/antismash/detection/sideloader/test/test_structures.py
@@ -4,9 +4,9 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,too-many-public-methods
 
-import json
 import unittest
 
+from antismash.common import json
 from antismash.common.secmet.features.protocluster import SideloadedProtocluster
 from antismash.common.secmet.features.subregion import SideloadedSubRegion
 from antismash.common.test.helpers import DummyRecord

--- a/antismash/download_databases.py
+++ b/antismash/download_databases.py
@@ -6,7 +6,6 @@
 import argparse
 import gzip
 import hashlib
-import json
 import lzma
 import os
 import pathlib
@@ -22,6 +21,7 @@ from antismash.common.html_renderer import (
     get_antismash_js_version,
     get_antismash_js_url,
 )
+from antismash.common import json
 
 PFAM_LATEST_VERSION = "35.0"
 PFAM_LATEST_URL = f"https://ftp.ebi.ac.uk/pub/databases/Pfam/releases/Pfam{PFAM_LATEST_VERSION}/Pfam-A.hmm.gz"

--- a/antismash/modules/cluster_compare/__init__.py
+++ b/antismash/modules/cluster_compare/__init__.py
@@ -3,13 +3,12 @@
 
 """ A module for comparing clusters """
 
-import json
 import os
 from typing import Any, Dict, List, Optional
 
 import jsonschema
 
-from antismash.common import path
+from antismash.common import json, path
 from antismash.config import ConfigType, get_config
 from antismash.config.args import ModuleArgs, MultipleFullPathAction
 from antismash.common.secmet import Record

--- a/antismash/modules/cluster_compare/data/build_cluster_compare.py
+++ b/antismash/modules/cluster_compare/data/build_cluster_compare.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import argparse
 import glob
-import json
 import os
 from typing import (
     Any,
@@ -10,7 +9,7 @@ from typing import (
     List,
 )
 
-from antismash.common import secmet
+from antismash.common import json, secmet
 
 
 class Counter:
@@ -110,7 +109,7 @@ def convert_all(input_dir: str, output_dir: str) -> None:
                     continue
                 result[record.id] = convert_record(record, fasta)
     with open(os.path.join(output_dir, "data.json"), "w") as handle:
-        handle.write(json.dumps(result, indent=1))
+        handle.write(json.dumps(result, indent=True))
 
 
 def convert_all_mibig(input_dir: str, output_dir: str, accessions: List[str]) -> None:
@@ -140,7 +139,7 @@ def convert_all_mibig(input_dir: str, output_dir: str, accessions: List[str]) ->
             except KeyError as err:
                 print(accession, "is invalid:", err)
     with open(os.path.join(output_dir, "data.json"), "w") as handle:
-        json.dump(result, handle, indent=1, sort_keys=True)
+        json.dump(result, handle, indent=True, sort_keys=True)
 
 
 if __name__ == "__main__":

--- a/antismash/modules/cluster_compare/data_structures.py
+++ b/antismash/modules/cluster_compare/data_structures.py
@@ -5,9 +5,9 @@
 
 import dataclasses
 from enum import Enum, unique
-import json
 from typing import Any, Dict, List, Optional, Tuple
 
+from antismash.common import json
 from antismash.common.secmet import CDSFeature, Record
 from antismash.common.secmet.locations import location_from_string, FeatureLocation, Location
 

--- a/antismash/modules/cluster_compare/test/integration_cc.py
+++ b/antismash/modules/cluster_compare/test/integration_cc.py
@@ -4,12 +4,11 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
-import json
 import unittest
 from unittest.mock import patch
 
 from antismash.main import get_all_modules
-from antismash.common import path, subprocessing
+from antismash.common import json, path, subprocessing
 from antismash.common.secmet import Record
 from antismash.common.test import helpers
 from antismash.config import build_config, destroy_config, update_config

--- a/antismash/modules/rrefinder/test/test_rrefinder.py
+++ b/antismash/modules/rrefinder/test/test_rrefinder.py
@@ -5,12 +5,12 @@
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 from collections import defaultdict
-import json as jsonlib
 import unittest
 from unittest.mock import patch
 
 import antismash
 from antismash.common.hmmer import HmmerResults
+from antismash.common import json as jsonlib
 from antismash.common.secmet.features import FeatureLocation
 from antismash.common.secmet.test.helpers import DummyRegion
 from antismash.common.test.helpers import (

--- a/antismash/modules/t2pks/t2pks_analysis.py
+++ b/antismash/modules/t2pks/t2pks_analysis.py
@@ -10,11 +10,10 @@
 
 """
 
-import json
 from typing import Dict, Iterable, List, Tuple, Set
 from collections import defaultdict
 
-from antismash.common import fasta, path, subprocessing
+from antismash.common import fasta, json, path, subprocessing
 from antismash.common.hmmscan_refinement import refine_hmmscan_results, HMMResult
 from antismash.common.utils import get_hmm_lengths, get_fasta_lengths
 from antismash.common.secmet import Protocluster, CDSFeature, Record

--- a/antismash/modules/t2pks/test/test_results.py
+++ b/antismash/modules/t2pks/test/test_results.py
@@ -4,9 +4,9 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
-import json
 import unittest
 
+from antismash.common import json
 from antismash.modules.t2pks.results import (
     CDSPrediction,
     ProtoclusterPrediction,

--- a/antismash/modules/tfbs_finder/test/test_tfbs_finder.py
+++ b/antismash/modules/tfbs_finder/test/test_tfbs_finder.py
@@ -4,13 +4,13 @@
 # for test files, silence irrelevant and noisy pylint warnings
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
-import json
 import unittest
 
 from Bio.Seq import Seq
 from Bio.SeqFeature import FeatureLocation
 
 from antismash import get_all_modules
+from antismash.common import json
 from antismash.common.secmet.test.helpers import DummyRegion, DummySubRegion
 from antismash.common.test.helpers import (
     DummyCandidateCluster,

--- a/antismash/modules/tfbs_finder/tfbs_finder.py
+++ b/antismash/modules/tfbs_finder/tfbs_finder.py
@@ -13,12 +13,11 @@ import logging
 from typing import Any, Dict, List, Optional, Tuple
 
 from collections import Counter
-import json as jsonlib
 from Bio.Seq import Seq
 from MOODS import tools, scan
 
 from antismash.config import get_config
-from antismash.common import path
+from antismash.common import json as jsonlib, path
 from antismash.common.module_results import ModuleResults
 from antismash.common.secmet import Record, Region
 from antismash.common.secmet.features import Feature, FeatureLocation

--- a/antismash/outputs/html/generator.py
+++ b/antismash/outputs/html/generator.py
@@ -4,13 +4,12 @@
 """ Responsible for creating the single web page results """
 
 import importlib
-import json
 import pkgutil
 import string
 import os
 from typing import cast, Any, Dict, List, Tuple, Union, Optional
 
-from antismash.common import path
+from antismash.common import json, path
 from antismash.common.html_renderer import (
     FileTemplate,
     HTMLSections,
@@ -108,7 +107,7 @@ def write_regions_js(records: List[Dict[str, Any]], output_dir: str,
         of code"""
 
     with open(os.path.join(output_dir, "regions.js"), "w", encoding="utf-8") as handle:
-        handle.write(f"var recordData = {json.dumps(records, indent=1)};\n")
+        handle.write(f"var recordData = {json.dumps(records)};\n")
         regions: Dict[str, Any] = {"order": []}
         for record in records:
             for region in record['regions']:

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ install_requires = [
     'bcbio-gff == 0.7.1',
     'libsass >= 0.22',
     'matplotlib',
+    'orjson',
     'scipy',
     'scikit-learn >= 0.19.0',
     'MOODS-python'


### PR DESCRIPTION
The stdlib python does not respect subclasses of types without either a custom encoder being passed to every json.dump(s) call or forcing pure-python conversion with by setting `json.encoder.c_make_encoder` to False. This caused the JSON helper classes in `antismash.common.json` to be converted to an empty dictionary when using the C implementation, which in turn prevented the NRPS/PKS domain view from showing anything after the changes in 09e7076bc where indentation was removed to save disk space.

Both options are poor because it's easy to miss the extra option or it becomes much slower to convert to JSON for the large HTML JSON dumps.

As a solution, all json library calls have been swapped to use `antismash.common.json` instead, taking advantage of the opportunity to switch to the much faster `orjson` library instead of the standard library.

This comes at the cost of slight flexibility, as indent levels in `orjson` are either 2 spaces or no indentation, but that seems bearable, given the speed increase.

Along with speed increases, the changes also add more flexibility in class conversion. All classes with a `to_json()` or `__json__()` method will now convert automatically, which will simplify many instances of classes with attributes of other classes needing conversion to JSON. This only applies to conversion *to* JSON, converting *from* JSON must still be specified.