### PR TITLE
Crash and performance fixes

### DIFF
--- a/antismash/common/secmet/features/cdscollection.py
+++ b/antismash/common/secmet/features/cdscollection.py
@@ -31,6 +31,7 @@ from ..locations import (
     FeatureLocation,
     Location,
     Position,
+    make_forwards,
     location_bridges_origin,
     split_origin_bridging_location,
 )
@@ -196,6 +197,7 @@ class CDSCollection(Feature):
 
     def __init__(self, location: Location, feature_type: str,
                  child_collections: Sequence["CDSCollection"] = None) -> None:
+        location = make_forwards(location)
         # it's fine to have two parts if crossing the origin
         if len(location.parts) > 1:
             # but it must only be the two halves, more indicates a problem of some kind
@@ -205,8 +207,6 @@ class CDSCollection(Feature):
                 raise ValueError("Collections cannot have compound locations without crossing the origin")
         assert len(set(part.strand for part in location.parts)) == 1, f"mixed strands for collection: {location=}"
         super().__init__(location, feature_type, created_by_antismash=True)
-        if len(location.parts) > 1 and location.strand != 1:
-            raise ValueError("CDS collections spanning the origin must be in the forward strand")
         self._parent_record: Any = None  # should be Record but will cause circular dependencies
         self._contig_edge = False
         self._cdses = _SectionedCDSCache()

--- a/antismash/common/secmet/features/test/test_cdscollection.py
+++ b/antismash/common/secmet/features/test/test_cdscollection.py
@@ -257,6 +257,17 @@ class TestSectioning(unittest.TestCase):
         assert area.cds_children.cross_origin == (cross,)
         assert area.cds_children.post_origin == (post,)
 
+    def test_cross_origin_reverse(self):
+        location = CompoundLocation([
+            FeatureLocation(0, 10, -1),
+            FeatureLocation(90, 100, -1),
+        ])
+        area = CDSCollection(location, feature_type="test")
+        assert area.location == CompoundLocation([
+            FeatureLocation(90, 100, 1),
+            FeatureLocation(0, 10, 1),
+        ])
+
     def test_pickleable(self):
         # due to the combination of caches and custom tuples,
         # pickling can go very wrong, leading to hangs in multiprocess/multithread sections

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -49,7 +49,7 @@ class _LocationMixin(_Location):
         return (start, len(self))
 
     def __lt__(self: T, other: Any) -> bool:
-        if isinstance(other, self.__class__):
+        if isinstance(other, _Location):
             other_loc = other
         elif hasattr(other, "location") and isinstance(other.location, self.__class__):
             other_loc = other.location

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -41,12 +41,14 @@ class _LocationMixin(_Location):
     def get_comparator(self: T) -> tuple[int, int]:
         """Get a comparison helper tuple consisting of start position and length."""
         start = self.start
+        end = self.end
         if self.crosses_origin():
             _, head = split_origin_bridging_location(self)
             start = min(part.start for part in head) - max(part.end for part in head)
+            end = len(self)
         if not isinstance(start, int):
             return (-1, id(self))
-        return (start, len(self))
+        return (start, end)
 
     def __lt__(self: T, other: Any) -> bool:
         if isinstance(other, _Location):

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -968,3 +968,26 @@ class TestMakingStrandForwards(unittest.TestCase):
         parts = [FeatureLocation(0, 50, -1), FeatureLocation(60, 70, -1)]
         location = CompoundLocation(parts)
         assert self.func(location) == CompoundLocation([FeatureLocation(f.start, f.end, 1) for f in parts[::-1]])
+
+
+class TestComparison(unittest.TestCase):
+    def test_simple(self):
+        assert FeatureLocation(1, 5) < FeatureLocation(10, 20)
+
+    def test_longer(self):
+        assert FeatureLocation(1, 20) > FeatureLocation(1, 10)
+        # and with exons with later ends but shorter lengths
+        first = CompoundLocation([
+            FeatureLocation(1, 10),
+            FeatureLocation(15, 30),
+        ])
+        second = CompoundLocation([
+            FeatureLocation(1, 5),
+            FeatureLocation(15, 20),
+            FeatureLocation(45, 50),
+        ])
+        assert first < second
+
+    def test_cross_origin(self):
+        location = CompoundLocation([FeatureLocation(15, 20), FeatureLocation(0, 5)])
+        assert location < FeatureLocation(0, 5)

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -914,7 +914,7 @@ class TestRegionManipulation(unittest.TestCase):
         self.record.create_regions()
         assert len(self.record.get_regions()) == 1
         region = self.record.get_regions()[0]
-        assert region.location == FeatureLocation(3, 300)
+        assert region.location == FeatureLocation(3, 300, 1)
         assert region.candidate_clusters == (extra_sup, self.candidate_cluster)
         assert region.subregions == (extra_sub, self.subregion)
 
@@ -934,12 +934,12 @@ class TestRegionManipulation(unittest.TestCase):
         assert len(self.record.get_regions()) == 2
 
         region = self.record.get_regions()[0]
-        assert region.location == FeatureLocation(3, 100)
+        assert region.location == FeatureLocation(3, 100, 1)
         assert region.candidate_clusters == (self.candidate_cluster,)
         assert region.subregions == (self.subregion,)
 
         region = self.record.get_regions()[1]
-        assert region.location == FeatureLocation(800, 870)
+        assert region.location == FeatureLocation(800, 870, 1)
         assert region.candidate_clusters == (extra_sup,)
         assert region.subregions == tuple()
 

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -438,14 +438,15 @@ def write_outputs(results: serialiser.AntismashResults, options: ConfigType) -> 
     logging.debug("Writing non-HTML output files")
     # don't use results for which the module no longer exists to regenerate/calculate
     module_results_per_record = []
-    for record_results in results.results:
+    assert len(results.records) == len(results.results)
+    for record, record_results in zip(results.records, results.results):
         record_result = {}
         for module_name, result in record_results.items():
             if isinstance(result, ModuleResults):
+                assert result.record_id == record.id
                 logging.debug(" Writing relevant output files for %s", module_name)
                 record_result[module_name] = result
-                for record in results.records:
-                    result.write_outputs(record, options)
+                result.write_outputs(record, options)
         module_results_per_record.append(record_result)
 
     if html.is_enabled(options):

--- a/antismash/modules/clusterblast/results.py
+++ b/antismash/modules/clusterblast/results.py
@@ -7,7 +7,7 @@
 from collections import OrderedDict
 import logging
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, IO, List, Optional, Tuple
 
 from antismash.common.module_results import ModuleResults
 from antismash.common.layers import AbstractRelatedArea
@@ -339,15 +339,15 @@ def write_clusterblast_output(options: ConfigType, record: Record,
     filename = f"{record.id}_c{region_number}.txt"
 
     with changed_directory(_get_output_dir(options, searchtype)):
-        _write_output(filename, record, cluster_result, proteins)
+        with open(filename, "w", encoding="utf-8") as out_file:
+            _write_output(out_file, record, cluster_result, proteins)
 
 
-def _write_output(filename: str, record: Record, cluster_result: RegionResult,
+def _write_output(out_file: IO, record: Record, cluster_result: RegionResult,
                   proteins: Dict[str, Protein]) -> None:
     ranking = cluster_result.ranking
     # Output for each hit: table of genes and locations of input cluster,
     # table of genes and locations of hit cluster, table of hits between the clusters
-    out_file = open(filename, "w", encoding="utf-8")  # pylint: disable=consider-using-with
     out_file.write("ClusterBlast scores for " + record.id + "\n")
     out_file.write("\nTable of genes, locations, strands and annotations of query cluster:\n")
     for i, cds in enumerate(cluster_result.region.cds_children):
@@ -385,7 +385,6 @@ def _write_output(filename: str, record: Record, cluster_result: RegionResult,
         else:
             out_file.write("data not found\n")
         out_file.write("\n")
-    out_file.close()
 
 
 def _get_output_dir(options: ConfigType, searchtype: str) -> str:


### PR DESCRIPTION
Fixed crashes:
- in cluster detection for the specific case of splice variants where one variant had a shorter sequence while also a later end coordinate, due to a failure in correctly comparing order of locations
- while directly comparing two locations, while one was compound and the other was not
- in cluster detection when a negative stranded feature caused a cluster to be extended over the origin, due to CDSCollection being too strict with locations in constructors
- (potential fix) one instance of clusterblast output caused an OSError on some systems due to file descriptor leaks (possibly also container file limits), due to the number of files generated per record with many records

Following that last one, a bug was discovered in module output writing that caused a module's results for one record being written out once for _every_ record. In a test case of a metagenomic input with roughly 5,000 contigs, that results in 3 minutes of file writing and almost 15,000 files. After the fix, the time taken went down to 20 seconds and the file count down to around 250. This didn't affect many modules, but clusterblast was the most egregious case due to the heavy file counts.