### PR TITLE
Fixes for non-standard and incorrect HTML formatting

### DIFF
--- a/antismash/common/comparippson/templates/generic.html
+++ b/antismash/common/comparippson/templates/generic.html
@@ -19,12 +19,11 @@
      <span class="comparippson-similarity">{{ "%.1f" % (hit.similarity*100) }}%</span>
      <span class="comparippson-link">{{ link(hit) }}
      {%- if tail_list %}<span class="comparippson-extra-indicator">{{ tail }}</span>:{{ collapser_start("comparippson-extra-names", level="none") }}
-       <div class="comparippson-extra-names">
+       <span class="comparippson-extra-names">
         {%- for other in tail_list -%}
         <span>{{ link(other) }}</span>
-        {{ description(other) }}
+        <span>{{ description(other) }}</span>
         {%- endfor %}
-       </div>
       {{ collapser_end() }}{% else %}:{% endif %}</span>
      {{ description(hit) }}
      <div class="comparippson-alignment">

--- a/antismash/common/comparippson/templates/generic.html
+++ b/antismash/common/comparippson/templates/generic.html
@@ -17,14 +17,20 @@
 {%- macro create_hit_block(hit, tail, tail_list, colour_subset) -%}
     <div class="comparippson-container">
      <span class="comparippson-similarity">{{ "%.1f" % (hit.similarity*100) }}%</span>
-     <span class="comparippson-link">{{ link(hit) }}
-     {%- if tail_list %}<span class="comparippson-extra-indicator">{{ tail }}</span>:{{ collapser_start("comparippson-extra-names", level="none") }}
+     <div class="comparippson-link">{{ link(hit) }}
+     {%- if tail_list %}<span class="comparippson-extra-indicator">{{ tail }}</span>:
+      {{- collapser_start("comparippson-extra-names", level="none") }}
        <span class="comparippson-extra-names">
         {%- for other in tail_list -%}
         <span>{{ link(other) }}</span>
         <span>{{ description(other) }}</span>
         {%- endfor %}
-      {{ collapser_end() }}{% else %}:{% endif %}</span>
+       </span>
+      {{ collapser_end() }}
+     {%- else -%}
+     :
+     {%- endif -%}
+     </div>
      {{ description(hit) }}
      <div class="comparippson-alignment">
        {{ segment_line(hit.query, colour_subset) }}

--- a/antismash/modules/cluster_compare/templates/matrix.html
+++ b/antismash/modules/cluster_compare/templates/matrix.html
@@ -13,7 +13,7 @@
     </tr>
     {% for ref, total in results %}
       <tr class="cc-heat-row heat-row-{{class_name}}" data-accession="{{ref.get_identifier()}}">
-      <td>{% if url %}<a href="{{url.format(accession=ref.accession.split('.')[0], version=ref.accession.split('.')[1], start=ref.start, end=ref.end)}}" target="_new">{{ref.accession if class_name == "MIBiG" else ref.get_identifier()}}</a>{% else %} {{ref.get_identifier()}} {% endif %}</td>
+      <td>{% if url %}<a href="{{url.format(accession=ref.accession.split('.')[0], version=ref.accession.split('.')[1], start=ref.start, end=ref.end)}}" target="_blank">{{ref.accession if class_name == "MIBiG" else ref.get_identifier()}}</a>{% else %} {{ref.get_identifier()}} {% endif %}</td>
        {% for proto in region.get_unique_protoclusters() %}
          <td></td>
        {% endfor %}

--- a/antismash/modules/cluster_compare/templates/row.html
+++ b/antismash/modules/cluster_compare/templates/row.html
@@ -21,7 +21,7 @@
     </tr>
     {% for ref, total in results %}
         <tr class="cc-heat-row heat-row-{{class_name}}" data-accession="{{ref.get_identifier()}}">
-      <td>{% if url %}<a href="{{url.format(accession=ref.accession.split('.')[0], version=ref.accession.split('.')[1], start=ref.start, end=ref.end)}}" target="_new">{{ref.accession if class_name == "MIBiG" else ref.get_identifier()}}</a>{% else %} {{ref.get_identifier()}} {% endif %}</td>
+      <td>{% if url %}<a href="{{url.format(accession=ref.accession.split('.')[0], version=ref.accession.split('.')[1], start=ref.start, end=ref.end)}}" target="_blank">{{ref.accession if class_name == "MIBiG" else ref.get_identifier()}}</a>{% else %} {{ref.get_identifier()}} {% endif %}</td>
         {% for proto in region.get_unique_protoclusters() %}
          {% if proto_results.get(proto.get_protocluster_number(), {}).get(ref) %}
           {% set score = proto_results[proto.get_protocluster_number()][ref] %}

--- a/antismash/modules/cluster_compare/templates/single.html
+++ b/antismash/modules/cluster_compare/templates/single.html
@@ -12,7 +12,7 @@
     {% for score in proto_results %}
      {% set ref = score.reference %}
      <tr class="cc-heat-row heat-row-{{class_name}}" data-accession="{{ref.get_identifier()}}">
-      <td>{% if url %}<a href="{{url.format(accession=ref.accession.split('.')[0], version=ref.accession.split('.')[1], start=ref.start, end=ref.end)}}" target="_new">{{ref.accession if class_name == "MIBiG" else ref.get_identifier()}}</a>{% else %} {{ref.get_identifier()}} {% endif %}</td>
+      <td>{% if url %}<a href="{{url.format(accession=ref.accession.split('.')[0], version=ref.accession.split('.')[1], start=ref.start, end=ref.end)}}" target="_blank">{{ref.accession if class_name == "MIBiG" else ref.get_identifier()}}</a>{% else %} {{ref.get_identifier()}} {% endif %}</td>
       {% set perc = "{:.0f}".format(score.final_score*100) %}
       {% set colour = "rgb(0, 0, 0, {:.2f})".format(score.final_score) %}
       <td class="cc-heat-cell" title="{{score.table_string()}}" style="background-image: linear-gradient(to top, {{colour}}, {{colour}} {{perc}}%, white {{perc}}%)"></td>

--- a/antismash/modules/clusterblast/templates/clusterblast.html
+++ b/antismash/modules/clusterblast/templates/clusterblast.html
@@ -1,7 +1,7 @@
 <div class = "{{ search_type }}">
  <div class="heading">
   <span>{{ title }}</span>
-  {{help_tooltip(tooltip, "cb-{{ prefix | 'general' }}")}}
+  {{help_tooltip(tooltip, search_type)}}
   {% if references %}
   <div class="download-container">
    <div class="download-icon download-svg" data-tag="{{ search_type }}-{{region.anchor_id}}-svg" data-filename="{{record.id}}_{{region.anchor_id}}_{{ search_type }}.svg">

--- a/antismash/modules/nrps_pks/html_output.py
+++ b/antismash/modules/nrps_pks/html_output.py
@@ -34,6 +34,9 @@ def generate_html(region_layer: RegionLayer, results: NRPS_PKS_Results,
         if not consensus:
             continue
         domain = record_layer.get_domain_by_name(domain_name)
+        cds = record_layer.get_cds_by_name(domain.locus_tag)
+        if cds not in region_layer.cds_children:
+            continue
         features_with_domain_predictions[domain.locus_tag] = []
 
     for feature_name, monomers in features_with_domain_predictions.items():

--- a/antismash/modules/nrps_pks/minowa/base.py
+++ b/antismash/modules/nrps_pks/minowa/base.py
@@ -37,7 +37,7 @@ class MinowaPrediction(Prediction):
             " <dd>\n"
             "  <dl>\n"
         )
-        core = "\n".join(f"  <dd></dd><dt>{name}: {score:.1f}</dt>\n" for name, score in self.predictions)
+        core = "\n".join(f"  <dt>{name}: {score:.1f}</dt><dd></dd>\n" for name, score in self.predictions)
         raw_end = (
             "\n"
             "  </dl>\n"

--- a/antismash/modules/nrps_pks/templates/monomers.html
+++ b/antismash/modules/nrps_pks/templates/monomers.html
@@ -3,7 +3,7 @@
       <span>NRPS/PKS substrate predictions</span>
       {{help_tooltip(tooltip, "nrps-monomers")}}
     </div>
-  <div class="prediction-text">
+  <div class="prediction-text nrps-monomer-details">
     {% for gene_id in region.sidepanel_features if gene_id in relevant_features %}
       <strong><span class="serif">{{gene_id}}</span></strong>: {{relevant_features[gene_id] | join(" - ")}}
       {{collapser_start(target=gene_id, level="cds")}}

--- a/antismash/modules/nrps_pks/templates/monomers.html
+++ b/antismash/modules/nrps_pks/templates/monomers.html
@@ -10,9 +10,9 @@
       <dt></dt>
       {% if gene_id in region.url_strict %}
         <dd> Search NORINE for peptide:
-          <a class="external-link" href="{{region.url_strict[gene_id]}}" target="_new">strict</a>
+          <a class="external-link" href="{{region.url_strict[gene_id]}}" target="_blank">strict</a>
             or
-          <a class="external-link" href="{{region.url_relaxed[gene_id]}}" target="_new">relaxed</a>
+          <a class="external-link" href="{{region.url_relaxed[gene_id]}}" target="_blank">relaxed</a>
         </dd>
         <br>
       {% endif %}
@@ -36,6 +36,6 @@
   </dl>
   <div class="prediction-text">
     <br>
-    <a class="external-link" href="https://paras.bioinformatics.nl" target="_new">Link to PARAS substrate predictor</a>
+    <a class="external-link" href="https://paras.bioinformatics.nl" target="_blank">Link to PARAS substrate predictor</a>
   </div>
 </div>

--- a/antismash/modules/nrps_pks/templates/monomers.html
+++ b/antismash/modules/nrps_pks/templates/monomers.html
@@ -3,22 +3,21 @@
       <span>NRPS/PKS substrate predictions</span>
       {{help_tooltip(tooltip, "nrps-monomers")}}
     </div>
-  <dl class="prediction-text">
+  <div class="prediction-text">
     {% for gene_id in region.sidepanel_features if gene_id in relevant_features %}
       <strong><span class="serif">{{gene_id}}</span></strong>: {{relevant_features[gene_id] | join(" - ")}}
       {{collapser_start(target=gene_id, level="cds")}}
-      <dt></dt>
       {% if gene_id in region.url_strict %}
-        <dd> Search NORINE for peptide:
+        <div> Search NORINE for peptide:
           <a class="external-link" href="{{region.url_strict[gene_id]}}" target="_blank">strict</a>
             or
           <a class="external-link" href="{{region.url_relaxed[gene_id]}}" target="_blank">relaxed</a>
-        </dd>
+        </div>
         <br>
       {% endif %}
       {% for domain in record.get_cds_by_name(gene_id).nrps_pks.domains %}
         {% if domain.feature_name in results.consensus %}
-          <dd><strong>{{domain.name}} ({{domain.start}}..{{domain.end}})</strong>: {{results.consensus[domain.feature_name]}}
+          <div><strong>{{domain.name}} ({{domain.start}}..{{domain.end}})</strong>: {{results.consensus[domain.feature_name]}}
           {{collapser_start(gene_id, level="candidate")}}
           {% for prediction in results.domain_predictions.get(domain.feature_name, {}).values() %}
               {{prediction.method}}:  {{prediction.get_classification() | join(", ") or "(unknown)"}}
@@ -27,13 +26,13 @@
               {{collapser_end()}}<br>
           {% endfor %}
           {{collapser_end()}}
-          </dd>
+          </div>
         {% endif %}
       {% endfor %}
       {{collapser_end()}}
       <br>
     {% endfor %}
-  </dl>
+  </div>
   <div class="prediction-text">
     <br>
     <a class="external-link" href="https://paras.bioinformatics.nl" target="_blank">Link to PARAS substrate predictor</a>

--- a/antismash/modules/nrps_pks/templates/products.html
+++ b/antismash/modules/nrps_pks/templates/products.html
@@ -29,9 +29,9 @@
                 {% endif %}
               </dl>
               <br>Direct lookup in NORINE database:
-              <a class="external-link" href="{{candidate.get_norine_url()}}" target="_new">strict</a>
+              <a class="external-link" href="{{candidate.get_norine_url()}}" target="_blank">strict</a>
                 or
-              <a class="external-link" href="{{candidate.get_norine_url(be_strict = False)}}" target="_new">relaxed</a><br>
+              <a class="external-link" href="{{candidate.get_norine_url(be_strict = False)}}" target="_blank">relaxed</a><br>
             </div>
             {% endif %}
             {{collapser_end()}}
@@ -51,7 +51,7 @@
     {% endfor %}
     <div class="prediction-text">
       <br>
-      <a class="external-link" href="{{ norine_base }}/form2.jsp" target="_new">Link to NORINE database query form</a>
+      <a class="external-link" href="{{ norine_base }}/form2.jsp" target="_blank">Link to NORINE database query form</a>
     </div>
   {% endif %}
 </div>

--- a/antismash/modules/t2pks/templates/sidepanel.html
+++ b/antismash/modules/t2pks/templates/sidepanel.html
@@ -16,7 +16,6 @@
 				{{pred.__str__()}}<br>
 			{% endfor %}
 	    <dd>
-		</tr>
 		{% endif %}
 		{% if prediction.malonyl_elongations %}
 		<dt><strong>Malonyl elongations:</strong></dt>
@@ -27,7 +26,7 @@
     	</dd>
 		{% endif %}
 		{% if prediction.product_classes %}
-		<dt><strong>Product class(es):</strong></td>
+		<dt><strong>Product class(es):</strong></dt>
         <dd>
 				{% for class in prediction.product_classes | sort %}
 				{{ class }}<br>

--- a/antismash/modules/terpene/templates/details.html
+++ b/antismash/modules/terpene/templates/details.html
@@ -1,6 +1,6 @@
 <div class="terpene-details">
     <div class="heading">
-      <span>Detailed domain annotation</span> {{ help_tooltip(tooltip, "terpene-body") }}
+      <span>Detailed terpene predictions</span> {{ help_tooltip(tooltip, "terpene-body") }}
     </div>
     {% for cluster, prediction in preds_by_cluster.items() %}
       <div class="protocluster-pred">

--- a/antismash/outputs/html/css/style.scss
+++ b/antismash/outputs/html/css/style.scss
@@ -1159,6 +1159,12 @@ ul.dropdown-options {
     justify-content: space-around;
 }
 
+.nrps-monomer-details {
+    * dl {
+        margin: 0;
+    }
+}
+
 .switch-container {
     & span.switch-desc {
         padding-right: 0.5em;

--- a/antismash/outputs/html/templates/cds_detail.html
+++ b/antismash/outputs/html/templates/cds_detail.html
@@ -73,16 +73,16 @@
  {{build_blastp_link(feature.get_name(), "NCBI BlastP on this gene")}}<br>
  <span class="asdb-linkout link-like wildcard-container" data-locus="{{feature.get_name()}}" data-wildcard-attrs="data-seq" data-seq="{{replace_with('translation')}}">Blast against antiSMASH-database</span><br>
  {%- if add_ncbi_context and not feature.crosses_origin() -%}
- <a href="{{urls['context']}}" target="_new">View genomic context</a><br>
+ <a href="{{urls['context']}}" target="_blank">View genomic context</a><br>
  {%- endif -%}
  {%- if urls['mibig'] -%}
-  <a href="{{urls['mibig']}}" target="_new">MIBiG Hits</a><br>
+  <a href="{{urls['mibig']}}" target="_blank">MIBiG Hits</a><br>
  {%- endif -%}
  {%- if urls['transport'] -%}
-  <a href="{{urls['transport']}}" target="_new">TransportDB BLAST on this gene</a><br>
+  <a href="{{urls['transport']}}" target="_blank">TransportDB BLAST on this gene</a><br>
  {%- endif -%}
  {%- if urls['smcog_tree'] -%}
-  <a href="{{urls['smcog_tree']}}" target="_new">View smCOG seed phylogenetic tree with this gene</a><br>
+  <a href="{{urls['smcog_tree']}}" target="_blank">View smCOG seed phylogenetic tree with this gene</a><br>
  {%- endif -%}
 </div>
 <div class="focus-clipboard">

--- a/antismash/outputs/html/templates/footer.html
+++ b/antismash/outputs/html/templates/footer.html
@@ -1,13 +1,13 @@
   <footer class="footer">
     <div class="container">
       <div>
-        <img src="images/{{options.taxon}}_antismash_logo.svg" style="height:90px;width:unset;">
+        <img src="images/{{options.taxon}}_antismash_logo.svg" alt="antiSMASH logo" style="height:90px;width:unset;">
       </div>
       <div class="cite-me">
         If you have found antiSMASH useful, please <a href="{{options.base_url}}#!/about">cite us</a>.
       </div>
       <div>
-        <img src="images/{{options.taxon}}_antismash_icon.svg" style="height:100px;width:unset;">
+        <img src="images/{{options.taxon}}_antismash_icon.svg" alt="antiSMASH taxon icon" style="height:100px;width:unset;">
       </div>
     </div>
   </footer>

--- a/antismash/outputs/html/templates/region_table_macros.html
+++ b/antismash/outputs/html/templates/region_table_macros.html
@@ -18,7 +18,7 @@
 {% macro region_row(region, cycle, record_index, options, css) -%}
    <tr class="linked-row {{cycle}}" data-anchor="#{{region.anchor_id}}">
      {{region_button(region, "td", css)}}
-      <a href="#{{region.anchor_id}}">Region&nbsp{% if record_index %}{{record_index}}.{% endif %}{{region.get_region_number()}}</a>
+      <a href="#{{region.anchor_id}}">Region&nbsp;{% if record_index %}{{record_index}}.{% endif %}{{region.get_region_number()}}</a>
      </td>
      <td>
        {% set join = joiner(",") %}

--- a/antismash/outputs/html/templates/region_table_macros.html
+++ b/antismash/outputs/html/templates/region_table_macros.html
@@ -5,7 +5,7 @@
    <th>Type</th>
    <th>From</th>
    <th>To</th>
-   <th>Confidence</th>
+   <th>Similarity Confidence</th>
    <th colspan="2">Most similar known cluster</th>
   </tr>
  </thead>

--- a/antismash/outputs/html/templates/regions.html
+++ b/antismash/outputs/html/templates/regions.html
@@ -59,7 +59,7 @@
             {% call le.static_symbol_legend('legend-binding-site', 'binding site') %}
                 <svg viewbox="0 -1 8 8">
                     <g class="svgene-binding-site">
-                    <line x1="4" y1="8" x2="4" y1="4"></line>
+                    <line x1="4" y1="8" x2="4" y2="4"></line>
                     <circle cx="4" cy="2" r="2"></circle>
                     </g>
                 </svg>

--- a/antismash/outputs/html/templates/regions.html
+++ b/antismash/outputs/html/templates/regions.html
@@ -51,7 +51,7 @@
         {% if show_tta %}
             {% call le.symbol_legend('legend-tta-codon', 'TTA codons') %}
                 <svg viewbox="0 0 6 6">
-                    <polyline class="svgene-tta-codon" points="3,0 0,6 6,6 3,0">
+                    <polyline class="svgene-tta-codon" points="3,0 0,6 6,6 3,0"/>
                 </svg>
             {% endcall %}
         {% endif %}
@@ -60,7 +60,8 @@
                 <svg viewbox="0 -1 8 8">
                     <g class="svgene-binding-site">
                     <line x1="4" y1="8" x2="4" y1="4"></line>
-                    <circle cx="4" cy="2" r="2"></line>
+                    <circle cx="4" cy="2" r="2"></circle>
+                    </g>
                 </svg>
             {% endcall %}
         {% endif %}


### PR DESCRIPTION
There's a number of issues that weren't legal HTML, even though they were rendering correctly (so far). Among them are:

- elements without closing tags
- closing tags without opening tags
- mismatched opening and closing tags
- incompatible child elements (e.g. `div` in a `span`)
- etc

Also changes "Confidence" in the HTML overview table to "Similarity Confidence" due to ambiguity around it's application to similarity or the protocluster calls themselves.