### PR TITLE
Fix some links out to MIBiG using old style API

### DIFF
--- a/antismash/modules/cluster_compare/data/mibig.json
+++ b/antismash/modules/cluster_compare/data/mibig.json
@@ -1,7 +1,7 @@
 {
     "name": "MIBiG",
     "description": "The MIBiG database.",
-    "url": "https://mibig.secondarymetabolites.org/repository/{accession}.{version}/index.html#r1c1",
+    "url": "https://mibig.secondarymetabolites.org/go/{accession}.{version}",
     "path": "$datadir/clustercompare/mibig/4.0",
     "comparisons": ["RegionToRegion", "ProtoToRegion"],
     "mode": "RiQ"

--- a/antismash/outputs/html/templates/mibig_hits_table.html
+++ b/antismash/outputs/html/templates/mibig_hits_table.html
@@ -54,7 +54,7 @@ table {
           <tr>
               <td>{{line.gene_id}}</td>
               <td>{{line.gene_description}}</td>
-              <td><a href="https://mibig.secondarymetabolites.org/go/{{line.mibig_id}}/{{line.mibig_cluster_number}}">{{line.mibig_id}}</a></td>
+              <td><a target="_new" href="https://mibig.secondarymetabolites.org/go/{{line.mibig_id}}">{{line.mibig_id}}</a></td>
               <td>{{line.mibig_product}}</td>
               <td>{{line.percent_id}}</td>
               <td>{{"%.1f" % line.coverage}}</td>


### PR DESCRIPTION
Fixes #827 and includes a similar change for ClusterCompare.

Also makes the KCB HTML tables open new windows/tabs when following links.