### PR TITLE
Update ClusterCompare with modules that use CAL domains 

### DIFF
--- a/antismash/common/secmet/features/module.py
+++ b/antismash/common/secmet/features/module.py
@@ -20,6 +20,7 @@ class ModuleType(Enum):
     UNKNOWN = 0
     NRPS = 1
     PKS = 2
+    CAL = 3  # this is very specific to CAL domains, but they're common enough to justify this
 
     def __str__(self) -> str:
         return str(self.name).lower()

--- a/antismash/detection/nrps_pks_domains/domain_identification.py
+++ b/antismash/detection/nrps_pks_domains/domain_identification.py
@@ -22,7 +22,6 @@ from antismash.common.secmet.features import (
 )
 from antismash.common.secmet.locations import FeatureLocation
 from antismash.config import get_config
-from antismash.detection.nrps_pks_domains.modular_domain import ModularDomain
 
 from .module_identification import (
     build_modules_for_cds,
@@ -142,6 +141,8 @@ class NRPSPKSDomains(module_results.DetectionResults):
                     mod_type = ModuleFeature.types.NRPS
                 elif module.is_pks():
                     mod_type = ModuleFeature.types.PKS
+                elif module.is_coa_ligase():
+                    mod_type = ModuleFeature.types.CAL
                 feature = ModuleFeature(domains, mod_type, complete=module.is_complete(),
                                         starter=module.is_starter_module(),
                                         final=module.is_termination_module(),

--- a/antismash/detection/nrps_pks_domains/module_identification.py
+++ b/antismash/detection/nrps_pks_domains/module_identification.py
@@ -273,6 +273,10 @@ class Module:
         return bool(self._starter and self._starter.is_nrps_specific()
                     or self._loader and self._loader.is_nrps_specific())
 
+    def is_coa_ligase(self) -> bool:
+        """ Returns True if the module uses a CAL domain """
+        return bool(self._starter and self._starter.is_coa_ligase())
+
     def is_trans_at(self) -> bool:
         """ Returns True if the module is Trans-AT variant of a PKS module """
         # since there's some alternatives, start by checking the bare minimum

--- a/antismash/modules/cluster_compare/data_structures.py
+++ b/antismash/modules/cluster_compare/data_structures.py
@@ -78,8 +78,33 @@ class Components:
     """
     nrps: SubComponents
     pks: SubComponents
+    generic_modules: SubComponents
     secmet: SubComponents
     functions: SubComponents
+
+    @property
+    def module_count(self) -> int:
+        """ The number of modules within the area """
+        return sum(sum(sub.values()) for sub in [self.nrps, self.pks, self.generic_modules])
+
+    def get_module_weightings(self, normalisation: int = None) -> dict[str, float]:
+        """ Gathers the proportion of module components for each type.
+
+            Arguments:
+                normalisation: an override for the number of modules
+
+            Returns:
+                a dictionary mapping module type to proportion
+        """
+        if normalisation is None:
+            normalisation = max(1, self.module_count)
+        if not normalisation:  # prevent division by zero
+            normalisation = 1
+        return {
+            "nrps": sum(self.nrps.values()) / normalisation,
+            "pks": sum(self.pks.values()) / normalisation,
+            "generic": sum(self.generic_modules.values()) / normalisation,
+        }
 
 
 @dataclasses.dataclass(frozen=True)

--- a/antismash/modules/cluster_compare/test/test_data_structures.py
+++ b/antismash/modules/cluster_compare/test/test_data_structures.py
@@ -52,7 +52,7 @@ class TestMode(unittest.TestCase):
 
 class TestComponents(unittest.TestCase):
     def test_restrictions(self):
-        components = Components({}, {}, {}, {})
+        components = Components({}, {}, {}, {}, {})
         with self.assertRaises(AttributeError):
             components.something_invalid = "test"
 


### PR DESCRIPTION
This fixes a crash that occurred when a ClusterCompare query region included a module that used a CAL domain (as introduced in #724), because they were registered as a having a module type of "unknown" in the features.
This has been corrected by adding a new CAL-specific module type in `secmet` and by setting that type in `nrps_pks_domains`.

Adding on that fix, ClusterCompare has been changed from a binary weighting system (i.e. PKS and NRPS) for modules to a system that can take an arbitrary number of types. Initially, these CAL domains have been included in a "generic domains" category, intended for those modules which are too constrained/specific for their own category. This may need to be updated in future, if detection can find a larger variety of these modules.

The building of ClusterCompare databases is unaffected, as that uses `secmet` module types already.