### PR TITLE
Fixes for some output files not being recreated on reuse

### DIFF
--- a/antismash/common/fasta.py
+++ b/antismash/common/fasta.py
@@ -6,7 +6,7 @@
 
 from collections import OrderedDict
 import logging
-from typing import Dict, Iterable, List, Union
+from typing import Dict, Iterable, Iterator, List, Union
 
 from antismash.common.secmet import Record
 from antismash.common.secmet.features import CDSFeature, Domain
@@ -53,6 +53,19 @@ def get_fasta_from_record(record: Record) -> str:
     return "\n".join(all_fastas)
 
 
+def build_fasta(mapping: dict[str, str]) -> Iterator[str]:
+    """ Generates a FASTA formatted string
+
+        Arguments:
+            mapping: a mapping of identifier to sequence
+
+        Returns:
+            an iterator with each identifier/sequence pair
+    """
+    for name, seq in mapping.items():
+        yield f">{name}\n{seq}\n"
+
+
 def write_fasta(names: List[str], seqs: List[str], filename: str) -> None:
     """ Writes name/sequence pairs to file in FASTA format
 
@@ -65,8 +78,8 @@ def write_fasta(names: List[str], seqs: List[str], filename: str) -> None:
             None
     """
     with open(filename, "w", encoding="utf-8") as out_file:
-        for name, seq in zip(names, seqs):
-            out_file.write(f">{name}\n{seq}\n")
+        for chunk in build_fasta(dict(zip(names, seqs))):
+            out_file.write(chunk)
 
 
 def read_fasta(filename: str) -> Dict[str, str]:

--- a/antismash/common/module_results.py
+++ b/antismash/common/module_results.py
@@ -7,6 +7,8 @@
 
 from typing import Any, Dict, List, Optional
 
+from antismash.config import ConfigType
+
 from .secmet import Record
 from .secmet.features import Protocluster, SubRegion
 
@@ -49,6 +51,15 @@ class ModuleResults:
             Stores relevant information from the results in the given record
         """
         raise NotImplementedError()
+
+    def write_outputs(self, record: Record, options: ConfigType) -> None:
+        """ Writes output files specific to this module
+
+            Arguments:
+                record: the record the results belong to
+                options: the options for the run
+        """
+        pass
 
 
 class DetectionResults(ModuleResults):

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -435,13 +435,17 @@ def write_outputs(results: serialiser.AntismashResults, options: ConfigType) -> 
         Returns:
             None
     """
+    logging.debug("Writing non-HTML output files")
     # don't use results for which the module no longer exists to regenerate/calculate
     module_results_per_record = []
     for record_results in results.results:
         record_result = {}
         for module_name, result in record_results.items():
             if isinstance(result, ModuleResults):
+                logging.debug(" Writing relevant output files for %s", module_name)
                 record_result[module_name] = result
+                for record in results.records:
+                    result.write_outputs(record, options)
         module_results_per_record.append(record_result)
 
     if html.is_enabled(options):

--- a/antismash/modules/clusterblast/known.py
+++ b/antismash/modules/clusterblast/known.py
@@ -21,7 +21,7 @@ from .core import (
     run_diamond_on_all_regions,
     score_clusterblast_output,
 )
-from .results import RegionResult, GeneralResults, write_clusterblast_output
+from .results import RegionResult, GeneralResults
 from .data_structures import MibigEntry, ReferenceCluster, Protein
 
 
@@ -131,8 +131,6 @@ def perform_knownclusterblast(options: ConfigType, record: Record,
         region_result = RegionResult(region, ranking, proteins, "knownclusterblast")
         results.add_region_result(region_result, reference_clusters, proteins)
 
-        write_clusterblast_output(options, record, region_result, proteins,
-                                  searchtype="knownclusterblast")
     results.mibig_entries = mibig_protein_homology(blastoutput, record,
                                                    reference_clusters)
     return results

--- a/antismash/modules/clusterblast/results.py
+++ b/antismash/modules/clusterblast/results.py
@@ -315,6 +315,11 @@ class ClusterBlastResults(ModuleResults):
             if result is not None:
                 result.add_to_record(record)
 
+    def write_outputs(self, record: Record, options: ConfigType) -> None:
+        for subresult in [self.general, self.knowncluster, self.subcluster]:
+            if subresult:
+                subresult.write_to_file(record, options)
+
 
 def write_clusterblast_output(options: ConfigType, record: Record,
                               cluster_result: RegionResult, proteins: Dict[str, Protein],

--- a/antismash/modules/smcog_trees/__init__.py
+++ b/antismash/modules/smcog_trees/__init__.py
@@ -11,13 +11,12 @@ import logging
 import os
 from typing import Any, Dict, List, Optional
 
-from antismash.common import path
 from antismash.common.module_results import ModuleResults
 from antismash.common.secmet import Record
 from antismash.config import ConfigType
 from antismash.config.args import ModuleArgs
 
-from .trees import generate_trees
+from .trees import draw_tree, generate_trees
 
 NAME = "smcogs"
 SHORT_DESCRIPTION = "gene function classification via smCOG"
@@ -27,18 +26,18 @@ class SMCOGTreeResults(ModuleResults):
     """ Results for the smcogs trees. Tracks the location of the tree images
         generated but does not keep a full copy of the tree.
     """
-    schema_version = 2
+    schema_version = 3
 
-    def __init__(self, record_id: str, relative_path: str, tree_images: Dict[str, str]) -> None:
+    def __init__(self, record_id: str, trees_by_name: dict[str, str]) -> None:
         super().__init__(record_id)
-        self.tree_images = tree_images  # cds_name -> tree filename
-        self.relative_tree_path = relative_path  # path where tree images are saved
+        self.trees = trees_by_name
 
     def to_json(self) -> Dict[str, Any]:
-        return {"schema_version": self.schema_version,
-                "record_id": self.record_id,
-                "tree_paths": self.tree_images,
-                "image_dir": self.relative_tree_path}
+        return {
+            "schema_version": self.schema_version,
+            "record_id": self.record_id,
+            "trees": self.trees,
+        }
 
     @staticmethod
     def from_json(json: Dict[str, Any], record: Record) -> Optional["SMCOGTreeResults"]:
@@ -48,14 +47,18 @@ class SMCOGTreeResults(ModuleResults):
         if record.id != json.get("record_id"):
             logging.debug("Record ID mismatch, discarding SMCOGs results")
             return None
-        return SMCOGTreeResults(json["record_id"], json["image_dir"], json["tree_paths"])
+        return SMCOGTreeResults(json["record_id"], json["trees"])
 
     def add_to_record(self, record: Record) -> None:
-        """ Annotate smCOG tree paths in CDS features """
-        logging.debug("annotating genes with SMCOG trees: %d genes", len(self.tree_images))
-        for feature in record.get_cds_features_within_regions():
-            if feature.get_name() in self.tree_images:
-                feature.notes.append(f"smCOG tree PNG image: smcogs/{self.tree_images[feature.get_name()]}")
+        pass
+
+    def write_outputs(self, record: Record, options: ConfigType) -> None:
+        # create the smcogs output directory if required
+        smcogs_dir = os.path.join(options.output_dir, "smcogs")
+        os.makedirs(smcogs_dir, exist_ok=True)
+        for name, tree in self.trees.items():
+            tree_filename = os.path.join(smcogs_dir, f"{name}.png")
+            draw_tree(tree, tree_filename, name)
 
 
 def check_options(_options: ConfigType) -> List[str]:
@@ -90,15 +93,7 @@ def regenerate_previous_results(results: Dict[str, Any], record: Record, _option
     """
     if not results:
         return None
-    parsed = SMCOGTreeResults.from_json(results, record)
-    if not parsed:
-        return None
-
-    for tree_filename in parsed.tree_images.values():
-        if not os.path.exists(os.path.join(parsed.relative_tree_path, tree_filename)):
-            logging.debug("Tree image files missing and must be regenerated")
-            return None
-    return parsed
+    return SMCOGTreeResults.from_json(results, record)
 
 
 def check_prereqs(options: ConfigType) -> List[str]:
@@ -112,19 +107,13 @@ def check_prereqs(options: ConfigType) -> List[str]:
 
 
 def run_on_record(record: Record, results: Optional[SMCOGTreeResults],
-                  options: ConfigType) -> SMCOGTreeResults:
+                  options: ConfigType) -> SMCOGTreeResults:  # pylint: disable=unused-argument
     """ Generates phylogeny trees of the classifications made by SMCOGs
     """
     if results and isinstance(results, SMCOGTreeResults):
         return results
-    # create the smcogs output directory if required
-    relative_output_dir = os.path.relpath(os.path.join(options.output_dir, "smcogs"), os.getcwd())
-    smcogs_dir = os.path.abspath(relative_output_dir)
-    if not os.path.exists(smcogs_dir):
-        os.mkdir(smcogs_dir)
 
     nrpspks_genes = record.get_nrps_pks_cds_features()
-    with path.changed_directory(smcogs_dir):
-        trees = generate_trees(smcogs_dir, record.get_cds_features_within_regions(), nrpspks_genes)
+    trees = generate_trees(record.get_cds_features_within_regions(), nrpspks_genes)
 
-    return SMCOGTreeResults(record.id, relative_output_dir, trees)
+    return SMCOGTreeResults(record.id, trees)


### PR DESCRIPTION
Fixes #811 by adding `ModuleResults.write_outputs()`, which can then handle any output files for a module outside the analysis and in-memory regeneration stages.

The smCOG trees module stores the raw newick tree and not the images themselves, for space considerations. In return it will take some time to regenerate the images themselves (about 1 second/tree, from my tests). This might be significant for large or dense inputs.

No significant timing changes for the clusterblast module, and no changes are made at all for results size.