### PR TITLE
chore: Bump version number to 8

### DIFF
--- a/antismash/config/__init__.py
+++ b/antismash/config/__init__.py
@@ -23,7 +23,7 @@ from .args import build_parser, AntismashParser
 from .executables import get_default_paths
 from .loader import load_config_from_file
 
-_USER_FILE_NAME = os.path.expanduser('~/.antismash7.cfg')
+_USER_FILE_NAME = os.path.expanduser('~/.antismash8.cfg')
 _INSTANCE_FILE_NAME = os.path.abspath(os.path.join(os.path.dirname(__file__), 'instance.cfg'))
 
 

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -41,7 +41,7 @@ from antismash.outputs import html
 from antismash.support import genefinding
 from antismash.custom_typing import AntismashModule
 
-__version__ = "7.dev"
+__version__ = "8.dev"
 
 
 def _gather_analysis_modules() -> List[AntismashModule]:


### PR DESCRIPTION
**Note:** As this sets up the new major release, the config file path has changed from `~/.antismash7.cfg` to `~/.antismash8.cfg`