### PR TITLE
Fix a crash when cluster neighbourhoods wrap more than once around the record

### DIFF
--- a/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/test/test_cluster_prediction.py
@@ -488,6 +488,41 @@ class TestLocationExtension(unittest.TestCase):
         assert result.parts[1].start == parts[1].start == 0
         assert result.parts[1].end == parts[1].end + distance
 
+    def test_extension_to_full_record(self):
+        def build(location, distance):
+            assert location.crosses_origin()  # otherwise the test doesn't test the relevant code
+            result = self.func(location, distance, self.record, force_cross_origin=False)
+            assert not result.crosses_origin()
+
+            result = self.func(location, distance, self.record, force_cross_origin=True)
+            assert len(result) == len(self.record) - 1  # because otherwise it's a point location
+            assert result.crosses_origin()
+            assert len(result.parts) == 2
+            return result
+
+        self.record.make_circular()
+        # an even midpoint
+        assert len(self.record) % 2 == 0  # the record must be even
+        parts = [
+            FeatureLocation(75, 100, 1),
+            FeatureLocation(0, 25, 1),
+        ]
+        location = CompoundLocation(parts)
+        distance = 60
+        result = build(location, distance)
+        assert result.parts[0].start == 50
+        assert result.parts[1].end == 49
+
+        # an odd midpoint
+        parts = [
+            FeatureLocation(60, 100, 1),
+            FeatureLocation(0, 19, 1),
+        ]
+        location = CompoundLocation(parts)
+        result = build(location, distance)
+        assert result.parts[0].start == 39
+        assert result.parts[1].end == 38
+
 
 class TestMergeOverOrigin(unittest.TestCase):
     def test_full_region_cores(self):


### PR DESCRIPTION
With a very small circular record/contig, e.g. 38kb long, a protocluster with a cross-origin core could have a neighbourhood (e.g. 20kb each side) applied such that the neighbourhood extension alone was longer than the record. 
This caused the location extension to always a single part full-record location, which then crashed in the check that any protocluster with a cross-origin core must also have a cross-origin neighbourhood.

To solve this, an option to the relevant extension function was added to force the extended location to also be cross-origin, taking the mid-point between the existing location's start and end points as the point of separation.

In order to not appear as a point location (i.e. start and end are equal), the end coordinate is shifted back by one.
This in turn caused the containment checks of protoclusters against their defined `SUPERIORS` to return false when they did _not_ cross the origin and the superior _did_ cross the origin with this full-record neighbourhood. The solution there was to change the cluster containment check to compare not the location which included the neighbourhood, but only the core.