### PR TITLE
Misc fixes

### DIFF
--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -829,6 +829,12 @@ class Record:
             raise SecmetInvalidInputError(f"{seq_record.id}: {err}") from err
 
         for feature in seq_record.features:
+            if (len(feature.location.parts) > 1 and feature.location.start == 0
+                and feature.location.end == len(record) and not record.is_circular()):
+                raise SecmetInvalidInputError(
+                    "feature contains an origin spanning exon while in a linear record: "
+                    f"{record.id} {feature.type} {feature.location}"
+                )
             if feature.location.ref or feature.location.ref_db:
                 for ref in [feature.location.ref, feature.location.ref_db]:
                     if ref and ref != seq_record.id:

--- a/antismash/detection/nrps_pks_domains/module_identification.py
+++ b/antismash/detection/nrps_pks_domains/module_identification.py
@@ -186,7 +186,7 @@ class Component:
             ADENYLATIONS,
             ACYLTRANSFERASES,
             ALTERNATE_STARTERS
-        )) or self.is_coa_ligase()
+        ))
 
     def is_loader(self) -> bool:
         """ Returns True if the component can function as a loader domain """

--- a/antismash/outputs/html/visualisers/bubble_view.py
+++ b/antismash/outputs/html/visualisers/bubble_view.py
@@ -282,7 +282,8 @@ def _gen_js_data_for_candidate(record: Record, result: CandidateClusterPredictio
             if domain in existing:
                 continue
             profile_name = hits_by_domain[domain].hit_id
-            extras.append(SimpleModule([build_domain_json(profile_name, domain, False)], False, cds_positions[name]))
+            inactive = domain.domain_id in inactive_domains
+            extras.append(SimpleModule([build_domain_json(profile_name, domain, inactive)], False, cds_positions[name]))
 
     modules = sorted(modules + extras, key=lambda x: (x.cds_position, x.domains[0]["start"]))
 


### PR DESCRIPTION
In genbank inputs, features with compound locations in the reverse strand aren't always annotated correctly by other tools. Previously, in linear records, these have been reversed to be in the correct order. However, after the changes to support circular inputs, this reversal has caused some crashes further down the line in cluster detection. This crash requires that the location is in the reverse strand, that the location is compound/has introns, and that the record is incorrectly labelled as linear. The solution here is to change the check to instead forbid inputs which are not marked as circular and have a location with the first section ending at the record end and the second section starting at the origin.

~~A-OX domains were previously not fed into the typical adenylation substrate predictions, which can be a little misleading, since they still show in the HTML output as being an NRPS loader domain. Unsurprisingly, the results aren't great, but at least now it's consistent.~~

Also in NRPS/PKS module/bubble visualisation, inactive domains were not being marked if they were not within a module (e.g. the last condensation domain in `CP023254.1  CK934_15050`). These now correctly display as inactive.