### PR TITLE
Small fixes and improvements

### DIFF
--- a/antismash/common/secmet/__init__.py
+++ b/antismash/common/secmet/__init__.py
@@ -22,6 +22,7 @@ from .features import (
     Prepeptide,
     Protocluster,
     Region,
+    Source,
     SubRegion,
 )
 from .qualifiers import GeneFunction

--- a/antismash/common/secmet/features/__init__.py
+++ b/antismash/common/secmet/features/__init__.py
@@ -17,4 +17,5 @@ from .pfam_domain import PFAMDomain
 from .prepeptide import Prepeptide
 from .protocluster import Protocluster
 from .region import Region
+from .source import Source
 from .subregion import SubRegion

--- a/antismash/common/secmet/features/cdscollection.py
+++ b/antismash/common/secmet/features/cdscollection.py
@@ -65,7 +65,7 @@ class CDSCollection(Feature):
         if isinstance(other, CDSFeature):
             return other in self._cdses
         if isinstance(other, CDSCollection) and self._children:
-            return other in self._children
+            return any(other is child or other in child for child in self._children)
         return False
 
     @property

--- a/antismash/common/secmet/features/module.py
+++ b/antismash/common/secmet/features/module.py
@@ -117,13 +117,14 @@ class Module(Feature):
         """
         if self.is_multigene_module():
             raise ValueError("cannot generate protein location for multi-CDS module")
-        return FeatureLocation(self._domains[0].protein_location.start, self._domains[-1].protein_location.end)
+        return self.get_parent_protein_location(self._parent_cds_names[0])
 
     def get_parent_protein_location(self, parent: str) -> FeatureLocation:
         """ Returns the location within the specified parent for multi-CDS modules """
         if parent not in self._parent_cds_names:
             raise ValueError(f"module {self} has no parent named {parent}")
-        domains = [domain for domain in self._domains if domain.locus_tag == parent]
+        domains = sorted((domain for domain in self._domains if domain.locus_tag == parent),
+                         key=lambda dom: dom.protein_location.start)
         return FeatureLocation(domains[0].protein_location.start, domains[-1].protein_location.end)
 
     def add_monomer(self, substrate: str, monomer: str) -> None:

--- a/antismash/common/secmet/features/prepeptide.py
+++ b/antismash/common/secmet/features/prepeptide.py
@@ -130,7 +130,7 @@ class Prepeptide(CDSMotif):  # pylint: disable=too-many-instance-attributes
             leader_qualifiers = {
                 "prepeptide": ["leader"],
                 "note": [
-                    "peptide class: {self.peptide_class}",
+                    f"peptide class: {self.peptide_class}",
                     f"predicted sequence: {self.leader}",
                 ],
                 "locus_tag": [self.locus_tag],

--- a/antismash/common/secmet/features/region.py
+++ b/antismash/common/secmet/features/region.py
@@ -173,6 +173,15 @@ class Region(CDSCollection, AbstractRegion):
             warnings.simplefilter("ignore")
             cluster_record = record[self.location.start:self.location.end]
 
+        # find the source that starts this section of the record and insert it
+        for source in self.parent_record.get_sources():
+            if source.location.start < self.location.start < source.location.end:
+                source_bio = source.to_biopython()[0]
+                end = min(source_bio.location.end - self.location.start, len(cluster_record.seq))
+                source_bio.location = FeatureLocation(0, end)
+                cluster_record.features.insert(0, source_bio)
+                break
+
         cluster_record.annotations["date"] = record.annotations.get("date", '')
         cluster_record.annotations["source"] = record.annotations.get("source", '')
         cluster_record.annotations["organism"] = record.annotations.get("organism", '')

--- a/antismash/common/secmet/features/region.py
+++ b/antismash/common/secmet/features/region.py
@@ -4,6 +4,7 @@
 """ A class for region features """
 
 from collections import OrderedDict
+from copy import deepcopy
 import os
 from typing import Any, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
 import warnings
@@ -182,15 +183,8 @@ class Region(CDSCollection, AbstractRegion):
                 cluster_record.features.insert(0, source_bio)
                 break
 
-        cluster_record.annotations["date"] = record.annotations.get("date", '')
-        cluster_record.annotations["source"] = record.annotations.get("source", '')
-        cluster_record.annotations["organism"] = record.annotations.get("organism", '')
-        cluster_record.annotations["taxonomy"] = record.annotations.get("taxonomy", [])
-        cluster_record.annotations["data_file_division"] = record.annotations.get("data_file_division", 'UNK')
-        cluster_record.annotations["comment"] = record.annotations.get("comment", '')
-        # biopython does not persist the molecule_type annotation in slices,
-        # despite it being required for output to the genbank format
-        cluster_record.annotations["molecule_type"] = record.annotations["molecule_type"]
+        # biopython does not persist many annotations in slices
+        cluster_record.annotations = deepcopy(self.parent_record.annotations)
 
         # update the antiSMASH annotation to include some region details
         structured = cluster_record.annotations.get("structured_comment", {})

--- a/antismash/common/secmet/features/source.py
+++ b/antismash/common/secmet/features/source.py
@@ -1,0 +1,44 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+""" A feature to represent a gene """
+
+from typing import Any, Dict, List, Optional, Type, TypeVar
+
+from Bio.SeqFeature import SeqFeature
+
+from .feature import Feature, Location
+
+T = TypeVar("T", bound="Source")
+
+
+class Source(Feature):
+    """ A feature for `source` features within records.
+        Typically only one of these is present, but when multiple are present
+        then it is meaningful.
+    """
+    __slots__: List[str] = []
+    FEATURE_TYPE = "source"
+
+    def __init__(self, location: Location, created_by_antismash: bool = False,
+                 qualifiers: Optional[Dict[str, List[str]]] = None) -> None:
+        super().__init__(location, feature_type=self.FEATURE_TYPE,
+                         created_by_antismash=created_by_antismash)
+        if qualifiers:
+            assert isinstance(qualifiers, dict)
+            self._qualifiers.update(qualifiers)
+
+    def to_biopython(self, qualifiers: Dict[str, Any] = None) -> SeqFeature:
+        """ Construct a matching SeqFeature for this Source feature """
+        if not qualifiers:
+            qualifiers = {}
+        return super().to_biopython(qualifiers)
+
+    @classmethod
+    def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,
+                       leftovers: Dict[str, List[str]] = None, record: Any = None) -> T:
+        if leftovers is None:
+            leftovers = Feature.make_qualifiers_copy(bio_feature)
+        feature = cls(bio_feature.location)
+        super().from_biopython(bio_feature, feature=feature, leftovers=leftovers, record=record)
+        return feature

--- a/antismash/common/secmet/features/test/test_cdscollection.py
+++ b/antismash/common/secmet/features/test/test_cdscollection.py
@@ -57,6 +57,22 @@ class TestCDSCollection(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "not contained by"):
             collection.add_cds(cds)
 
+    def test_containment_transitivity(self):
+        location = FeatureLocation(20, 40)
+        inner = CDSCollection(location, feature_type="test", child_collections=[])
+        middle = CDSCollection(location, feature_type="test", child_collections=[inner])
+        outer = CDSCollection(location, feature_type="test", child_collections=[middle])
+
+        # check containment is transitive
+        assert inner in middle
+        assert middle in outer
+        assert inner in outer
+
+        # check that containment is not bidirectional
+        assert middle not in inner
+        assert outer not in inner
+        assert outer not in middle, middle._children
+
     def test_contig_edge_transitivity(self):
         inner = CDSCollection(FeatureLocation(30, 40), feature_type="test")
         mid = CDSCollection(FeatureLocation(20, 50), feature_type="test", child_collections=[inner])

--- a/antismash/common/secmet/features/test/test_module.py
+++ b/antismash/common/secmet/features/test/test_module.py
@@ -246,3 +246,20 @@ class TestModule(unittest.TestCase):
             ]
             module = create_module(domains=domains)
             assert module.location.strand == strand
+
+    def test_protein_location(self):
+        domains = (
+            DummyAntismashDomain(locus_tag="A", protein_start=15, protein_end=20, strand=-1),
+            DummyAntismashDomain(locus_tag="A", protein_start=5, protein_end=10, strand=-1),
+        )
+        module = create_module(domains=list(domains))
+        # the domain order, as given, is respected in the feature itself
+        # but ensuring the original argument isn't modified by using two lists
+        assert module._domains == list(domains)
+        # if the ordering doesn't take place here, then the new location will
+        # cause an error to be raised
+        location = module.get_parent_protein_location("A")
+        assert location.start == 5
+        assert location.end == 20
+        # similarly, the single-parent option should succeed
+        assert module.protein_location == location

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -402,7 +402,7 @@ def ensure_valid_locations(features: List[SeqFeature], can_be_circular: bool, se
             raise ValueError("one or more features with missing or invalid locations")
         # features outside the sequence cause problems with motifs and translations
         if feature.location.end > sequence_length:
-            raise ValueError("feature outside record sequence: {feature.location}")
+            raise ValueError(f"feature outside record sequence: {feature.location}")
         # features with overlapping exons cause translation problems
         if location_contains_overlapping_exons(feature.location):
             raise ValueError(f"location contains overlapping exons: {feature.location}")

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -13,8 +13,21 @@
 
 import bisect
 from collections import Counter, defaultdict, OrderedDict
+import itertools
 import logging
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, TypeVar, Union, cast
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 from zlib import crc32
 
 from Bio import SeqIO
@@ -471,24 +484,24 @@ class Record:
             raise ValueError(f"Use the appropriate get_* type instead for {label}")
         return tuple(i for i in self.get_generics() if i.type == label)
 
-    def get_all_features(self) -> List[Feature]:
-        """ Returns all features
-            note: This is slow, if only a specific type is required, use
-                  the other get_*() functions
-        """
-        features: list[Feature] = list(self._genes)
-        features.extend(self.get_generics())
-        features.extend(self.get_protoclusters())
-        features.extend(self.get_candidate_clusters())
-        features.extend(self.get_subregions())
-        features.extend(self.get_regions())
-        features.extend(self.get_cds_features())
-        features.extend(self.get_cds_motifs())
-        features.extend(self.get_antismash_domains())
-        features.extend(self.get_pfam_domains())
-        features.extend(self.get_modules())
-        features.extend(self.get_sources())
-        return features
+    @property
+    def all_features(self) -> Iterable[Feature]:
+        """ An iterator over all the features contained by the record """
+        # in order of least references to other features
+        return itertools.chain(
+            self._sources,
+            self._nonspecific_features,
+            self._genes,
+            self._cds_features,
+            self._cds_motifs,
+            self._antismash_domains,
+            self._pfam_domains,
+            self._modules,
+            self._subregions,
+            self._protoclusters,
+            self._candidate_clusters,
+            self._regions,
+        )
 
     def get_cds_features_within_location(self, location: Location,
                                          with_overlapping: bool = False) -> List[CDSFeature]:
@@ -540,9 +553,8 @@ class Record:
 
     def to_biopython(self) -> SeqRecord:
         """Returns a Bio.SeqRecord instance of the record"""
-        features = self.get_all_features()
         bio_features: List[SeqFeature] = []
-        for feature in sorted(features):
+        for feature in sorted(self.all_features):
             bio_features.extend(feature.to_biopython())
         if "molecule_type" not in self._record.annotations:
             self._record.annotations["molecule_type"] = "DNA"

--- a/antismash/common/secmet/test/helpers.py
+++ b/antismash/common/secmet/test/helpers.py
@@ -44,13 +44,15 @@ class DummyAntismashDomain(AntismashDomain):
 class DummyCDS(CDSFeature):
     counter = 0
 
-    def __init__(self, start=0, end=7, strand=1, locus_tag=None, translation=None):
+    def __init__(self, start=0, end=7, strand=1, locus_tag=None, translation=None, location=None):
         if not translation:
             translation = "A"*(abs(start-end))
         if not locus_tag:
             locus_tag = f"dummy_locus_tag_{DummyCDS.counter}"
             DummyCDS.counter += 1
-        super().__init__(FeatureLocation(start, end, strand), translation=translation,
+        if location is None:
+            location = FeatureLocation(start, end, strand)
+        super().__init__(location, translation=translation,
                          locus_tag=locus_tag)
         assert self.get_accession() == locus_tag, self.get_accession()
 

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -130,7 +130,7 @@ class TestConversion(unittest.TestCase):
         assert len(rec.features) == 1
         assert rec.features[0].location.parts == [location.parts[0], location.parts[2]]
 
-        features = sec_rec.get_all_features()
+        features = list(sec_rec.all_features)
         assert len(features) == 2
         assert features[0].location.parts == [location.parts[2]]
         assert features[1].location.parts == [location.parts[0]]
@@ -148,7 +148,7 @@ class TestConversion(unittest.TestCase):
                 Record.from_biopython(bio, taxon="bacteria")
             # with the discard flag, the bad antismash-specific feature should just disappear
             rec = Record.from_biopython(bio, taxon="bacteria", discard_antismash_features=True)
-            assert len(rec.get_all_features()) == 1
+            assert len(list(rec.all_features)) == 1
             # and that single feature had better be the CDS
             assert len(rec.get_cds_features()) == 1
 

--- a/antismash/common/subprocessing/prodigal.py
+++ b/antismash/common/subprocessing/prodigal.py
@@ -4,7 +4,34 @@
 """ A collection of functions for running prodigal.
 """
 
+from dataclasses import dataclass
+import logging
+from typing import Iterable
+
 from .base import execute, get_config
+
+
+@dataclass(frozen=True)
+class ProdigalGene:
+    """ Genes as detected by prodigal.
+        Similar to locations in general, start coordinates are 0-indexed, end coordinates are 1-indexed.
+    """
+    name: str
+    start: int
+    end: int
+    strand: int
+
+    @classmethod
+    def from_raw_line(cls, line: str) -> "ProdigalGene":
+        """ Converts a raw prodigal output line to an instance of the class.
+            e.g. '>5_7137_7874_+'
+        """
+        # strip the leading >
+        # split the underscores
+        # convert strand from +/- to int
+        name, start, end, strand = line.lstrip(">").split("_")
+        # convert 1-indexed start into 0-indexed for consistency throughout the whole codebase
+        return cls(name, int(start) - 1, int(end), -1 if strand == "-" else 1)
 
 
 def run_prodigal_version() -> str:
@@ -21,3 +48,30 @@ def run_prodigal_version() -> str:
         raise RuntimeError(msg % prodigal)
     # get rid of the non-version stuff in the output
     return version_string.split()[1][:-1]
+
+
+def run_prodigal(sequence: str, options: list[str] = None) -> Iterable[ProdigalGene]:
+    """ Run prodigal on the given sequence, with any additional options if provided.
+
+        Arguments:
+            sequence: the sequence to run prodigal over
+            options: any additional options as provided to the command line
+
+        Returns:
+            a ProdigalGene instance for each gene found
+    """
+    config = get_config()
+
+    args = [config.executables.prodigal, "-f", "sco"]
+    if config.genefinding_tool == "prodigal-m" or len(sequence) < 20000:
+        args.extend(["-p", "meta"])
+    if options:
+        args.extend(options)
+
+    result = execute(args, stdin=f">input\n{sequence}")
+    if not result.successful():
+        logging.error("Failed to run prodigal: %s", result.stderr)
+        raise RuntimeError(f"prodigal error: {result.stderr}")
+    # remembering to remove all header lines
+    return (ProdigalGene.from_raw_line(line) for line in result.stdout.splitlines()
+            if line.startswith(">"))

--- a/antismash/config/__init__.py
+++ b/antismash/config/__init__.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 from antismash.custom_typing import AntismashModule, ConfigType
 
 from .args import build_parser, AntismashParser
+from .executables import get_default_paths
 from .loader import load_config_from_file
 
 _USER_FILE_NAME = os.path.expanduser('~/.antismash7.cfg')
@@ -50,6 +51,12 @@ class Config:  # since it's a glorified namespace, pylint: disable=too-few-publi
         def __getattr__(self, attr: str) -> Any:
             if attr in self.__dict__:
                 return self.__dict__[attr]
+            # for some cases of members which are their own namespace, they
+            # should be created with default values if missing
+            if attr == "executables":
+                executables = Namespace(**get_default_paths())
+                self.__dict__[attr] = executables
+                return executables
             raise AttributeError(f"Config has no attribute: {attr}")
 
         def __setattr__(self, attr: str, value: Any) -> None:

--- a/antismash/config/test/test_args.py
+++ b/antismash/config/test/test_args.py
@@ -110,7 +110,8 @@ class TestConfig(unittest.TestCase):
         config = get_config(no_defaults=True)
         assert len(config) == 0
         with self.assertRaises(AttributeError):
-            assert config.executables
+            assert config.verbose
+        assert config.executables  # this namespace must always exist, but the contents may or may not
 
 
 class TestExecutableArg(unittest.TestCase):

--- a/antismash/modules/lassopeptides/specific_analysis.py
+++ b/antismash/modules/lassopeptides/specific_analysis.py
@@ -327,19 +327,19 @@ def acquire_rodeo_heuristics(record: Record, cluster: Protocluster, query: CDSFe
     distance = utils.distance_to_pfam(record, query, hmmer_profiles)
     tabs.append(distance)
     # Within 500 nucleotides of any biosynthetic protein (E, B, C)	+1
-    if distance < 500:
+    if 0 <= distance < 500:
         score += 1
         tabs.append(1)
     else:
         tabs.append(0)
     # Within 150 nucleotides of any biosynthetic protein (E, B, C)	+1
-    if distance < 150:
+    if 0 <= distance < 150:
         score += 1
         tabs.append(1)
     else:
         tabs.append(0)
     # Greater than 1000 nucleotides from every biosynthetic protein (E, B, C)	-2
-    if distance > 1000:
+    if distance > 1000 or distance == -1:
         score -= 2
         tabs.append(1)
     else:

--- a/antismash/modules/lassopeptides/specific_analysis.py
+++ b/antismash/modules/lassopeptides/specific_analysis.py
@@ -435,8 +435,8 @@ def acquire_rodeo_heuristics(record: Record, cluster: Protocluster, query: CDSFe
     else:
         tabs.append(0)
     # cluster does not contain PF13471	-2
-    if utils.distance_to_pfam(record, query, ['PF13471']) == -1 or \
-       utils.distance_to_pfam(record, query, ['PF13471']) > 10000:
+    distance = utils.distance_to_pfam(record, query, ['PF13471'])
+    if distance == -1 or distance > 10000:
         score -= 2
     # Peptide utilizes alternate start codon	-1
     if not str(query.extract(record.seq)).startswith("ATG"):
@@ -480,24 +480,12 @@ def generate_rodeo_svm_csv(record: Record, query: CDSFeature, leader: str, core:
     # classification
     columns.append(0)
     columns += previously_gathered_tabs
-    # cluster has PF00733?
-    if utils.distance_to_pfam(record, query, ['PF00733']) == -1 or \
-       utils.distance_to_pfam(record, query, ['PF00733']) > 10000:
-        columns.append(0)
-    else:
-        columns.append(1)
-    # cluster has PF05402?
-    if utils.distance_to_pfam(record, query, ['PF05402']) == -1 or \
-       utils.distance_to_pfam(record, query, ['PF05402']) > 10000:
-        columns.append(0)
-    else:
-        columns.append(1)
-    # cluster has PF13471?
-    if utils.distance_to_pfam(record, query, ['PF13471']) == -1 or \
-       utils.distance_to_pfam(record, query, ['PF13471']) > 10000:
-        columns.append(0)
-    else:
-        columns.append(1)
+    for identifier in ["PF00733", "PF05402", "PF13471"]:
+        distance = utils.distance_to_pfam(record, query, [identifier])
+        if 0 <= distance <= 10000:
+            columns.append(1)
+        else:
+            columns.append(0)
     # Leader has LxxxxxT motif?
     if re.search('(L.....T)', leader):
         columns.append(1)

--- a/antismash/modules/rrefinder/test/test_rrefinder.py
+++ b/antismash/modules/rrefinder/test/test_rrefinder.py
@@ -180,9 +180,9 @@ class TestRREResults(unittest.TestCase):
         record = DummyRecord()
         results = self.create_results(record_id=record.id)
 
-        assert not record.get_all_features()
+        assert not list(record.all_features)
         results.add_to_record(record)
-        assert len(record.get_all_features()) == 2
+        assert len(list(record.all_features)) == 2
         assert len(record.get_antismash_domains_by_tool(TOOL)) == 2
 
 

--- a/antismash/modules/sactipeptides/specific_analysis.py
+++ b/antismash/modules/sactipeptides/specific_analysis.py
@@ -192,20 +192,19 @@ def acquire_rodeo_heuristics(cluster: secmet.Protocluster, query: secmet.CDSFeat
     distance = utils.distance_to_pfam(cluster.parent_record, query, hmmer_profiles)
     tabs.append(distance)
     # rSAM within 500 nt?
-    if utils.distance_to_pfam(cluster.parent_record, query, ['PF04055']) < 500:
+    if 0 <= distance < 500:
         score += 1
         tabs.append(1)
     else:
         tabs.append(0)
     # rSAM within 150 nt?
-    if utils.distance_to_pfam(cluster.parent_record, query, ['PF04055']) < 150:
+    if 0 <= distance < 150:
         score += 1
         tabs.append(1)
     else:
         tabs.append(0)
     # rSAM further than 1000 nt?
-    if utils.distance_to_pfam(cluster.parent_record, query, ['PF04055']) == -1 or \
-       utils.distance_to_pfam(cluster.parent_record, query, ['PF04055']) > 10000:
+    if distance == -1 or distance > 10000:
         score -= 2
         tabs.append(1)
     else:

--- a/antismash/support/genefinding/__init__.py
+++ b/antismash/support/genefinding/__init__.py
@@ -98,6 +98,6 @@ def run_on_record(record: Record, options: ConfigType) -> None:
 
     if options.genefinding_tool in ["prodigal", "prodigal-m"]:
         logging.debug("Running prodigal based genefinding")
-        return run_prodigal(record, options)
+        return run_prodigal(record)
 
     raise ValueError(f"Unknown genefinding tool: {options.genefinding_tool}")

--- a/antismash/support/genefinding/test/integration_prodigal.py
+++ b/antismash/support/genefinding/test/integration_prodigal.py
@@ -6,7 +6,7 @@
 
 from unittest import TestCase
 
-from antismash.config import get_config, update_config
+from antismash.config import destroy_config, update_config
 from antismash.common.record_processing import parse_input_sequence, pre_process_sequences
 from antismash.common.test.helpers import get_simple_options, get_path_to_nisin_fasta
 from antismash.support import genefinding
@@ -19,7 +19,7 @@ class TestProdigal(TestCase):
                                                          '--cpus', '1']))
 
     def tearDown(self):
-        get_config().__dict__.clear()
+        destroy_config()
 
     def test_nisin(self):
         record = parse_input_sequence(get_path_to_nisin_fasta())[0]

--- a/antismash/support/genefinding/test/test_prodigal.py
+++ b/antismash/support/genefinding/test/test_prodigal.py
@@ -1,0 +1,25 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+# for test files, silence irrelevant and noisy pylint warnings
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
+
+import unittest
+
+from antismash.common.secmet.locations import FeatureLocation
+from antismash.support.genefinding.run_prodigal import (
+    _build_location_from_prodigal,
+    ProdigalGene,
+)
+
+
+def build_location(start, end, strand):
+    gene = ProdigalGene("dummy", start, end, strand)
+    return _build_location_from_prodigal(gene)
+
+
+class TestProdigal(unittest.TestCase):
+    def test_simple(self):
+        for strand in [1, -1]:
+            loc = build_location(5, 15, strand)  # 1-indexed start
+            assert loc == FeatureLocation(5, 15, strand)

--- a/antismash/test/test_antismash.py
+++ b/antismash/test/test_antismash.py
@@ -69,31 +69,33 @@ class TestAntismash(unittest.TestCase):
         bio = rec.to_biopython()
 
         main.add_antismash_comments([(rec, bio)], options)
-        assert "##antiSMASH-Data-START##" in bio.annotations["comment"]
-        assert "##antiSMASH-Data-END##" in bio.annotations["comment"]
-        assert "Version" in bio.annotations["comment"] and options.version in bio.annotations["comment"]
-        assert "Original ID" not in bio.annotations["comment"]
-        assert "Starting at" not in bio.annotations["comment"]
-        assert "Ending at" not in bio.annotations["comment"]
+        comment = bio.annotations["structured_comment"]["antiSMASH-Data"]
+        assert comment["Version"] == options.version
+        assert "Original ID" not in comment
+        assert "Starting at" not in comment
+        assert "Ending at" not in comment
 
-        bio.annotations["comment"] = ""
+        bio.annotations["structured_comment"].pop("antiSMASH-Data")
         options.start = 7
         main.add_antismash_comments([(rec, bio)], options)
-        assert "Original ID" not in bio.annotations["comment"]
-        assert "Starting at  :: 7\n" in bio.annotations["comment"]
+        comment = bio.annotations["structured_comment"]["antiSMASH-Data"]
+        assert "Original ID" not in comment
+        assert comment["Starting at"] == "7"
 
-        bio.annotations["comment"] = ""
+        bio.annotations["structured_comment"].pop("antiSMASH-Data")
         options.start = -1
         options.end = 1000
         main.add_antismash_comments([(rec, bio)], options)
-        assert "Original ID" not in bio.annotations["comment"]
-        assert "Ending at    :: 1000\n" in bio.annotations["comment"]
+        comment = bio.annotations["structured_comment"]["antiSMASH-Data"]
+        assert "Original ID" not in comment
+        assert comment["Ending at"] == "1000"
 
-        bio.annotations["comment"] = ""
+        bio.annotations["structured_comment"].pop("antiSMASH-Data")
         options.end = -1
         rec.original_id = "something else"
         main.add_antismash_comments([(rec, bio)], options)
-        assert "Original ID" in bio.annotations["comment"] and "something else" in bio.annotations["comment"]
+        comment = bio.annotations["structured_comment"]["antiSMASH-Data"]
+        assert comment["Original ID"] == rec.original_id
 
     def test_canonical_base_filename(self):
         options = build_parser(modules=self.all_modules).parse_args([])


### PR DESCRIPTION
A collection of small changes, most of which are simple fixes or improvements. The remainder are aimed at supporting future use cases or use as a library (e.g. adding `subprocessing.prodigal` runners.

- Improves some testing helpers, and performance for various areas.
- Improves communication of `--sideload-by-cds` with a name that does not exist in inputs. As no mechanism exists (yet) for checking all records with all options, for now this just logs a warning.
- Adds explicit tracking of `source` features in records, for future use in multi-source inputs.
- Fixes an issue in lassopeptide scoring where checking that another component was within a certain distance would never fail.
- Fixes an issue with some very specific NRPS/PKS module constructs resulting in crashes due to unexpected domain ordering when fetching the module's protein location.

