### PR TITLE
cluster_compare: penalise single gene hits to multi-gene references

### DIFF
--- a/antismash/modules/cluster_compare/data_structures.py
+++ b/antismash/modules/cluster_compare/data_structures.py
@@ -408,9 +408,7 @@ class ReferenceScorer:
     def final_score(self) -> float:
         """ Calculates the singular score of a result from its metric scores """
         if self._final_score is None:
-            metrics = [self.identity]
-            if len(self.hits_by_gene) > 1:
-                metrics.append(self.order)
+            metrics = [self.identity, self.order]
             if self.component is not None:
                 metrics.append(self.component)
             score = 1.

--- a/antismash/modules/cluster_compare/ordering.py
+++ b/antismash/modules/cluster_compare/ordering.py
@@ -49,7 +49,13 @@ def calculate_order_score(area_features: Sequence[CDSFeature], hits: Dict[str, H
     segments = find_segments(hits, area_features, references)
     assert segments
 
-    return score_segments(segments, len(area_features), len(references))
+    score = score_segments(segments, len(area_features), len(references))
+
+    # handle single hits only creating a single segment,
+    # despite potentially missing the remainder of a reference
+    if len(hits) == 1 and len(references) > 1:
+        score *= EXTRA_SEGMENT_PENALTY
+    return score
 
 
 def _build_segments_from_pairings(pairings: Sequence[Pairing]) -> List[List[Pairing]]:

--- a/antismash/modules/cluster_compare/test/test_order.py
+++ b/antismash/modules/cluster_compare/test/test_order.py
@@ -68,6 +68,14 @@ class TestOrdering(unittest.TestCase):
     def test_empty(self):
         assert ordering.calculate_order_score([], {}, None) == 0.
 
+    def test_single_hit_penalised(self):
+        hits = {
+            "0": generate_hit(self.cdses[0], "0"),
+        }
+        assert len(self.refs) > 1
+        score = ordering.calculate_order_score(self.cdses, hits, self.refs)
+        assert 0. < score < 1.
+
 
 class TestSegmentScoring(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
ClusterCompare only adds an ordering metric when multiple genes in the reference have hits. This raises some single gene hits in the ranking more than they deserve, due to the final ranking using a geometric average of the metrics. This caused rankings like these (the top three hits from a lanthipeptide in NZ_BEWD01000001.1):
![image](https://github.com/user-attachments/assets/8818fbc9-22f0-4753-9cbf-a252e0762a8c)

By adding a penalty for these, as if there was a second segment, the scores for these kinds of hits are reduced, leading to the top three changing to these:
![image](https://github.com/user-attachments/assets/40697e2d-fd71-4312-b9e1-530438fb2f94)

The final score of venezuelin, since it's used in the example, changes from the initial 0.61 to 0.52, below the lowest of the multi-gene hits against similar class II lanthipeptides within MIBiG. This is true for other single-gene hits in the same example, though they're not shown in the screenshots.