### PR TITLE
common.signature: forbid leading and trailing whitespace in signature identifiers

### DIFF
--- a/antismash/common/signature.py
+++ b/antismash/common/signature.py
@@ -11,6 +11,8 @@ from .path import get_full_path
 class Signature:
     """Secondary metabolite signature"""
     def __init__(self, name: str, _type: str, description: str, cutoff: int, path: str, seed_count: int = 0) -> None:
+        if name.strip() != name:
+            raise ValueError(f"Signature identifiers cannot have leading or trailing whitespace: {name!r}")
         self.name = name
         self.type = _type
         self.description = description

--- a/antismash/common/test/test_signature.py
+++ b/antismash/common/test/test_signature.py
@@ -1,0 +1,17 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+# for test files, silence irrelevant and noisy pylint warnings
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring,consider-using-with
+
+from unittest import TestCase
+
+from antismash.common.signature import Signature
+
+
+class TestSignature(TestCase):
+    def test_whitespace_in_identifiers(self):
+        for name in [" leading", "trailing ", " both "]:
+            with self.assertRaisesRegex(ValueError, "cannot have leading or trailing"):
+                Signature(name, "type", "description", 50, "dummy_path")
+        assert Signature("good", "type", "description", 50, "dummy_path").name == "good"


### PR DESCRIPTION
Prevents difficult to find issues in whitespace splitting in HMM details files, e.g. #732.

At some point in the future, a clearer file format would be much better, but for the moment this is the simplest fix. 