### PR TITLE
common.record_processing: catch missing sequences in fasta files via biopython

### DIFF
--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -490,6 +490,8 @@ def records_contain_shotgun_scaffolds(records: List[Record]) -> bool:
             record.seq[0]
         except UndefinedSequenceError:
             defined = False
+        except IndexError:
+            raise AntismashInputError(f"record contains no sequence information: {record.id}")
         if not defined and any(key in record.annotations for key in [
             "wgs_scafld",
             "wgs",

--- a/antismash/common/test/test_record_processing.py
+++ b/antismash/common/test/test_record_processing.py
@@ -382,6 +382,15 @@ class TestPreprocessRecords(unittest.TestCase):
         # then ensure genefinding would have run normally
         assert self.genefinding.was_run
 
+    def test_missing_sequence(self):
+        # a record missing a sequence shouldn't crash in WGS testing
+        # and shouldn't report as a WGS
+        with NamedTemporaryFile(suffix=".fasta") as handle:
+            handle.write(">R1\nACGT\n>R2\n\n>R3\nACGT\n".encode())
+            handle.flush()
+            with self.assertRaisesRegex(AntismashInputError, "no sequence .*R2.*"):
+                record_processing.parse_input_sequence(handle.name)
+
 
 class TestUniqueID(unittest.TestCase):
     def test_bad_starts(self):


### PR DESCRIPTION
Biopython allows FASTA files to have missing sequence information, e.g.
```
>R1
GCTA
>R2

>R3
TACG
```
This caused a crash in record processing, where the check for WGS records hit an `IndexError` in biopython's sequence indexing, that would previously have been caught in the following check for missing sequence information (which included WGS records with undefined sequences).

The fix here was to also handle that particular index error in the WGS check, leaving the original check for missing sequences in place as a backup for other potential code paths. 