### PR TITLE
Add CAL domain as a loader

### DIFF
--- a/antismash/detection/nrps_pks_domains/module_identification.py
+++ b/antismash/detection/nrps_pks_domains/module_identification.py
@@ -164,6 +164,10 @@ class Component:
         """ Returns True if the component can function as an acyltransferase domain """
         return self.label in ACYLTRANSFERASES
 
+    def is_cal(self) -> bool:
+        """ Returns True if the component can function as an acyltransferase domain """
+        return self.label == "CAL_domain"
+
     def is_condensation(self) -> bool:
         """ Returns True if the component can function as a condensation domain """
         return self.label in CONDENSATIONS
@@ -180,7 +184,7 @@ class Component:
 
     def is_loader(self) -> bool:
         """ Returns True if the component can function as a loader domain """
-        return self.is_acyltransferase() or self.is_adenylation()
+        return self.is_acyltransferase() or self.is_adenylation() or self.is_cal()
 
     def is_modification(self) -> bool:
         """ Returns True if the component can function as a modification domain """


### PR DESCRIPTION
Many lipopeptide siderophore NRPSs start with a fatty acid adenylation domain belonging to the CAL domain family (ex: [pyoverdine's PvdL](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3220798/)). Because `CAL_domain` isn't in the list of loaders, the module isn't recognized as valid. Here's PvdL:
![image](https://github.com/antismash/antismash/assets/21180350/4571df22-4feb-4dc3-ab34-590ae34df7fe)

In this more unusual case (NZ_ABLD01000016), the gene with the true initiation module is excluded from the modules tab, leading to another gene to incorrectly be labeled as the "complete" starter module.
![image](https://github.com/antismash/antismash/assets/21180350/e26a0f20-7dfc-4783-8c45-ed5ea993e0bd)
![image](https://github.com/antismash/antismash/assets/21180350/f3f33f49-5e21-4339-87df-5026099bf1b8)

This pull request adds the CAL domain to the list of loaders, which then allows the `CAL_domain - PCP` module to be recognized as complete:
![image](https://github.com/antismash/antismash/assets/21180350/c2471b32-5440-4fd3-9156-cbf95eafaf5f)

BGC0000180 is an example of a non-siderophore BGC that will be affected (correctly, I'd say).