### PR TITLE
genefunctions: show explicit not-found message in HTML rather than empty

### DIFF
--- a/antismash/detection/genefunctions/templates/tailoring.html
+++ b/antismash/detection/genefunctions/templates/tailoring.html
@@ -5,6 +5,9 @@
   </div>
   <div class="gt-scroll-container">
     <div class="tailoring-container">
+    {%- if entries | length == 0 -%}
+      <span style="padding: 0.5em;">No tailoring functions detected.</span>
+    {%- endif -%}
     {% for ec_group in entries %}
       <div class="tailoring-ec-group">
         <span class="tailoring-ec-label">{{ ec_group.name.capitalize() }}:</span>


### PR DESCRIPTION
Empty output sections are ambiguous as to whether there was a fault or no results. This adds an explicit message to clarify it.

Before:
![image](https://github.com/user-attachments/assets/ac1e382c-6b93-42e4-8b78-7fbf948b8060)

After:
![image](https://github.com/user-attachments/assets/88f86cd7-9808-46aa-8b53-c80cdb0f3b34)
