### PR TITLE
hmm_detection: extend and improve the mycosporine rule

### DIFF
--- a/antismash/detection/hmm_detection/cluster_rules/relaxed.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/relaxed.txt
@@ -5,7 +5,7 @@
 RULE NRPS-like
     CATEGORY NRPS
     DESCRIPTION Catches NRPS-like fragments that are not detected by the NRPS rule
-    SUPERIORS NRPS, NAPAA, isocyanide-nrp
+    SUPERIORS NRPS, NAPAA, isocyanide-nrp, mycosporine-like
     CUTOFF 0  # since we're really looking at single CDS fragments
     NEIGHBOURHOOD 20
     CONDITIONS cds((PP-binding or NAD_binding_4) and (AMP-binding or A-OX))

--- a/antismash/detection/hmm_detection/cluster_rules/strict.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/strict.txt
@@ -165,11 +165,13 @@ RULE NAPAA
 RULE mycosporine-like
     CATEGORY NRPS
     DESCRIPTION mycosporine-like amino acid containing molecules
-    EXAMPLE NCBI MN401680.1 0-5063 mycosporine
-    RELATED Dala_Dala_lig_C, Dala_Dala_lig_N
+    # see DOI: 10.1128/AEM.00727-14
+    EXAMPLE NCBI MN401680.1 0-5063 mycosporine with ligase
+    EXAMPLE NCBI CP000117.1 4798900-4805360 mycosporine with NRPS-like
     CUTOFF 10
     NEIGHBOURHOOD 20
     CONDITIONS DHQ_synthase and Methyltransf_3 and ATP-grasp_3
+    EXTENDERS cds(Dala_Dala_lig_C or Dala_Dala_lig_N or AMP-binding)
 
 RULE terpene
     CATEGORY terpene


### PR DESCRIPTION
Extend mycosporine rule to detect ligases participating in mycosporine-like amino acid biosynthesis and add the paper the rule relies on (https://journals.asm.org/doi/10.1128/aem.00727-14)