### PR TITLE
clusterblast: fix storing large, unfiltered dictionaries

### DIFF
--- a/antismash/modules/clusterblast/html_output.py
+++ b/antismash/modules/clusterblast/html_output.py
@@ -381,7 +381,7 @@ def generate_javascript_data(record: Record, region: Region, results: ClusterBla
             for query, reference in score.scored_pairings:
                 pairs_per_ref[reference.name].append((query, reference))
             assert pairs_per_ref
-            reference_genes = [region_results.reference_proteins[tag] for tag in ref.tags]
+            reference_genes = [region_results.displayed_reference_proteins[tag] for tag in ref.tags]
 
             start = min(gene.draw_start for gene in reference_genes)
             end = max(gene.draw_end for gene in reference_genes)
@@ -393,7 +393,7 @@ def generate_javascript_data(record: Record, region: Region, results: ClusterBla
             output.append(ref_data)
             average_strand = 0
             for locus_tag in ref.tags:
-                protein: Protein = region_results.reference_proteins[locus_tag]
+                protein: Protein = region_results.displayed_reference_proteins[locus_tag]
                 colour = colours.get(locus_tag, "white")
                 ref_gene = ReferenceGeneJSON.from_protein(protein, colour=colour)
                 ref_data.genes.append(ref_gene)

--- a/antismash/modules/clusterblast/test/test_results.py
+++ b/antismash/modules/clusterblast/test/test_results.py
@@ -1,0 +1,49 @@
+# License: GNU Affero General Public License v3 or later
+# A copy of GNU AGPL v3 should have been included in this software package in LICENSE.txt.
+
+# for test files, silence irrelevant and noisy pylint warnings
+# pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
+
+import unittest
+from unittest.mock import patch
+
+from antismash.modules.clusterblast.data_structures import Protein, ReferenceCluster
+from antismash.modules.clusterblast import results
+from antismash.common.secmet.test.helpers import DummyRecord, DummyRegion
+
+
+def create_reference(accession, proteins):
+    return ReferenceCluster(
+        accession,
+        "c1",
+        proteins,
+        description="desc",
+        cluster_type="type",
+        tags=[protein.locus_tag for protein in proteins],
+    )
+
+
+def create_protein(name, tag):
+    return Protein(name, tag, "1234-5678", "1", "annots")
+
+
+class TestRegionResults(unittest.TestCase):
+    def test_reference_protein_filtering(self):
+        proteins = {f"t{c}": create_protein(c, f"t{c}") for c in "ABCDEF"}
+        scores = []
+        for i in range(4, 1, -1):
+            scores.append(results.Score())
+            scores[-1].hits = i
+
+        ranking = [
+            (create_reference("acc1", proteins=[proteins["tA"]]), scores[0]),
+            (create_reference("acc2", proteins=[proteins[f"t{c}"] for c in "BC"]), scores[2]),
+            (create_reference("acc3", proteins=[proteins[f"t{c}"] for c in "DEF"]), scores[2]),
+        ]
+
+        region = DummyRegion()
+        region.parent_record = DummyRecord()
+        with patch.object(results, "get_display_limit", return_value=2):
+            result = results.RegionResult(region, ranking, proteins, "")
+        assert len(proteins) == 6
+        assert len(result.displayed_reference_proteins) == 3


### PR DESCRIPTION
Fixes an issue I introduced in #701. The original change was to keep reference gene information available for the purposes of drawing the clusterblast SVGs dynamically. The problem was that it made a copy of the reference protein dictionary for each region, without any filtering.

This caused some systems to run out of memory and kill the antiSMASH job, with up to 40GB used before that happened. On my machine, running a large input of 130 contigs, memory use hit 20GB (for the whole antiSMASH run, not just these dictionaries) in 5 minutes without getting through the vast majority of those contigs.

After filtering out all reference proteins unrelated to the region matches, the memory use for all 130 contigs came down to 14GB (taking about an hour on my machine, for comparison). Filtering the set further to only include those being displayed in the HTML took the memory use down even further, to a little over 6GB (again, the whole antiSMASH run over those 130 decently sized contigs).

Also refactors the fetching of the display limit a tiny bit to make testing a little less obnoxious.