### PR TITLE
terpene: Fix a template-related crash for regions with > 1 terpenes

### DIFF
--- a/antismash/modules/terpene/templates/details.html
+++ b/antismash/modules/terpene/templates/details.html
@@ -2,10 +2,10 @@
     <div class="heading">
       <span>Detailed domain annotation</span> {{ help_tooltip(tooltip, "terpene-body") }}
     </div>
-    {% if preds_by_cluster | length > 1 %}
-      <span class="cluster-header"> Terpene cluster {{ loop.index }}: {{ cluster.location.start }}-{{ cluster.location.end }} </span><br>
-    {% endif %}
       {% for cluster, prediction in preds_by_cluster.items() %}
+      {% if preds_by_cluster | length > 1 %}
+      <span class="cluster-header"> Terpene cluster {{ loop.index }}: {{ cluster.location.start }}-{{ cluster.location.end }} </span><br>
+      {% endif %}
       <div class="protocluster-pred">
         {% if prediction.products %}
         <span class="section-header"> Product predictions: </span><br>


### PR DESCRIPTION
Reproducer for the crash is running `NC_003888.3` with `--taxon fungi`, which makes two of the terpene clusters get close enough to merge into a single region with the neighbourhood and cutoff boosts.