### PR TITLE
Small corrections for input handling

### DIFF
--- a/antismash/common/gff_parser.py
+++ b/antismash/common/gff_parser.py
@@ -182,7 +182,7 @@ def split_cross_origin_locations(features: list[SeqFeature], length: int) -> Non
 
     for feature in features:
         if feature.location.start > length:
-            raise ValueError(f"GFF location entirely outside record: {feature.location}")
+            raise AntismashInputError(f"GFF location entirely outside record ({length=}): {feature.location}")
         # most circular records won't have introns, but handle it just in case
         parts = []
         for part in feature.location.parts:

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -227,7 +227,11 @@ class CDSFeature(Feature):
         if not _is_valid_translation_length(translation, self.location):
             raise ValueError(f"translation longer than location allows: {len(translation) * 3} > {len(self.location)}")
         # finally, any alternate start codon should be changed to methionine
-        if translation[0] != "M":
+        # except in cases where the start coordinate is ambiguous
+        if translation[0] != "M" and not (
+                (self.location.strand == -1 and isinstance(self.end, AfterPosition))
+                or (self.location.strand == 1 and isinstance(self.start, BeforePosition))
+        ):
             translation = "M" + translation[1:]
         self._translation = translation
 

--- a/antismash/common/secmet/features/test/test_cds_feature.py
+++ b/antismash/common/secmet/features/test/test_cds_feature.py
@@ -69,6 +69,16 @@ class TestCDSFeature(unittest.TestCase):
         cds.translation = translation
         assert cds.translation == expected
 
+    def test_methionine_starts_when_ambiguous(self):
+        # ambiguous start coordinates should not be adjusted to methionines
+        translation = "LAGIC"
+        for location in [
+                FeatureLocation(BeforePosition(10), 25, 1),
+                FeatureLocation(10, AfterPosition(25), -1),
+        ]:
+            cds = CDSFeature(location, locus_tag="test", translation=translation)
+            assert cds.translation == translation, location
+
 
 class TestCDSBiopythonConversion(unittest.TestCase):
     def setUp(self):

--- a/antismash/common/test/test_gff_parser.py
+++ b/antismash/common/test/test_gff_parser.py
@@ -161,10 +161,10 @@ class TestSplitLocation(TestCase):
 
     def test_all_after_point(self):
         self.feature.location = FeatureLocation(20, 30, 1)
-        with self.assertRaisesRegex(ValueError, "entirely outside record"):
+        with self.assertRaisesRegex(errors.AntismashInputError, "entirely outside record"):
             self.split(10)
         self.feature.location = CompoundLocation([FeatureLocation(20, 30, 1), FeatureLocation(40, 50, 1)])
-        with self.assertRaisesRegex(ValueError, "entirely outside record"):
+        with self.assertRaisesRegex(errors.AntismashInputError, "entirely outside record"):
             self.split(10)
 
     def test_simple_all_before_point(self):


### PR DESCRIPTION
- wraps plain `ValueError` stack traces for GFF feature annotations outside the matching FASTA record
- prevents coercing translations from starting with `M` in cases where the feature's start location is ambiguous