### PR TITLE
Dev container workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ antismash/git_hash
 pip-delete-this-directory.txt
 pip-egg-info/*
 
+# release-specific files
+.mailmap
+changes.txt
+
 # generated during make test
 nisin/*
 /*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # antiSMASH container with a snapshot of the development tree
-# VERSION 0.0.1
-FROM docker.io/antismash/base-nonfree:latest
+# VERSION 0.0.2
+FROM docker.io/antismash/base:latest
 LABEL maintainer="Kai Blin <kblin@biosustain.dtu.dk>"
 
 # Python and Docker are not getting along encoding-wise
@@ -14,7 +14,7 @@ COPY . /antismash
 
 ADD docker/instance.cfg /antismash/antismash/config
 
-RUN HARDCODE_ANTISMASH_GIT_VERSION=1 pip3 install /antismash && python3 -c "import antismash; antismash.config.build_config(['--databases', 'mounted_at_runtime'], modules=antismash.get_all_modules()); antismash.main.prepare_module_data()"
+RUN HARDCODE_ANTISMASH_GIT_VERSION=1 pip3 install /antismash --break-system-packages && python3 -c "import antismash; antismash.config.build_config(['--databases', 'mounted_at_runtime'], modules=antismash.get_all_modules()); antismash.main.prepare_module_data()"
 
 RUN mkdir /matplotlib && MPLCONFIGDIR=/matplotlib python3 -c "import matplotlib.pyplot as plt" && chmod -R a+rw /matplotlib
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,13 @@ LABEL maintainer="Kai Blin <kblin@biosustain.dtu.dk>"
 # Python and Docker are not getting along encoding-wise
 ENV LANG C.UTF-8
 
-# Install git
-RUN apt-get update && apt-get install -y git && apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
+# set up antiSMASH deb repo
+ADD https://dl.secondarymetabolites.org/antismash-stretch.list /etc/apt/sources.list.d/antismash.list
+ADD https://dl.secondarymetabolites.org/antismash.asc /tmp/
+RUN apt-key add /tmp/antismash.asc
+
+# Install git and meme-suite
+RUN apt-get update && apt-get install -y git meme-suite && apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
 
 # Grab antiSMASH
 COPY . /antismash

--- a/docker/run_from_podman
+++ b/docker/run_from_podman
@@ -24,13 +24,12 @@ if [ ! -d ${OUTPUT_DIR} ]; then
     mkdir -p ${OUTPUT_DIR}
 fi
 
-docker run \
+podman run \
     --volume ${INPUT_DIR}:${CONTAINER_SRC_DIR}:ro \
     --volume ${OUTPUT_DIR}:${CONTAINER_DST_DIR}:rw \
     --volume ${DATABASE_DIR}:${CONTAINER_DB_DIR}:ro \
     --detach=false \
     --rm \
-    --user=$(id -u):$(id -g) \
     docker.io/antismash/antismash-dev:latest \
     ${INPUT_FILE} \
     $@


### PR DESCRIPTION
The base container doesn't ship with meme-suite installed anymore, as that fails to build on Debian 12. Until we figure out how to drop it properly, shove meme-suite back into the dev container to allow for dev builds.