### PR TITLE
HTML fixes

### DIFF
--- a/antismash/common/comparippson/templates/generic.html
+++ b/antismash/common/comparippson/templates/generic.html
@@ -38,6 +38,7 @@
 {%- endmacro -%}
 
 {%- set display_limit = 3 -%}
+{%- set extra_limit = 10 -%}
 <div class="comparippson-details">
   <h4>{{ db.name }} {{ db.version }} matches for {{ name }}</h4>
   {% if not groups -%}
@@ -51,7 +52,11 @@
   {%- if groups | length > display_limit -%}
   <div class="comparippson-block comparippson-extension">
    with {{ groups | length - display_limit }} more sequence matches {{ collapser_start("comparippson-worse-hits", "none") }}
-    {% for hit, tail, tail_list in groups[display_limit:] -%}
+    {%- set extras = [extra_limit, groups | length - display_limit] | min -%}
+    {%- if groups | length - display_limit > extra_limit -%}
+    <div style="padding: 1em;"> Only the first {{ extras }} are displayed here.</div>
+    {%- endif -%}
+    {% for hit, tail, tail_list in groups[display_limit:display_limit + extra_limit] -%}
      {{ create_hit_block(hit, tail, tail_list, colour_subset) }}
     {% endfor -%}
    {{ collapser_end() }}

--- a/antismash/outputs/html/js.py
+++ b/antismash/outputs/html/js.py
@@ -166,7 +166,7 @@ def convert_cds_features(record: Record, features: Iterable[CDSFeature], options
                 start += len(record)
                 end += len(record)
             elif feature.crosses_origin():
-                end = len(record)
+                end += len(record)
         js_orfs.append({
             "start": start,
             "end": end,


### PR DESCRIPTION
Cross-origin genes were being truncated in the visualisation, showing only the pre-origin portion. This has been fixed here.

Page load times were in the order of seconds for some inputs. This turned out to be with RiPPs that had many CompaRiPPson results that generated quite a lot of HTML for the browser to parse.
A test input of six copies of nisin resulted in `index.html` being 2.3 MB, since each input had a precursor with around 130 matches to the antiSMASH-DB. Changing the rendering to only show the first 10 of the hits not shown by default reduced this file size to 383 KB and the load time to less than a second.

Semi-related: antiSMASH-JS has also been updated to 0.16.2 to fix an issue with multi-selecting, but that will apply automatically when running `download-antismash-databases`.