### PR TITLE
Misc small tweaks/fixes

### DIFF
--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -622,12 +622,12 @@ def debug_options() -> ModuleArgs:
     group = ModuleArgs("Debugging & Logging options", '', override_safeties=True)
     group.add_option('-v', '--verbose',
                      dest='verbose',
-                     action='store_true',
+                     action=argparse.BooleanOptionalAction,
                      default=False,
                      help="Print verbose status information to stderr.")
     group.add_option('-d', '--debug',
                      dest='debug',
-                     action='store_true',
+                     action=argparse.BooleanOptionalAction,
                      default=False,
                      help="Print debugging information to stderr.")
     group.add_option('--logfile',
@@ -660,17 +660,17 @@ def debug_options() -> ModuleArgs:
                      help="Display the version number and exit.")
     group.add_option('--profiling',
                      dest='profile',
-                     action='store_true',
+                     action=argparse.BooleanOptionalAction,
                      default=False,
                      help="Generate a profiling report, disables multiprocess python.")
     group.add_option('--skip-sanitisation',
                      dest='skip_sanitisation',
-                     action='store_true',
+                     action=argparse.BooleanOptionalAction,
                      default=False,
                      help="Skip input record sanitisation. Use with care.")
     group.add_option('--skip-zip-file',
                      dest='skip_zip_file',
-                     action='store_true',
+                     action=argparse.BooleanOptionalAction,
                      default=False,
                      help="Do not create a zip of the output")
     return group
@@ -698,7 +698,7 @@ def specific_debugging(modules: Optional[List[AntismashModule]]) -> Optional[Mod
     group = ModuleArgs('Debugging options for cluster-specific analyses', '', override_safeties=True)
     group.add_option('--minimal',
                      dest='minimal',
-                     action='store_true',
+                     action=argparse.BooleanOptionalAction,
                      default=False,
                      help="Only run core detection modules, no analysis modules unless explicitly enabled")
     errors = []
@@ -706,7 +706,7 @@ def specific_debugging(modules: Optional[List[AntismashModule]]) -> Optional[Mod
         try:
             group.add_option(f"--enable-{module.NAME.replace('_', '-')}",
                              dest=f"{module.NAME}_enabled",
-                             action='store_true',
+                             action=argparse.BooleanOptionalAction,
                              default=False,
                              help=(f"Enable {module.SHORT_DESCRIPTION}"
                                    " (default: enabled, unless --minimal is specified)"

--- a/antismash/modules/clusterblast/results.py
+++ b/antismash/modules/clusterblast/results.py
@@ -80,6 +80,10 @@ class RegionResult:
                         javascript on the results page can differentiate between
                         types of clusterblast
         """
+        record_prefix = (region.parent_record.original_id or region.parent_record.id).split(".", 1)[0]
+        # remove self-hits
+        if prefix != "subclusterblast":
+            ranking = list(filter(lambda pair: pair[0].accession != record_prefix, ranking))
         self.region = region
         self.ranking = ranking[:get_result_limit()]  # [(ReferenceCluster, Score),...]
         self.total_hits = len(ranking)
@@ -88,13 +92,7 @@ class RegionResult:
 
         # for the SVG portion, limit the ranking to the display limit
         display_limit = get_display_limit()
-        # omitting any self-hits in the display
         display_ranking = self.ranking[:display_limit]
-        if prefix != "subclusterblast":
-            record_prefix = (region.parent_record.original_id or region.parent_record.id).split(".", 1)[0]
-            display_ranking = list(filter(lambda pair: pair[0].accession != record_prefix, display_ranking))
-            if len(display_ranking) < display_limit < len(self.ranking) - 1:
-                display_ranking.append(self.ranking[display_limit])
 
         for ref_cluster, _ in display_ranking:
             for name in ref_cluster.tags:

--- a/antismash/modules/clusterblast/test/test_results.py
+++ b/antismash/modules/clusterblast/test/test_results.py
@@ -29,13 +29,14 @@ def create_protein(name, tag):
 
 class TestRegionResults(unittest.TestCase):
     def test_reference_protein_filtering(self):
-        proteins = {f"t{c}": create_protein(c, f"t{c}") for c in "ABCDEF"}
+        proteins = {f"t{c}": create_protein(c, f"t{c}") for c in "ABCDEFX"}
         scores = []
         for i in range(4, 1, -1):
             scores.append(results.Score())
             scores[-1].hits = i
 
         ranking = [
+            (create_reference("same_accession", proteins=[proteins["tX"]]), scores[0]),
             (create_reference("acc1", proteins=[proteins["tA"]]), scores[0]),
             (create_reference("acc2", proteins=[proteins[f"t{c}"] for c in "BC"]), scores[2]),
             (create_reference("acc3", proteins=[proteins[f"t{c}"] for c in "DEF"]), scores[2]),
@@ -43,7 +44,11 @@ class TestRegionResults(unittest.TestCase):
 
         region = DummyRegion()
         region.parent_record = DummyRecord()
+        region.parent_record.id = "same_accession"
         with patch.object(results, "get_display_limit", return_value=2):
             result = results.RegionResult(region, ranking, proteins, "")
-        assert len(proteins) == 6
+        # ensure self hit is removed entirely
+        assert len(result.ranking) == len(ranking) - 1
+        assert ranking[0] not in result.ranking
+        assert len(proteins) == 7
         assert len(result.displayed_reference_proteins) == 3

--- a/antismash/modules/lassopeptides/specific_analysis.py
+++ b/antismash/modules/lassopeptides/specific_analysis.py
@@ -60,9 +60,6 @@ class LassoResults(module_results.ModuleResults):
         motifs = {}
         for locus, locus_motifs in self.motifs_by_locus.items():
             motifs[locus] = [motif.to_json() for motif in locus_motifs]
-        comparison = None
-        if comparison:
-            comparison = self.comparippson_results.to_json()
         return {
             "record_id": self.record_id,
             "schema_version": LassoResults.schema_version,


### PR DESCRIPTION
- Removes some dead code from lassopeptides
- Changes a number of general command line arguments to have an automatic inverse (e.g. `--no-debug` and `--no-minimal`) to handle cases where users would like to temporarily disable one of these options that they have enabled in a config file
- Fixes an issue in Clusterblast where self-hits weren't being consistently removed, leading to a crash in HTML generation