### PR TITLE
common.hmm_rule_parser: allow dynamic profiles access to existing HMMer profile hits

### DIFF
--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -780,7 +780,7 @@ def detect_protoclusters_and_signatures(record: Record, ruleset: Ruleset,
                                              ruleset.get_equivalence_groups()))
 
     # gather dynamic hits and merge them with HMMer results
-    dynamic_results = find_dynamic_hits(record, list(ruleset.dynamic_profiles.values()))
+    dynamic_results = find_dynamic_hits(record, list(ruleset.dynamic_profiles.values()), results_by_id)
     for name, dynamic_hits in dynamic_results.items():
         if name not in results_by_id:
             results_by_id[name] = []
@@ -813,18 +813,20 @@ def strip_inferior_domains(cds_domains_by_cluster: Dict[str, Dict[str, Set[str]]
                 domains_by_cluster.pop(product)
 
 
-def find_dynamic_hits(record: Record, dynamic_profiles: List[DynamicProfile]) -> Dict[str, List[DynamicHit]]:
+def find_dynamic_hits(record: Record, dynamic_profiles: list[DynamicProfile],
+                      hmmer_hits: dict[str, list[ProfileHit]]) -> dict[str, list[DynamicHit]]:
     """ Finds hits for dynamic profiles
 
     Arguments:
         record: the Record to search
         dynamic_profiles: the dynamic profiles to find hits with
+        hmmer_hits: existing HMMer profile hits for use in dynamic profiles
 
     Returns:
         a dictionary mapping CDS name to list of DynamicHit
     """
     results: Dict[str, List[DynamicHit]] = defaultdict(list)
     for profile in dynamic_profiles:
-        for name, hits in profile.find_hits(record).items():
+        for name, hits in profile.find_hits(record, hmmer_hits).items():
             results[name].extend(hits)
     return results

--- a/antismash/common/hmm_rule_parser/structures.py
+++ b/antismash/common/hmm_rule_parser/structures.py
@@ -50,15 +50,17 @@ class DynamicHit(ProfileHit):
 class DynamicProfile(Signature):
     """ A dynamic profile based on code, rather than a HMM """
     def __init__(self, name: str, description: str,
-                 detect: Callable[[Record], Dict[str, List[DynamicHit]]]) -> None:
+                 detect: Callable[[Record, dict[str, list[ProfileHit]]], dict[str, list[DynamicHit]]],
+                 ) -> None:
         super().__init__(name, "dynamic", description, 0, __file__)
         self._callable = detect
 
-    def find_hits(self, record: Record) -> Dict[str, List[DynamicHit]]:
+    def find_hits(self, record: Record, hmmer_hits: Dict[str, List[ProfileHit]],
+                  ) -> dict[str, list[DynamicHit]]:
         """ Runs the profile over the record and return a dictionary mapping
             CDS name to a list of HSPs, one for each 'hit'
         """
-        return self._callable(record)
+        return self._callable(record, hmmer_hits)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
@@ -121,9 +121,9 @@ class TestDynamic(unittest.TestCase):
     def test_find_dynamic(self):
         expected_a = {"cds_name": [structures.DynamicHit("prof_a", "cds_name")]}
         expected_b = {"cds_name": [structures.DynamicHit("prof_b", "cds_name")]}
-        profile_a = structures.DynamicProfile("prof_a", "desc a", lambda record: expected_a)
-        profile_b = structures.DynamicProfile("prof_b", "desc b", lambda record: expected_b)
-        results = cluster_prediction.find_dynamic_hits(DummyRecord(), [profile_a, profile_b])
+        profile_a = structures.DynamicProfile("prof_a", "desc a", lambda record, _: expected_a)
+        profile_b = structures.DynamicProfile("prof_b", "desc b", lambda record, _: expected_b)
+        results = cluster_prediction.find_dynamic_hits(DummyRecord(), [profile_a, profile_b], {})
         assert results["cds_name"] == expected_a["cds_name"] + expected_b["cds_name"]
 
     @patch.object(cluster_prediction, "find_hmmer_hits", return_value={})
@@ -133,7 +133,7 @@ class TestDynamic(unittest.TestCase):
         record = DummyRecord(features=cdses)
 
         # create a dummy dynamic profile
-        def find_a(rec):
+        def find_a(rec, _hmmer_hits):
             hits = {}
             for cds in rec.get_cds_features():
                 if cds.get_name() == "A":
@@ -141,7 +141,7 @@ class TestDynamic(unittest.TestCase):
             return hits
         profile = structures.DynamicProfile("a_finder", "desc", find_a)
         # make sure the 'profile' functions as expected
-        assert cdses[0].get_name() in profile.find_hits(record)
+        assert cdses[0].get_name() in profile.find_hits(record, {})
 
         # build a dummy rule that will search for this hit
         condition = rule_parser.SingleCondition(False, "a_finder")

--- a/antismash/detection/hmm_detection/dynamic_profiles/cyanobactin_precursor.py
+++ b/antismash/detection/hmm_detection/dynamic_profiles/cyanobactin_precursor.py
@@ -14,7 +14,11 @@ from typing import Dict, List
 import re
 
 
-from antismash.common.hmm_rule_parser.structures import DynamicHit, DynamicProfile
+from antismash.common.hmm_rule_parser.structures import (
+    DynamicHit,
+    DynamicProfile,
+    ProfileHit,
+)
 from antismash.common.secmet import Record
 
 # This is the name this profile will have in the cluster rules
@@ -40,7 +44,8 @@ MAX_LEN = 150
 LAST_ALLOWABLE_START = 50  # We expect the pattern in the leader
 
 
-def find_hits(record: Record, allowable_misses: int = ALLOWABLE_MISSES) -> Dict[str, List[DynamicHit]]:
+def find_hits(record: Record, _hmmer_hits: dict[str, list[ProfileHit]],
+              allowable_misses: int = ALLOWABLE_MISSES) -> dict[str, list[DynamicHit]]:
     """Find all CDSes where the pattern is found"""
     hits: Dict[str, List[DynamicHit]] = {}
 

--- a/antismash/detection/hmm_detection/dynamic_profiles/darobactin_precursor.py
+++ b/antismash/detection/hmm_detection/dynamic_profiles/darobactin_precursor.py
@@ -10,7 +10,11 @@ from typing import Dict, List
 import re
 
 
-from antismash.common.hmm_rule_parser.structures import DynamicHit, DynamicProfile
+from antismash.common.hmm_rule_parser.structures import (
+    DynamicHit,
+    DynamicProfile,
+    ProfileHit,
+)
 from antismash.common.secmet import Record
 
 # This is the name this profile will have in the cluster rules
@@ -22,7 +26,7 @@ ANCHOR = re.compile(r"W.W.K..")
 MIN_LEN = 10  # The final compound core is 7 AAs, 
 MAX_LEN = 80
 
-def find_hits(record: Record) -> Dict[str, List[DynamicHit]]:
+def find_hits(record: Record, hmmer_hits: dict[str, list[ProfileHit]]) -> dict[str, list[DynamicHit]]:
     """Find all CDSes where the pattern is found"""
     hits: Dict[str, List[DynamicHit]] = {}
 

--- a/antismash/detection/hmm_detection/dynamic_profiles/test/test_cyanobactin_precursor.py
+++ b/antismash/detection/hmm_detection/dynamic_profiles/test/test_cyanobactin_precursor.py
@@ -38,11 +38,12 @@ class TestCyanobactinPrecursor(unittest.TestCase):
             features.append(feature)
 
         self.record = DummyRecord(features=features)
+        self.hmmer_hits = {}
 
     def test_one_mismatch(self) -> None:
-        results = cyanobactin_precursor.find_hits(self.record)
+        results = cyanobactin_precursor.find_hits(self.record, self.hmmer_hits)
         assert set(results.keys()) == {"exact_match", "one_mismatch", "exact_match_with_offset"}
 
     def test_two_mismatches(self) -> None:
-        results = cyanobactin_precursor.find_hits(self.record, 2)
+        results = cyanobactin_precursor.find_hits(self.record, self.hmmer_hits, 2)
         assert set(results.keys()) == {"exact_match", "one_mismatch", "two_mismatches", "exact_match_with_offset"}

--- a/antismash/detection/hmm_detection/dynamic_profiles/test/test_darobactin_precursor.py
+++ b/antismash/detection/hmm_detection/dynamic_profiles/test/test_darobactin_precursor.py
@@ -34,5 +34,5 @@ class TestDarobactinPrecursor(unittest.TestCase):
         self.record = DummyRecord(features=features)
 
     def test_hits(self) -> None:
-        results = darobactin_precursor.find_hits(self.record)
+        results = darobactin_precursor.find_hits(self.record, {})
         assert set(results.keys()) == {"darA"}

--- a/antismash/detection/hmm_detection/dynamic_profiles/test/test_triceptide_precursor.py
+++ b/antismash/detection/hmm_detection/dynamic_profiles/test/test_triceptide_precursor.py
@@ -35,5 +35,5 @@ class TestTriceptidePrecursor(unittest.TestCase):
         self.record = DummyRecord(features=features)
 
     def test_hits(self) -> None:
-        results = triceptide_precursor.find_hits(self.record)
+        results = triceptide_precursor.find_hits(self.record, {})
         assert set(results.keys()) == {"YxD", "HAA", "YRD"}

--- a/antismash/detection/hmm_detection/dynamic_profiles/triceptide_precursor.py
+++ b/antismash/detection/hmm_detection/dynamic_profiles/triceptide_precursor.py
@@ -10,7 +10,11 @@ from typing import Dict, List
 import re
 
 
-from antismash.common.hmm_rule_parser.structures import DynamicHit, DynamicProfile
+from antismash.common.hmm_rule_parser.structures import (
+    DynamicHit,
+    DynamicProfile,
+    ProfileHit,
+)
 from antismash.common.secmet import Record
 
 # This is the name this profile will have in the cluster rules
@@ -22,7 +26,7 @@ ANCHOR = re.compile(r"(A.Y.D.P|HAASL|Y.R.H..H.R)")
 MIN_LEN = 10
 MAX_LEN = 100
 
-def find_hits(record: Record) -> Dict[str, List[DynamicHit]]:
+def find_hits(record: Record, hmmer_hits: dict[str, list[ProfileHit]]) -> dict[str, list[DynamicHit]]:
     """Find all CDSes where the pattern is found"""
     hits: Dict[str, List[DynamicHit]] = {}
 


### PR DESCRIPTION
Changes dynamic profiles to pass in hits from existing HMMs from earlier in detection. This allows for dynamic profiles to avoid duplicating any work in finding the broader applicability before moving on to their more specific checks.

Should replace the base commit in #739, which reintroduced obsolete code and styling.