### PR TITLE
tfbs: fix HTML JSON generation for hits within genes

### DIFF
--- a/antismash/modules/tfbs_finder/html_output.py
+++ b/antismash/modules/tfbs_finder/html_output.py
@@ -228,6 +228,13 @@ def add_neighbouring_genes(hit: dict[str, Any], left: Optional[CDSFeature], mid:
         }
         if location_contains_other(left.location, location):
             hit["contained_by_left"] = True
+            hit["left"]["location"] = int(left.start)
+            hit["right"] = {
+                "name": left.get_name(),
+                "location": int(left.end),
+                "strand": left.location.strand
+            }
+            return hit
 
     if mid:
         length = mid.end - mid.start

--- a/antismash/modules/tfbs_finder/test/test_tfbs_finder.py
+++ b/antismash/modules/tfbs_finder/test/test_tfbs_finder.py
@@ -305,6 +305,24 @@ class TestFinder(unittest.TestCase):
             "strand": -1,
         }
 
+    def test_fully_within_gene(self):
+        hit = {"start": 5, "end": 15}
+        left = DummyCDS(start=0, end=30)
+        mid = None
+        right = DummyCDS(start=35, end=40, strand=-1)
+        results = add_neighbouring_genes(hit, left, mid, right)
+        assert results["left"] == {
+            "location": left.start,
+            "name": left.get_name(),
+            "strand": 1,
+        }
+        assert "mid" not in results
+        assert results["right"] == {
+            "location": left.end,
+            "name": left.get_name(),
+            "strand": 1,
+        }
+
 
 class TestFindingNeighbours(unittest.TestCase):
     def test_finding_cross_origin_neighbours(self):


### PR DESCRIPTION
Back in d7256c33 I apparently broke the drawing of TFBS hits that were fully contained by a gene, resulting in different gene names being used for both ends of the gene in question:

![image](https://github.com/user-attachments/assets/de3b84f1-a3cb-41f8-922e-99b6be48d4d9)

This has been fixed and the output now displays the same as it was in 7.1.0:

![image](https://github.com/user-attachments/assets/9e03aeb9-d043-4313-a599-101e9aea5e99)
