### PR TITLE
Misc python 3.12/macos fixes

### DIFF
--- a/antismash/common/subprocessing/base.py
+++ b/antismash/common/subprocessing/base.py
@@ -20,6 +20,10 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     from Bio import SearchIO  # for import by others without wrapping, pylint: disable=unused-import
 
+# more modern macos system calls don't handle config serialisation, so force them to fork
+if sys.platform == "darwin":
+    multiprocessing.set_start_method("fork")
+
 
 class RunResult:
     """ A container for simplifying the results of running a command """

--- a/antismash/common/subprocessing/test/integration_subprocessing.py
+++ b/antismash/common/subprocessing/test/integration_subprocessing.py
@@ -121,7 +121,8 @@ class TestExecute(unittest.TestCase):
 
         result = subprocessing.execute(["cat", "--bad-option"])
         assert result.stdout.strip() == ""
-        assert result.stderr.startswith("cat: unrecognized")
+        # the exact message isn't important, only that cat emitted it
+        assert result.stderr.startswith("cat: ")
         assert result.return_code and not result.successful()
 
         result = subprocessing.execute(["cat"], stdin="fish")
@@ -140,7 +141,7 @@ class TestExecute(unittest.TestCase):
         result = subprocessing.execute(["cat", "--bad-option"], stderr=open(os.devnull, "w"))
         assert result.stdout.strip() == ""
         with self.assertRaisesRegex(ValueError, "stderr was redirected to file, unable to access"):
-            assert result.stderr.startswith("cat: unrecognized")
+            _ = result.stderr
         assert result.return_code
 
     def test_timeout(self):

--- a/antismash/detection/cassis/motifs.py
+++ b/antismash/detection/cassis/motifs.py
@@ -144,7 +144,7 @@ def filter_meme_results(meme_dir: str, promoter_sets: List[Motif], anchor: str) 
             if anchor_seq_id in map(lambda site: site.attrib["sequence_id"], contributing_sites):
                 # save motif score
                 node = root.find("motifs/motif")
-                if not node:
+                if node is None:
                     raise ValueError("unknown MEME output format")
                 motif.score = float(node.attrib["e_value"])  # one motif, didn't ask MEME for more
 


### PR DESCRIPTION
- 3.12 changed regex boolean evaluation and one of the options (`len(node)`) isn't supported in 3.11
- handles newer macOS system calls for python parallelism failing to serialise our config
- fix test using `cat` that expected the same failure message on both linux and mac