### PR TITLE
config: add flag to skip gbk summary writing

### DIFF
--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -668,11 +668,11 @@ def debug_options() -> ModuleArgs:
                      action=argparse.BooleanOptionalAction,
                      default=False,
                      help="Skip input record sanitisation. Use with care.")
-    group.add_option('--skip-zip-file',
-                     dest='skip_zip_file',
+    group.add_option('--zip-output',
+                     dest='zip_output',
                      action=argparse.BooleanOptionalAction,
-                     default=False,
-                     help="Do not create a zip of the output")
+                     default=True,
+                     help="Create a ZIP file of the output (default: %(default)s)")
     group.add_option('--summary-gbk',
                      dest='summary_gbk',
                      action=argparse.BooleanOptionalAction,

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -678,6 +678,11 @@ def debug_options() -> ModuleArgs:
                      action=argparse.BooleanOptionalAction,
                      default=True,
                      help="Create a GenBank summary file (default: %(default)s)")
+    group.add_option('--region-gbks',
+                     dest='region_gbks',
+                     action=argparse.BooleanOptionalAction,
+                     default=True,
+                     help="Create a GenBank file for each region (default: %(default)s)")
     return group
 
 

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -673,6 +673,11 @@ def debug_options() -> ModuleArgs:
                      action=argparse.BooleanOptionalAction,
                      default=False,
                      help="Do not create a zip of the output")
+    group.add_option('--summary-gbk',
+                     dest='summary_gbk',
+                     action=argparse.BooleanOptionalAction,
+                     default=True,
+                     help="Create a GenBank summary file (default: %(default)s)")
     return group
 
 

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -459,10 +459,11 @@ def write_outputs(results: serialiser.AntismashResults, options: ConfigType) -> 
     # add antismash meta-annotation to records
     add_antismash_comments(list(zip(results.records, bio_records)), options)
 
-    logging.debug("Writing cluster-specific genbank files")
-    for record, bio_record in zip(results.records, bio_records):
-        for region in record.get_regions():
-            region.write_to_genbank(directory=options.output_dir, record=bio_record)
+    if options.region_gbks:
+        logging.debug("Writing cluster-specific genbank files")
+        for record, bio_record in zip(results.records, bio_records):
+            for region in record.get_regions():
+                region.write_to_genbank(directory=options.output_dir, record=bio_record)
 
     # write records to an aggregate output
     base_filename = canonical_base_filename(results.input_file, options.output_dir, options)

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -466,9 +466,10 @@ def write_outputs(results: serialiser.AntismashResults, options: ConfigType) -> 
 
     # write records to an aggregate output
     base_filename = canonical_base_filename(results.input_file, options.output_dir, options)
-    combined_filename = base_filename + ".gbk"
-    logging.debug("Writing final genbank file to '%s'", combined_filename)
-    SeqIO.write(bio_records, combined_filename, "genbank")
+    if options.summary_gbk:
+        combined_filename = base_filename + ".gbk"
+        logging.debug("Writing final genbank file to '%s'", combined_filename)
+        SeqIO.write(bio_records, combined_filename, "genbank")
 
     zipfile = base_filename + ".zip"
     if os.path.exists(zipfile):

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -475,7 +475,7 @@ def write_outputs(results: serialiser.AntismashResults, options: ConfigType) -> 
     zipfile = base_filename + ".zip"
     if os.path.exists(zipfile):
         os.remove(zipfile)
-    if not options.skip_zip_file:
+    if options.zip_output:
         logging.debug("Zipping output to '%s'", zipfile)
         with tempfile.NamedTemporaryFile(prefix="as_zip_tmp", suffix=".zip") as temp:
             shutil.make_archive(temp.name.replace(".zip", ""), "zip", root_dir=options.output_dir)

--- a/antismash/outputs/html/templates/header.html
+++ b/antismash/outputs/html/templates/header.html
@@ -15,7 +15,7 @@
     <div class="ancillary-links">
       <div class="ancillary-link dropdown-menu" id="download-dropdown"><a href="#" id="download-dropdown-link"><img src="images/download.svg" alt="download"> &nbsp; Download</a>
         <ul class="dropdown-options">
-        {% if not options.skip_zip_file %}
+        {% if options.zip_output %}
         <li><a href="{{options.output_basename}}.zip">Download all results</a></li>
         {% endif %}
         {% if options.summary_gbk %}

--- a/antismash/outputs/html/templates/header.html
+++ b/antismash/outputs/html/templates/header.html
@@ -18,7 +18,9 @@
         {% if not options.skip_zip_file %}
         <li><a href="{{options.output_basename}}.zip">Download all results</a></li>
         {% endif %}
+        {% if options.summary_gbk %}
           <li><a href="{{options.output_basename}}.gbk">Download GenBank summary file</a></li>
+        {% endif %}
           <li><a href="{{options.output_basename}}.json">Download JSON results file</a></li>
         {% if options.logfile and options.download_logfile() != None %}
           <li><a href="{{options.download_logfile()}}">Download log file</a></li>

--- a/antismash/outputs/html/templates/regions.html
+++ b/antismash/outputs/html/templates/regions.html
@@ -9,9 +9,11 @@
   <div class = "content">
     <div class ="description-container">
       <div class="heading"> {{record.get_name()}} - Region {{region.get_region_number()}} - {{region.get_product_string()}} {{help_tooltip(svg_tooltip, "region_svg")}}</div>
-      <div class="region-download">
-        <a href = {{ '%s.region%03d.gbk' % (record.id, region.get_region_number()) }}>Download region GenBank file</a>
-      </div>
+      {% if options.region_gbks %}
+        <div class="region-download">
+          <a href = {{ '%s.region%03d.gbk' % (record.id, region.get_region_number()) }}>Download region GenBank file</a>
+       </div>
+      {% endif %}
       <div class="region-download">
         <div class="link-like download-svg" data-tag="{{region.anchor_id}}-svg" data-filename="{{record.id}}_{{region.anchor_id}}.svg">Download region SVG</div>
       </div>

--- a/antismash/test/integration/integration_antismash.py
+++ b/antismash/test/integration/integration_antismash.py
@@ -46,7 +46,7 @@ class TestAntismash(unittest.TestCase):
 
 class TestSkipZip(TestAntismash):
     def get_args(self):
-        return ["--minimal", "--skip-zip-file"]
+        return ["--minimal", "--no-zip-output"]
 
     def check_output_files(self, filenames=None):
         super().check_output_files(filenames)


### PR DESCRIPTION
The genbank summary file is the single largest file in the output directory, adding up to gigabytes across my high-throughput runs, and none of my downstream tools use it.

I added a flag `--skip-gbk-file` to stop its creation. Modeling it after `--skip-zip-file`, I added two `if` statements to stop creation and to remove the download option from the HTML.