### PR TITLE
config: add an option to remove all existing annotations from an input

### DIFF
--- a/antismash/common/record_processing.py
+++ b/antismash/common/record_processing.py
@@ -121,6 +121,11 @@ def parse_input_sequence(filename: str, taxon: str = "bacteria", minimum_length:
         if minimum_length < 1 or len(record.seq) >= minimum_length:
             records.append(record)
 
+        # if requested, remove every existing annotation
+        if get_config().remove_existing_annotations:
+            record.features.clear()
+            assert not record.features
+
     # if no records are left, that's a problem
     if not records:
         raise AntismashInputError(f"all input records smaller than minimum length ({minimum_length})")

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -614,6 +614,12 @@ def advanced_options() -> ModuleArgs:
                      action=argparse.BooleanOptionalAction,
                      default=True,
                      help="Should sequence identifiers longer than 16 characters be allowed")
+    group.add_option("--remove-existing-annotations",
+                     dest="remove_existing_annotations",
+                     action=argparse.BooleanOptionalAction,
+                     default=False,
+                     help="Remove any existing features from annotation inputs",
+                     )
     return group
 
 


### PR DESCRIPTION
I regularly come across Genbank/RefSeq entries that have poor gene calling with PGAP and PKS genes. I'd normally have to convert the GBK to FASTA, then run antiSMASH over the result.

This PR brings in `--remove-existing-annotations`, which removes every feature from the inputs, allowing other genefinding to be used. The inverse is also accessible, `--no-remove-existing-annotations`, which isn't great naming but I don't have better ideas on that.