### PR TITLE
hmm_detection: include extender profiles in profile usage test

### DIFF
--- a/antismash/detection/hmm_detection/test/test_hmm_detection.py
+++ b/antismash/detection/hmm_detection/test/test_hmm_detection.py
@@ -191,6 +191,8 @@ class HmmDetectionTest(unittest.TestCase):
         rules = hmm_detection.create_rules(rule_files, self.signature_names, self.valid_categories)
         for rule in rules:
             profiles_used = profiles_used.union(rule.conditions.profiles)
+            if rule.extenders:
+                profiles_used.update(rule.extenders.profiles)
             for related in rule.related:
                 profiles_used.add(related)
 


### PR DESCRIPTION
Fixes a test issue blocking #729, where rule `EXTENDERS` conditions weren't considered for profiles being used.