### PR TITLE
Add support for treating modules with CAL domains as complete, including monomer/polymer generation

### DIFF
--- a/antismash/detection/nrps_pks_domains/module_identification.py
+++ b/antismash/detection/nrps_pks_domains/module_identification.py
@@ -164,6 +164,10 @@ class Component:
         """ Returns True if the component can function as an acyltransferase domain """
         return self.label in ACYLTRANSFERASES
 
+    def is_coa_ligase(self) -> bool:
+        """ Returns True if the component can function as a CoA-ligase"""
+        return self.label == "CAL_domain"
+
     def is_condensation(self) -> bool:
         """ Returns True if the component can function as a condensation domain """
         return self.label in CONDENSATIONS
@@ -176,11 +180,11 @@ class Component:
             ADENYLATIONS,
             ACYLTRANSFERASES,
             ALTERNATE_STARTERS
-        ))
+        )) or self.is_coa_ligase()
 
     def is_loader(self) -> bool:
         """ Returns True if the component can function as a loader domain """
-        return self.is_acyltransferase() or self.is_adenylation()
+        return self.is_acyltransferase() or self.is_adenylation() or self.is_coa_ligase()
 
     def is_modification(self) -> bool:
         """ Returns True if the component can function as a modification domain """
@@ -454,6 +458,11 @@ class Module:
 
             if any(mod.label == "PKS_ER" for mod in self._modifications):
                 conversions = {"ccmal": "redmal", "ccmmal": "redmmal", "ccmxmal": "redmxmal", "ccemal": "redemal"}
+                base = conversions.get(base, base)
+
+        if self._starter and self._starter.is_coa_ligase():
+            if any(mod.label == "PKS_KR" for mod in self._modifications):
+                conversions = {"AHBA": "ohAHBA"}
                 base = conversions.get(base, base)
 
         for mod in self._modifications:

--- a/antismash/detection/nrps_pks_domains/test/test_modules.py
+++ b/antismash/detection/nrps_pks_domains/test/test_modules.py
@@ -143,6 +143,15 @@ class TestModule(unittest.TestCase):
         assert new._starter.label == PKS_START
         assert not new._end
 
+    def test_cal_complete(self):
+        module = build_module(["CAL_domain", CP])
+        assert module.is_complete()
+        assert module.get_monomer("AHBA") == "AHBA"
+
+    def test_cal_modifications(self):
+        module = build_module(["CAL_domain", "PKS_KR", CP])
+        assert module.get_monomer("AHBA") == "ohAHBA"
+
     def test_methylations(self):
         pks = build_module([PKS_START, PKS_LOAD])
         # mmal is a methylated malonyl-CoA, so it should look the same

--- a/antismash/modules/nrps_pks/data/aaSMILES.txt
+++ b/antismash/modules/nrps_pks/data/aaSMILES.txt
@@ -105,3 +105,11 @@ emal C(CC)C(=O)
 ohemal C(CC)C(O)
 ccemal C(CC)=C
 redemal C(CC)C
+
+# MINOWA predictions
+AHBA C1=CC(=O)C(N)C=C1C(=O)O
+ohAHBA C1=CC(O)C(N)C=C1C(=O)O  # possible modification by a KR, consistent with PKS substrate modification naming
+fatty_acid C[*]C(=O)O
+NH2 N
+Acetyl-CoA CC(=O)O
+shikimic_acid C1C(O)C(O)C(O)C=C1C(=O)O

--- a/antismash/modules/nrps_pks/orderfinder.py
+++ b/antismash/modules/nrps_pks/orderfinder.py
@@ -139,7 +139,7 @@ def find_candidate_cluster_modular_enzymes(cds_features: List[CDSFeature]) -> Tu
     """
     def is_pks_module(module: Module) -> bool:
         domain_names = set(domain.domain for domain in module.domains)
-        return bool(domain_names.intersection({"PKS_KS", "PKS_AT"}))
+        return bool(domain_names.intersection({"PKS_KS", "PKS_AT", "CAL_domain"}))
 
     def is_nrps_module(module: Module) -> bool:
         domain_names = set(domain.domain for domain in module.domains)

--- a/antismash/modules/nrps_pks/parsers.py
+++ b/antismash/modules/nrps_pks/parsers.py
@@ -130,7 +130,7 @@ def calculate_consensus_prediction(cds_features: List[CDSFeature], results: Dict
                 preds = predictions["minowa_cal"].get_classification()
                 pred = get_short_form(preds[0])
                 assert isinstance(pred, str)
-                if pred in get_all_smiles():
+                if pred.lower() in get_all_smiles():
                     cis_at[domain.feature_name] = pred
                 else:
                     logging.debug("missing %s from SMILES parts for domain %s", pred, domain.feature_name)


### PR DESCRIPTION
A more complete version of #720. 

- adds SMILES for all predictions made for what's loaded by CAL domains
- treats CAL domains and starter domains and loader domains so that the module itself can count as a starter module
- adds support for monomer modification if dehydrogenase domains are present in the module (the only affected substrate is `AHBA`)
- treats modules with CAL domains as PKS domains to both include the monomer in the predicted polymer and enable non-colinear ordering 

Using some of the examples from the other PR, here's the results:
![image](https://github.com/antismash/antismash/assets/1700735/3b2893b1-3153-4aaf-b894-a0660d24b5ea)

![image](https://github.com/antismash/antismash/assets/1700735/240ff3fe-c903-409e-9757-a7fba53cd94f)

![image](https://github.com/antismash/antismash/assets/1700735/500f7694-6390-46c3-b0da-936235a3f900)

And an unmodified `AHBA`, non-colinear example from NZ_MEAX01000018:
![image](https://github.com/antismash/antismash/assets/1700735/2d3fa1d9-769c-48df-ace2-fe763638a0b0)
