### PR TITLE
Misc fixes

### DIFF
--- a/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
@@ -487,3 +487,32 @@ class TestLocationExtension(unittest.TestCase):
         assert result.parts[0].end == parts[0].end == len(self.record)
         assert result.parts[1].start == parts[1].start == 0
         assert result.parts[1].end == parts[1].end + distance
+
+
+class TestMergeOverOrigin(unittest.TestCase):
+    def test_full_region_cores(self):
+        record_length = 800
+        record = DummyRecord(length=record_length)
+        record.make_circular()
+        first = DummyProtocluster(core_start=200, core_end=600, neighbourhood_range=100,
+                                  product="same", record_length=record_length)
+        second = DummyProtocluster(core_start=550, core_end=250, neighbourhood_range=100,
+                                   product="same", record_length=record_length)
+        result = cluster_prediction.merge_over_origin([first, second], record)
+        assert len(result) == 1
+        assert not result[0].crosses_origin()
+        assert len(result[0].location) == record_length
+
+    def test_full_region_neighbourhood(self):
+        record_length = 1400
+        record = DummyRecord(length=record_length)
+        record.make_circular()
+        first = DummyProtocluster(core_start=1350, core_end=40, neighbourhood_range=200,
+                                  product="same", record_length=record_length)
+        second = DummyProtocluster(core_start=330, core_end=1375, neighbourhood_range=200,
+                                   product="same", record_length=record_length)
+        result = cluster_prediction.merge_over_origin([first, second], record)
+        assert len(result) == 1
+        assert result[0].crosses_origin()
+        assert result[0].start == 185
+        assert result[0].end == 184

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -367,11 +367,12 @@ def connect_locations(locations: list[Location], wrap_point: int = None) -> Loca
 
 
 def convert_protein_position_to_dna(start: int, end: int, location: Location) -> Tuple[int, int]:
-    """ Convert a protein position to a nucleotide sequence position for use in generating
+    """ Convert protein coordinates to a nucleotide sequence position for use in generating
         new FeatureLocations from existing FeatureLocations and/or CompoundLocations.
 
         Arguments:
-            position: the position in question, must be contained by the location
+            start: the start coordinate
+            end: the start coordinate
             location: the location of the related feature, for handling introns/split locations
 
         Returns:
@@ -393,7 +394,7 @@ def convert_protein_position_to_dna(start: int, end: int, location: Location) ->
                 f"Converted coordinates {dna_start}..{dna_end} "
                 f"out of bounds for location {location}"
             )
-        return dna_start, dna_end
+        return int(dna_start), int(dna_end)
 
     parts = sorted(location.parts, key=lambda x: x.start)
     gap = 0
@@ -421,7 +422,7 @@ def convert_protein_position_to_dna(start: int, end: int, location: Location) ->
             f"Converted coordinates {dna_start}..{dna_end} "
             f"out of bounds for location {location}"
         )
-    return dna_start, dna_end
+    return int(dna_start), int(dna_end)
 
 
 def build_location_from_others(locations: list[Location]) -> Location:

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -260,6 +260,31 @@ class TestProteinPositionConversion(unittest.TestCase):
                                      FeatureLocation(4952, 5682, strand=-1)])
         assert self.func(97, 336, location) == (5078, 5854)
 
+    def test_ambiguous_starts(self):
+        # DNA coordinates of a domain should never be ambiguous
+        # when the initial feature's DNA coordinate is ambiguous
+        location = FeatureLocation(BeforePosition(10), 40, 1)
+        # sanity check that ambiguous positions convert as such
+        assert str(location.start) == "<10"
+        start, end = convert_protein_position_to_dna(2, 4, location)
+        assert start == 16
+        assert end == 22
+        # ensure no ambiguity remains
+        assert not isinstance(start, BeforePosition)
+        assert not isinstance(end, BeforePosition)
+
+        # and for good measure, compound locations
+        location = CompoundLocation([
+            FeatureLocation(BeforePosition(10), 40, 1),
+            FeatureLocation(60, 80, 1),
+        ])
+        assert str(location.start) == "<10"
+        start, end = convert_protein_position_to_dna(2, 14, location)
+        assert start == 16
+        assert end == 72
+        assert not isinstance(start, BeforePosition)
+        assert not isinstance(end, BeforePosition)
+
 
 class TestCompoundCombination(unittest.TestCase):
     def test_separate(self):

--- a/antismash/detection/hmm_detection/cluster_rules/strict.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/strict.txt
@@ -547,7 +547,7 @@ RULE azoxy-crosslink
     EXAMPLE NCBI JARAKF010000001.1 1937858-1978761 azodyrecin # BGC0002805
     CUTOFF 20
     NEIGHBOURHOOD 10
-    CONDITIONS azdH_alignment and LPG_synthase_C and azdO and vlmB  # H A O B
+    CONDITIONS azdH and LPG_synthase_C and azdO and vlmB  # H A O B
 
 RULE azoxy-dimer
     # https://doi.org/10.1021/acschembio.3c00632

--- a/antismash/detection/hmm_detection/data/azdh.hmm
+++ b/antismash/detection/hmm_detection/data/azdh.hmm
@@ -1,5 +1,5 @@
 HMMER3/f [3.3.2 | Nov 2020]
-NAME  azdH_alignment
+NAME  azdH
 LENG  380
 ALPH  amino
 RF    no

--- a/antismash/detection/hmm_detection/data/hmmdetails.txt
+++ b/antismash/detection/hmm_detection/data/hmmdetails.txt
@@ -374,7 +374,7 @@ FAAL_cd05931	FAAL	20	FAAL_cd05931.hmm
 PP-binding_2	Acyl-carrier	10	PF14573.hmm
 Thioesterase	Thioesterase domain	26	PF00975.hmm
 LPG_synthase_C	Phosphatidylglycerol lysyltransferase, C-terminal	27	PF09924.hmm
-azdH_alignment	azdH	50	azdh.hmm
+azdH	azdH	50	azdh.hmm
 azdO	azdO/vlmO	50	azdO.hmm
 Ketoacyl-synt_2	Ketoacyl-synt_2	25	PF13723.hmm
 PT_phytoene_like	Prenyltransferase; Phytoene synthase like	20	PT_phytoene_like.hmm


### PR DESCRIPTION
Fixes a few issues found in testing and use:

- a crash when a circular plasmid had a cross-origin protocluster core that didn't cover the full plasmid, until the neighbourhood was added
- fixes protein to DNA coordinate conversion from parent features with ambiguous positions (e.g. `<10..50`) creating locations with both offset positions being the same ambiguous type (e.g. `<15..<45`)
- renames the `azdH_alignment` profile, removing the unnecessary `_alignment` portion of the name