### PR TITLE
secmet: fix false negatives in cross-origin test in linear records

### DIFF
--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -829,8 +829,7 @@ class Record:
             raise SecmetInvalidInputError(f"{seq_record.id}: {err}") from err
 
         for feature in seq_record.features:
-            if (len(feature.location.parts) > 1 and feature.location.start == 0
-                and feature.location.end == len(record) and not record.is_circular()):
+            if feature.location.crosses_origin() and not record.is_circular():
                 raise SecmetInvalidInputError(
                     "feature contains an origin spanning exon while in a linear record: "
                     f"{record.id} {feature.type} {feature.location}"


### PR DESCRIPTION
Fixes some crashes resulting from whole-contig genes that contained exons. The tests for cross-origin genes in linear records made some faulty assumptions about start and end coordinates with multiple exons.