### PR TITLE
secmet: fix within_location ignoring overlap arg

### DIFF
--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -528,7 +528,9 @@ class Record:
             for part in location.parts:
                 found = self.get_cds_features_within_location(part, with_overlapping=True)
                 features.extend(f for f in found if f not in features)
-            return [f for f in features if f.is_contained_by(location)]
+            if not with_overlapping:
+                return [f for f in features if f.is_contained_by(location)]
+            return features
 
         def find_start_in_list(location: Location, features: List[CDSFeature],
                                include_overlaps: bool) -> int:

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -517,6 +517,18 @@ class TestCDSFetchByLocation(unittest.TestCase):
         loc = FeatureLocation(110, 140)
         assert self.func(loc, with_overlapping=False) == [inner]
 
+    def test_compound_with_overlapping(self):
+        location = CompoundLocation([
+            FeatureLocation(20, 40, 1),
+            FeatureLocation(60, 80, 1),
+        ])
+        for cds, overlap_expected in zip(self.record.get_cds_features(), [True, False]):
+            assert not cds.is_contained_by(location)
+            assert cds.overlaps_with(location) == overlap_expected
+
+        assert self.func(location, with_overlapping=False) == []
+        assert self.func(location, with_overlapping=True) == [self.record.get_cds_features()[0]]
+
 
 class TestClusterManipulation(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #829 