### PR TITLE
Extend the detection of Pyr4 type terpene cyclases

### DIFF
--- a/antismash/detection/hmm_detection/data/hmmdetails.txt
+++ b/antismash/detection/hmm_detection/data/hmmdetails.txt
@@ -390,7 +390,7 @@ T1TS_KS	Type 1 terpene synthase; Ent-kaurene synthase type	200	T1TS_KS.hmm
 T2TS	Type 2 terpene synthase	45	T2TS.hmm
 TS_UbiA	UbiA type terpene synthase	117	TS_UbiA.hmm
 HAD_2	Haloacid dehalogenase-like hydrolase	15	PF13419.hmm
-TS_Pyr4	Pyr4 type terpene synthase	100	TS_Pyr4.hmm
+TS_Pyr4	Pyr4 type terpene synthase	50	TS_Pyr4.hmm
 Lycopene_cycl_fung	Lycopene cyclase domain; fungal	40	TIGR03462.hmm
 IPPT	IPP transferase	24	PF01715.hmm
 Lysine_decarbox	Possible lysine decarboxylase	27	PF03641.hmm

--- a/antismash/modules/terpene/data/hmm_properties.json
+++ b/antismash/modules/terpene/data/hmm_properties.json
@@ -968,7 +968,7 @@
             "description": "Pyr4 type terpene synthase",
             "type": "TS_Pyr4",
             "length": 243,
-            "cutoff": 100,
+            "cutoff": 50,
             "subtypes": [
                 "TS_Pyr4_C15_polyketide_a",
                 "TS_Pyr4_C15_polyketide_b",


### PR DESCRIPTION
I noticed that we can lower the cutoff of the TS_Pyr4 profile to enable detection of bacterial homologs (see [doi.org/10.1002/anie.202422270](url), GroF), without noticeably increasing the false positive rate.
I scanned TS_Pyr4 against all proteins in the antismash DB, and it hits some transporters with bitscores <20.
Other than that there is a steep jump to hypothetical proteins with bitscores >70, which I expect to be actual terpene cyclases.