### PR TITLE
hmm_rule_parser: fix cases of some core genes not being marked

### DIFF
--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -691,6 +691,7 @@ class SingleCondition(Conditions):
 
         cds_feature = details.features_by_id[details.cds]
         # look at neighbours in range
+        ancillary = {}
         for other, other_hits in details.results_by_id.items():
             if other == details.cds:
                 continue
@@ -699,8 +700,9 @@ class SingleCondition(Conditions):
                 continue
             other_possibilities = [res.query_id for res in other_hits]
             if self.name in other_possibilities:
-                # a positive match, so we can exit early
-                return ConditionMet(not self.negated)
+                ancillary[other] = {self.name}
+        if ancillary:
+            return ConditionMet(not self.negated, ancillary_hits=ancillary)
 
         # if negated and we failed to find anything, that's a good thing
         return ConditionMet(self.negated)

--- a/antismash/common/hmm_rule_parser/test/test_rule_parser.py
+++ b/antismash/common/hmm_rule_parser/test/test_rule_parser.py
@@ -124,8 +124,19 @@ class DetectionTest(unittest.TestCase):
         self.expect(results, [])
 
     def test_chained_and_c(self):
+        # This test is complicated, since it depends on a (currently) ambiguous
+        # definition of "not" in the rules.
+
+        # The interpretation originally used here is that "not" means the cluster
+        # cannot *contain* the relevant condition, but the negative condition
+        # can be *next* to the detected cluster.
+
+        # If the interpretation of "not" changes to "cannot be near", then this
+        # particular scenario would find no cluster at all.
+
         results = self.run_test("A", 21, 20, "a and b and not cds(a and b)")
-        self.expect(results, ["GENE_3"])  # 3 has b, 2 has a, 1 reaches 2 with a,b
+
+        self.expect(results, ["GENE_2", "GENE_3"])
 
     def test_simple_minimum(self):
         results = self.run_test("A", 10, 20, "minimum(2, [a, b])")


### PR DESCRIPTION
This PR fixes a bug in cluster detection that misses the marking of some core genes. This is due to an assumption that only genes that satisfy the conditions within the cutoff distance _from itself_ will be marked core, despite this not being true in some cases:

### Case 1:
This case occurs most often in rules with smaller cutoffs and requires at least three conditions within the rule.
Using `A and B and C` as an example rule and genes laid out like so:
```
  AAAAAA          BBBBBB      CCCCCC
  |<    cutoff   >|   |<  cutoff  >|
```
`A` here satisfies only the `A and B` portion of the rule, since it's too far from `C`. The opposite is true for `C`, being too far from `A`.
However, `B` is close enough to both and would then form a protocluster, with the core containing only itself, as the other two genes didn't satisfy the conditions by themselves.

With this fix, `A` and `C` are marked (correctly) as ancillary genes, which are then also used in the protocluster creation step to mark them as core genes and extend the protocluster core to contain all three.


### Case 2: (from NZ_CP073318.1, 7,328,644 - 7,451,084)
The lanthipeptide (with a cutoff of 20kb) protoclustercore contains only a single condition of the two required positive conditions to form a protocluster. The second condition is satisfied by the gene marked in the screenshot, however the `not` condition prevents the missed gene from being satisfied. The gene in the core is not within cutoff distance of the negative condition, so it is considered to satisfy the rule.
![image](https://github.com/user-attachments/assets/1cd1aeb1-ff80-4046-a3bb-6e929343a28e)

The fixed version looks like this, instead, with the highlighted gene being a gene in the "not" condition for the rule:
![image](https://github.com/user-attachments/assets/1c59d5b7-537a-4ac2-9d45-546327bf01ae)

### Complications
While this fix doesn't change which clusters are detected, it does bring up a problem about the definition and/or interpretation of `not` in the rules. 
With the current implementation, `not` serves only to break up clusters when the negated condition falls between all other required components. If a split such as that occurs and neither side satisfies the requirements by itself, no protocluster will form.

The implementation could be changed to disallow any components from contributing to the conditions when within the cutoff distance of a negative. That would remove the lanthipeptide protocluster in case 2. It would likely also remove some cases of other cluster types that are completely valid.

An alternative is to introduce different keywords and/or structure that allows the rule writer to specifically use one behaviour or the other e.g. `BLOCKED BY <condition>` or similar.

Note: negations within a `cds()` subcondition are unaffected by these issues.