### PR TITLE
secmet: fix record location extension and make more flexible

### DIFF
--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -468,7 +468,7 @@ def _extend_area_location(location: Location, distance: int, record: Record,
         result = make_forwards(location)
 
     # extend the location
-    result = record.connect_locations([record.extend_location(result, distance)])
+    result = record.extend_location(result, distance)
 
     if location.crosses_origin() and len(result) == len(record) \
             and not result.crosses_origin() and force_cross_origin:


### PR DESCRIPTION
This PR fixes crashes due to `CDSCollection` erroneously being passed a `CompoundLocation` that didn't cross the origin (e.g. in RBXO01000001.1). This specific case involves `find_motif_around_anchor` in dynamic profiles, where the anchor gene had a `CompoundLocation` that was extended via `Record.extend_location()`. The equivalent behaviour in cluster prediction was avoided because the resulting output was wrapped in `Record.connect_location()`, which merged all the resulting sections where possible.

Because this can cause problems in such a small amount of inputs, `Record.extend_location()` has been extended rather than just adding the same wrapping.

This change also means that now locations that crossed the origin will have each side extended to the closest edge of the contig, whereas previously they were not and that may have resulted in some very rare cases of missed clusters.