### PR TITLE
hmm_detection: add relevant RRE profile as extender for lassopeptides

### DIFF
--- a/antismash/detection/hmm_detection/cluster_rules/strict.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/strict.txt
@@ -359,6 +359,7 @@ RULE lassopeptide
     CUTOFF 10
     NEIGHBOURHOOD 10
     CONDITIONS PF13471 and Asn_synthase or micJ25 or mcjC
+    EXTENDERS Stand_Alone_Lasso_RRE
 
 RULE sactipeptide
     CATEGORY RiPP


### PR DESCRIPTION
There's [many](https://antismash-db.secondarymetabolites.org/area.html?record=NC_006322.1&start=3863358&end=3863484) [examples](https://antismash-db.secondarymetabolites.org/area?record=NZ_AUJV01000005&start=40770&end=75703) of `lassopeptide` protoclusters being beside `RRE-containing`, where the RRE hit is to `Stand_Alone_Lasso_RRE`.

It seems simpler to add that RRE profile to the more defined rule in the `EXTENDERS` section, so those "hybrids" will form a single contiguous protocluster instead.

Examples of affected hybrids that now form a single protocluster:
![image](https://github.com/user-attachments/assets/20fc1385-7f7e-40c6-b511-bba0c6fdf19b)
![image](https://github.com/user-attachments/assets/212aacdf-e29d-42dd-8124-25e577be1d65)
