### PR TITLE
Fixes for odd/unexpected input related errors

### DIFF
--- a/antismash/common/all_orfs.py
+++ b/antismash/common/all_orfs.py
@@ -70,14 +70,23 @@ def get_trimmed_orf(orf: CDSFeature, record: Record, include: int = None,
         return None
 
     # otherwise, use the start which gives the smallest possible ORF
+    start = orf.start
+    end = orf.end
     if orf.location.strand == 1:
-        start = orf.location.start + starts[-1]
-        end = orf.location.end
+        start += starts[-1]
+        start %= len(record)
     else:
-        start = orf.location.start
-        end = orf.location.end - starts[-1]
+        end -= starts[-1]
 
-    location = FeatureLocation(start, end, orf.location.strand)
+    if start > end:
+        location = CompoundLocation([
+            FeatureLocation(start, orf.location.end, orf.location.strand),
+            FeatureLocation(orf.location.start, end, orf.location.strand),
+        ])
+        if location.strand == -1:
+            location.parts.reverse()
+    else:
+        location = FeatureLocation(start, end, orf.location.strand)
     return create_feature_from_location(record, location, label=label)
 
 

--- a/antismash/common/gff_parser.py
+++ b/antismash/common/gff_parser.py
@@ -189,7 +189,7 @@ def split_cross_origin_locations(features: list[SeqFeature], length: int) -> Non
             if part.end < length:
                 # don't change the location, but convert to secmet for better usability
                 parts.append(FeatureLocation(part.start, part.end, part.strand))
-            elif part.start > length:
+            elif part.start >= length:
                 # the part will shift, but not be split
                 new = FeatureLocation(part.start % length, part.end % length, part.strand)
                 if part.strand == -1:

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -261,6 +261,12 @@ class CDSFeature(Feature):
                 return val
         raise ValueError(f"{self} altered to contain no identifiers")
 
+    def get_sub_location_from_protein_coordinates(self, start: int, end: int,
+                                                  *, protein_length: int = 0,
+                                                  ) -> Location:
+        protein_length = protein_length or len(self.translation)
+        return self.location.convert_protein_position_to_dna(start, end, protein_length=protein_length)
+
     @classmethod
     def from_biopython(cls: Type[T], bio_feature: SeqFeature, feature: T = None,
                        leftovers: Optional[Dict] = None, record: Any = None) -> T:

--- a/antismash/common/secmet/features/test/test_feature.py
+++ b/antismash/common/secmet/features/test/test_feature.py
@@ -5,7 +5,6 @@
 # pylint: disable=use-implicit-booleaness-not-comparison,protected-access,missing-docstring
 
 import unittest
-from unittest.mock import patch
 
 from antismash.common.test import helpers
 
@@ -16,7 +15,6 @@ from antismash.common.secmet.features.feature import (
     pop_locus_qualifier as pop_locus,
     SeqFeature,
 )
-from antismash.common.secmet import features
 from antismash.common.secmet.locations import (
     BeforePosition,
     AfterPosition,
@@ -210,31 +208,6 @@ class TestSubLocation(unittest.TestCase):
     def setUp(self):
         self.feature = Feature(FeatureLocation(10, 40, 1), feature_type="test")
         self.get_sub = self.feature.get_sub_location_from_protein_coordinates
-
-    def test_invalid(self):
-        for bad_start, bad_end in [(-1, 1), (1, -1), (1, 11)]:
-            with self.assertRaisesRegex(ValueError, "must be contained by the feature"):
-                self.get_sub(bad_start, bad_end)
-        for bad_start, bad_end in [("test", 5), (5, "test"), (None, 5)]:
-            with self.assertRaisesRegex(TypeError, "(unorderable types|not supported)"):
-                self.get_sub(bad_start, bad_end)
-        with self.assertRaisesRegex(ValueError, "must be less than the end"):
-            self.get_sub(5, 1)
-
-    @patch.object(features.feature, "convert_protein_position_to_dna", return_value=(9, 15))
-    def test_start_outside(self, _mocked):
-        with self.assertRaisesRegex(ValueError, "Protein coordinate start .* is outside feature"):
-            self.get_sub(1, 5)
-
-    @patch.object(features.feature, "convert_protein_position_to_dna", return_value=(15, 41))
-    def test_end_outside(self, _mocked):
-        with self.assertRaisesRegex(ValueError, "Protein coordinate end .* is outside feature"):
-            self.get_sub(1, 5)
-
-    @patch.object(features.feature, "convert_protein_position_to_dna", return_value=(10, 3))
-    def test_inverted(self, _mocked):
-        with self.assertRaisesRegex(ValueError, "Invalid protein coordinate conversion"):
-            self.get_sub(1, 5)
 
     def test_simple_forward(self):
         assert self.get_sub(0, 1) == FeatureLocation(10, 13, 1)

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -845,10 +845,6 @@ def _adjust_location_by_offset(location: Location, offset: int) -> Location:
 
     if isinstance(location, CompoundLocation):
         part = location.parts[0]
-        if location.strand == -1:
-            assert part.end == location.end
-        else:
-            assert part.start == location.start
         location = CompoundLocation([adjust_single_location(part)] + location.parts[1:])
     else:
         location = adjust_single_location(location)

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -9,7 +9,6 @@ from typing import (
     Iterable,
     List,
     Optional,
-    Tuple,
     Type,
     TypeVar,
     Union,
@@ -121,18 +120,22 @@ class _LocationMixin(_Location):
         """ Returns True if this location contains the given location """
         return location_contains_other(self, other)
 
-    def convert_protein_position_to_dna(self: T, start: int, end: int) -> tuple[int, int]:
+    def convert_protein_position_to_dna(self: T, start: int, end: int,
+                                        *, protein_length: int = 0,
+                                        ) -> Location:
         """ Convert a protein position to a nucleotide sequence position for use in generating
             new FeatureLocations from existing FeatureLocations and/or CompoundLocations.
 
             Arguments:
-                position: the position in question, must be contained by the location
-                location: the location of the related feature, for handling introns/split locations
+                start: the protein start coordinate
+                end: the protein end coordinate
+                protein_length: the length of the protein in question,
+                                required for locations with ambiguous start coordinates
 
             Returns:
                 an int representing the calculated DNA location
         """
-        return convert_protein_position_to_dna(start, end, self)
+        return convert_protein_position_to_dna(start, end, self, protein_length=protein_length)
 
     def get_distance_to(self: T, other: T, wrap_point: int = None) -> int:
         """ Finds the shortest distance between the two given features, crossing
@@ -392,63 +395,136 @@ def connect_locations(locations: list[Location], wrap_point: int = None) -> Loca
     return result
 
 
-def convert_protein_position_to_dna(start: int, end: int, location: Location) -> Tuple[int, int]:
+def _convert_protein_from_front(old_parts: list[FeatureLocation], start: int, length: int,
+                                ) -> list[FeatureLocation]:
+    assert start >= 0, start
+    old_parts = list(old_parts)
+    new_parts = []
+    # get start and following
+    for i, part in enumerate(old_parts):
+        if start < len(part):
+            part = FeatureLocation(part.start + start, part.end, part.strand)
+            if len(part) != 0:
+                new_parts.append(part)
+            new_parts.extend(old_parts[i + 1:])
+            break
+        start -= len(part)
+
+    # trim to end
+    old_parts = new_parts
+    new_parts = []
+    for part in old_parts:
+        if length < len(part):
+            part = FeatureLocation(part.start, part.start + length, part.strand)
+            if len(part) != 0:
+                new_parts.append(part)
+            break
+        new_parts.append(part)
+        length -= len(part)
+    assert new_parts
+    return new_parts
+
+
+def _convert_protein_from_back(old_parts: list[FeatureLocation], start: int, length: int,
+                               ) -> list[FeatureLocation]:
+    assert start >= 0, start
+    old_parts = list(old_parts)
+    new_parts = []
+    # get start and following
+    for i, part in enumerate(old_parts):
+        if start < len(part):
+            part = FeatureLocation(part.start, part.end - start, part.strand)
+            if len(part) != 0:
+                new_parts.append(part)
+            new_parts.extend(old_parts[i + 1:])
+            break
+        start -= len(part)
+
+    # trim to end
+    old_parts = new_parts
+    new_parts = []
+    for part in old_parts:
+        if length < len(part):
+            part = FeatureLocation(part.end - length, part.end, part.strand)
+            if len(part) != 0:
+                new_parts.append(part)
+            break
+        new_parts.append(part)
+        length -= len(part)
+    assert new_parts
+    return new_parts
+
+
+def convert_protein_position_to_dna(start: int, end: int, location: Location,
+                                    *, protein_length: int = 0) -> Location:
     """ Convert protein coordinates to a nucleotide sequence position for use in generating
         new FeatureLocations from existing FeatureLocations and/or CompoundLocations.
 
         Arguments:
             start: the start coordinate
-            end: the start coordinate
+            end: the end coordinate
             location: the location of the related feature, for handling introns/split locations
-
+            protein_length: the length of the protein in question,
+                            required for locations with ambiguous start coordinates
         Returns:
-            an int representing the calculated DNA location
+            a new Location
     """
-    if not 0 <= start < end <= len(location) // 3:
-        raise ValueError(f"Protein positions {start} and {end} must be contained by {location}")
+    if protein_length and protein_length < end:
+        raise ValueError(f"Protein coordinates {start=}, {end=}, outside given protein length ({protein_length})")
     if location.strand == -1:
-        dna_start = location.start + len(location) - end * 3
-        dna_end = location.start + len(location) - start * 3
+        ambiguous_start = isinstance(location.parts[0].end, AfterPosition)
+        ambiguous_end = isinstance(location.parts[-1].start, BeforePosition)
     else:
-        dna_start = location.start + start * 3
-        dna_end = location.start + end * 3
+        ambiguous_start = isinstance(location.parts[0].start, BeforePosition)
+        ambiguous_end = isinstance(location.parts[-1].end, AfterPosition)
 
-    # only CompoundLocations are complicated
-    if not isinstance(location, CompoundLocation):
-        if not location.start <= dna_start < dna_end <= location.end:
-            raise ValueError(
-                f"Converted coordinates {dna_start}..{dna_end} "
-                f"out of bounds for location {location}"
-            )
-        return int(dna_start), int(dna_end)
-
-    parts = sorted(location.parts, key=lambda x: x.start)
-    gap = 0
-    last_end = parts[0].start
-    start_found = False
-    end_found = False
-    for part in parts:
-        if start_found and end_found:
-            break
-        gap += part.start - last_end
-        if not start_found and dna_start + gap in part:
-            start_found = True
-            dna_start = dna_start + gap
-        if not end_found and dna_end + gap - 1 in part:
-            end_found = True
-            dna_end = dna_end + gap
-
-        last_end = part.end
-
-    assert start_found
-    assert end_found
-
-    if not location.start <= dna_start < dna_end <= location.end:
+    if ambiguous_start and not protein_length:
         raise ValueError(
-            f"Converted coordinates {dna_start}..{dna_end} "
-            f"out of bounds for location {location}"
+            "Cannot convert protein positions without protein length"
+            " when sequence start coordinate is ambiguous"
         )
-    return int(dna_start), int(dna_end)
+
+    if ambiguous_start and ambiguous_end:
+        # this is recoverable if, and only if, the translation was truncated to match
+        if protein_length != len(location) // 3:
+            raise ValueError(
+                "Cannot convert protein positions to DNA when location is completely"
+                f" ambiguous {start=} {end=} within {location=}"
+            )
+        # if so, then pretend the location is exact and not ambiguous
+        ambiguous_start = False
+        ambiguous_end = False
+        parts = [FeatureLocation(int(part.start), int(part.end), part.strand) for part in location.parts]
+        if len(parts) > 1:
+            location = CompoundLocation(parts)
+        else:
+            location = parts[0]
+
+    if not (ambiguous_start or ambiguous_end or 0 <= start < end <= len(location) // 3):
+        raise ValueError(f"Protein positions {start} and {end} must be contained by {location}")
+
+    start *= 3
+    end *= 3
+    length = end - start
+    protein_length_as_nt = protein_length * 3
+
+    if location.strand == -1:
+        if ambiguous_start:
+            effective_start = protein_length_as_nt - end
+            new_parts = _convert_protein_from_front(location.parts[::-1], effective_start, length)[::-1]
+        else:
+            new_parts = _convert_protein_from_back(location.parts, start, length)
+    else:
+        if ambiguous_start:
+            effective_start = protein_length_as_nt - end
+            new_parts = _convert_protein_from_back(location.parts[::-1], effective_start, length)[::-1]
+        else:  # ambiguous ends and exact ends don't vary
+            new_parts = _convert_protein_from_front(location.parts, start, length)
+
+    assert new_parts
+    if len(new_parts) == 1:
+        return new_parts[0]
+    return CompoundLocation(new_parts)
 
 
 def build_location_from_others(locations: list[Location]) -> Location:

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -551,12 +551,19 @@ class Record:
             location = FeatureLocation(0, max(1, location.end))
 
         index = find_start_in_list(location, self._cds_features, with_overlapping)
+        # in case of cross-origin features, the first few might only overlap,
+        # so those need to be passed over, but once the first fully contained feature
+        # is found, no further excluded overlaps can be skipped
+        has_yet_to_be_contained = True
         while index < len(self._cds_features):
             feature = self._cds_features[index]
             if feature.is_contained_by(location):
+                has_yet_to_be_contained = False
                 results.append(feature)
             elif with_overlapping and feature.overlaps_with(location):
                 results.append(feature)
+            elif has_yet_to_be_contained:
+                pass
             elif index + 1 < len(self._cds_features) and self._cds_features[index + 1].is_contained_by(feature):
                 pass
             else:

--- a/antismash/common/secmet/record.py
+++ b/antismash/common/secmet/record.py
@@ -831,7 +831,8 @@ class Record:
         record = cls(seq=seq_record.seq, transl_table=transl_table, **kwargs)
         record._record = seq_record
         # because is_circular() can't be used reliably at this stage due to fasta files
-        can_be_circular = taxon == "bacteria"
+        # unfortunately, circular records can also exist in fungal inputs, i.e. NC_027416, a mitochondrion
+        can_be_circular = True
         try:
             ensure_valid_locations(seq_record.features, can_be_circular, len(seq_record.seq))
         except ValueError as err:

--- a/antismash/common/secmet/test/test_circular_conversion.py
+++ b/antismash/common/secmet/test/test_circular_conversion.py
@@ -30,10 +30,10 @@ class TestBridgeConversion(unittest.TestCase):
     def test_bridge_in_linear_record(self):
         self.seqrec.annotations["topology"] = "linear"
         self.seqrec.features.append(self.seqcds)
-        with self.assertRaisesRegex(SecmetInvalidInputError, "cannot determine correct exon ordering"):
+        with self.assertRaisesRegex(SecmetInvalidInputError, "contains an origin spanning exon"):
             Record.from_biopython(self.seqrec, taxon='fungi')
         self.seqrec.features[0] = self.seqgene
-        with self.assertRaisesRegex(SecmetInvalidInputError, "cannot determine correct exon ordering"):
+        with self.assertRaisesRegex(SecmetInvalidInputError, "contains an origin spanning exon"):
             Record.from_biopython(self.seqrec, taxon='fungi')
 
 

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -175,115 +175,159 @@ class TestConnectLocations(unittest.TestCase):
 
 
 class TestProteinPositionConversion(unittest.TestCase):
-    def func(self, start, end, location):
-        static = convert_protein_position_to_dna(start, end, location)
-        dynamic = location.convert_protein_position_to_dna(start, end)
+    def func(self, start, end, location, **kwargs):
+        static = convert_protein_position_to_dna(start, end, location, **kwargs)
+        dynamic = location.convert_protein_position_to_dna(start, end, **kwargs)
         assert static == dynamic
         return static
+
+    def test_ambiguous_end_forward(self):
+        original = CompoundLocation([
+            FeatureLocation(20, 35, 1),
+            FeatureLocation(40, AfterPosition(50), 1),
+        ])
+        expected = CompoundLocation([
+            FeatureLocation(26, 35, 1),
+            FeatureLocation(40, AfterPosition(50), 1),
+        ])
+        length = 30
+        new = self.func(2, 2 + length, original)
+        assert new == expected
+        assert len(new) < length * 3
+
+    def test_ambiguous_end_reverse(self):
+        original = CompoundLocation([
+            FeatureLocation(40, 50, -1),
+            FeatureLocation(BeforePosition(20), 35, -1),
+        ])
+        expected = CompoundLocation([
+            FeatureLocation(40, 44, -1),
+            FeatureLocation(BeforePosition(20), 35, -1),
+        ])
+        length = 30
+        new = self.func(2, 2 + length, original)
+        assert new == expected
+        assert len(new) < length * 3
+
+    def test_ambiguous_start_forward(self):
+        full_protein_length = 60
+        original = CompoundLocation([
+            FeatureLocation(BeforePosition(20), 35, 1),
+            FeatureLocation(40, 50, 1),
+        ])
+        assert len(original) < full_protein_length * 3
+
+        end = full_protein_length - 1
+        # fully contained
+        length = 6
+        expected = CompoundLocation([
+            FeatureLocation(24, 35, 1),
+            FeatureLocation(40, 47, 1),
+        ])
+        with self.assertRaisesRegex(ValueError, "without protein length"):
+            self.func(end - length, end, original)
+        new = self.func(end - length, end, original, protein_length=full_protein_length)
+        assert new == expected
+        assert len(new) == length * 3
+
+        # extending into unknown
+        length = 12
+        expected = CompoundLocation([
+            original.parts[0],
+            FeatureLocation(40, 47, 1),
+        ])
+        new = self.func(end - length, end, original, protein_length=full_protein_length)
+        assert new == expected
+        assert len(new) < length * 3
+
+    def test_ambiguous_start_reverse(self):
+        full_protein_length = 60
+        original = CompoundLocation([
+            FeatureLocation(40, AfterPosition(50), -1),
+            FeatureLocation(20, 35, -1),
+        ])
+        assert len(original) < full_protein_length * 3
+
+        end = full_protein_length - 1
+        # fully contained
+        length = 6
+        expected = CompoundLocation([
+            FeatureLocation(40, 46, -1),
+            FeatureLocation(23, 35, -1),
+        ])
+        with self.assertRaisesRegex(ValueError, "without protein length"):
+            self.func(end - length, end, original)
+        new = self.func(end - length, end, original, protein_length=full_protein_length)
+        assert new == expected
+        assert len(new) == length * 3
+
+        # extending into unknown
+        length = 12
+        expected = CompoundLocation([
+            original.parts[0],
+            FeatureLocation(23, 35, -1),
+        ])
+        new = self.func(end - length, end, original, protein_length=full_protein_length)
+        assert new == expected
+        assert len(new) < length * 3
+
+    def test_border(self):
+        location = CompoundLocation([
+            FeatureLocation(21, 27, -1),
+            FeatureLocation(12, 15, -1),
+            FeatureLocation(0, 6, -1),
+        ])
+        assert self.func(2, 3, location) == FeatureLocation(12, 15, -1)
+
+    def test_both_ambiguous(self):
+        original = FeatureLocation(BeforePosition(50), AfterPosition(110), 1)
+        overly_long = 2 * len(original) // 3
+        incomplete = len(original) // 6
+        for length in [overly_long, incomplete]:
+            with self.assertRaisesRegex(ValueError, "completely ambiguous"):
+                new = self.func(1, 3, original, protein_length=length)
+        recoverable = len(original) // 3
+        new = self.func(1, 3, original, protein_length=recoverable)
+        assert new == FeatureLocation(53, 59, 1)
+
+    def test_compound_forward(self):
+        original = CompoundLocation([
+            FeatureLocation(94, 97, 1),
+            FeatureLocation(100, 120, 1),
+            FeatureLocation(117, 127, 1),  # overlaps with previous exon
+            FeatureLocation(130, 133, 1),
+        ])
+        expected = CompoundLocation([
+            FeatureLocation(106, 120, 1),
+            FeatureLocation(117, 124, 1),
+        ])
+        length = 7
+        new = self.func(3, 3 + length, original)
+        assert new == expected
+        assert len(new) == length * 3
 
     def test_position_conversion_simple_forward(self):
         location = FeatureLocation(0, 15, strand=1)
         assert len(location) == 15
-        assert self.func(0, 2, location) == (0, 6)
-        assert self.func(1, 4, location) == (3, 12)
+        assert self.func(0, 2, location) == FeatureLocation(0, 6, 1)
+        assert self.func(1, 4, location) == FeatureLocation(3, 12, 1)
 
     def test_position_conversion_simple_reverse(self):
         location = FeatureLocation(0, 15, strand=-1)
         assert len(location) == 15
-        assert self.func(0, 2, location) == (9, 15)
-        assert self.func(1, 4, location) == (3, 12)
+        assert self.func(0, 2, location) == FeatureLocation(9, 15, -1)
+        assert self.func(1, 4, location) == FeatureLocation(3, 12, -1)
 
     def test_position_conversion_nonzero_start(self):
         location = FeatureLocation(6, 21, strand=1)
         assert len(location) == 15
-        assert self.func(0, 2, location) == (6, 12)
-        assert self.func(1, 4, location) == (9, 18)
+        assert self.func(0, 2, location) == FeatureLocation(6, 12, 1)
+        assert self.func(1, 4, location) == FeatureLocation(9, 18, 1)
 
         location = FeatureLocation(6, 21, strand=-1)
         assert len(location) == 15
-        assert self.func(0, 2, location) == (15, 21)
-        assert self.func(1, 4, location) == (9, 18)
-
-    def test_position_conversion_nonzero_compound(self):
-        location = CompoundLocation([FeatureLocation(6, 18, strand=1),
-                                     FeatureLocation(24, 27, strand=1)])
-        assert len(location) == 15
-        assert self.func(0, 2, location) == (6, 12)
-        assert self.func(1, 4, location) == (9, 18)
-        assert self.func(3, 5, location) == (15, 27)
-
-        location = CompoundLocation([FeatureLocation(6, 15, strand=-1),
-                                     FeatureLocation(21, 27, strand=-1)])
-        assert len(location) == 15
-        assert self.func(0, 2, location) == (21, 27)
-        assert self.func(1, 4, location) == (9, 24)
-        assert self.func(3, 5, location) == (6, 12)
-
-    def test_position_conversion_compound_forward(self):
-        location = CompoundLocation([FeatureLocation(0, 6, strand=1),
-                                     FeatureLocation(9, 18, strand=1)])
-        assert len(location) == 15
-        assert self.func(0, 4, location) == (0, 15)
-        assert self.func(1, 5, location) == (3, 18)
-
-        location = CompoundLocation([FeatureLocation(0, 6, strand=1),
-                                     FeatureLocation(12, 15, strand=1),
-                                     FeatureLocation(21, 27, strand=1)])
-        assert len(location) == 15
-        assert self.func(0, 4, location) == (0, 24)
-        assert self.func(1, 5, location) == (3, 27)
-        assert self.func(2, 3, location) == (12, 15)
-
-    def test_position_conversion_compound_reverse(self):
-        location = CompoundLocation([FeatureLocation(0, 6, strand=-1),
-                                     FeatureLocation(9, 18, strand=-1)])
-        assert len(location) == 15
-        assert self.func(0, 4, location) == (3, 18)
-        assert self.func(1, 5, location) == (0, 15)
-
-        location = CompoundLocation([FeatureLocation(0, 6, strand=-1),
-                                     FeatureLocation(12, 15, strand=-1),
-                                     FeatureLocation(21, 27, strand=-1)])
-        assert len(location) == 15
-        assert self.func(0, 4, location) == (3, 27)
-        assert self.func(1, 5, location) == (0, 24)
-        assert self.func(2, 3, location) == (12, 15)
-
-    def test_other(self):
-        location = CompoundLocation([FeatureLocation(5922, 6190, strand=1),
-                                     FeatureLocation(5741, 5877, strand=1),
-                                     FeatureLocation(4952, 5682, strand=1)])
-        assert self.func(97, 336, location) == (5243, 6064)
-
-        location = CompoundLocation([FeatureLocation(5922, 6190, strand=-1),
-                                     FeatureLocation(5741, 5877, strand=-1),
-                                     FeatureLocation(4952, 5682, strand=-1)])
-        assert self.func(97, 336, location) == (5078, 5854)
-
-    def test_ambiguous_starts(self):
-        # DNA coordinates of a domain should never be ambiguous
-        # when the initial feature's DNA coordinate is ambiguous
-        location = FeatureLocation(BeforePosition(10), 40, 1)
-        # sanity check that ambiguous positions convert as such
-        assert str(location.start) == "<10"
-        start, end = convert_protein_position_to_dna(2, 4, location)
-        assert start == 16
-        assert end == 22
-        # ensure no ambiguity remains
-        assert not isinstance(start, BeforePosition)
-        assert not isinstance(end, BeforePosition)
-
-        # and for good measure, compound locations
-        location = CompoundLocation([
-            FeatureLocation(BeforePosition(10), 40, 1),
-            FeatureLocation(60, 80, 1),
-        ])
-        assert str(location.start) == "<10"
-        start, end = convert_protein_position_to_dna(2, 14, location)
-        assert start == 16
-        assert end == 72
-        assert not isinstance(start, BeforePosition)
-        assert not isinstance(end, BeforePosition)
+        assert self.func(0, 2, location) == FeatureLocation(15, 21, -1)
+        assert self.func(1, 4, location) == FeatureLocation(9, 18, -1)
 
 
 class TestCompoundCombination(unittest.TestCase):

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -733,6 +733,15 @@ class TestLocationAdjustment(unittest.TestCase):
                 for old_part, new_part in zip(old.parts[1:], new.parts[1:]):
                     assert old_part is new_part
 
+    def test_cross_origin(self):
+        old = CompoundLocation([
+            FeatureLocation(80, 100, 1),
+            FeatureLocation(0, 20, 1),
+        ])
+        offset = 2
+        new = adjust(old, offset)
+        assert new.parts[0].start == old.parts[0].start + offset
+
 
 def offset_location(location, offset, **kwargs):
     static = _offset_location(location, offset, **kwargs)

--- a/antismash/common/secmet/test/test_secmet.py
+++ b/antismash/common/secmet/test/test_secmet.py
@@ -529,6 +529,23 @@ class TestCDSFetchByLocation(unittest.TestCase):
         assert self.func(location, with_overlapping=False) == []
         assert self.func(location, with_overlapping=True) == [self.record.get_cds_features()[0]]
 
+    def test_cross_origin_exact(self):
+        record = Record(Seq("A" * 100))
+        edge = DummyCDS(0, 20)
+        record.add_cds_feature(edge)
+        cross_origin = DummyCDS(location=CompoundLocation([
+            FeatureLocation(90, 100, 1),
+            FeatureLocation(0, 8, 1),
+        ]))
+        record.add_cds_feature(cross_origin)
+
+        query = edge.location
+
+        without_overlap = record.get_cds_features_within_location(query, with_overlapping=False)
+        assert without_overlap == [edge]
+        with_overlap = record.get_cds_features_within_location(query, with_overlapping=True)
+        assert with_overlap == [cross_origin, edge]
+
 
 class TestClusterManipulation(unittest.TestCase):
     def setUp(self):

--- a/antismash/common/subprocessing/diamond.py
+++ b/antismash/common/subprocessing/diamond.py
@@ -54,6 +54,9 @@ def run_diamond(subcommand: str,
             params.extend([
                 "--threads", str(config.cpus),
                 "--tmpdir", temp_dir,
+                # diamond will fail if a translation happens to be a subset of GCTA, so ignore those
+                # as of diamond 2.1.3, the above case is the only case where this option is relevant
+                "--ignore-warnings",
             ])
             return run(params)
 

--- a/antismash/common/test/test_gff_parser.py
+++ b/antismash/common/test/test_gff_parser.py
@@ -218,6 +218,20 @@ class TestSplitLocation(TestCase):
         self.split(100)
         assert self.feature.location == expected
 
+    def test_point_at_exon_start(self):
+        # catches off by one in feature length check
+        original = CompoundLocation([
+            FeatureLocation(15, 20, 1),
+            FeatureLocation(30, 40, 1),
+        ])
+        expected = CompoundLocation([
+            FeatureLocation(15, 20, 1),
+            FeatureLocation(0, 10, 1),
+        ])
+        self.feature.location = original
+        self.split(30)
+        assert self.feature.location == expected
+
 
 class TestUpdateRecords(TestCase):
     def setUp(self):


### PR DESCRIPTION
Diamond raises an error when a protein sequence looks like a nucleotide sequence. This happened with some tiny pseudogenes, where the translation was valid. Diamond can be set to ignore warnings, and since this is the only case covered by that flag (as of now), it's been added.

When an input was circular and the sequence around the origin contained a small, unannotated, gene that were then found in that area with `all_orfs` were then incorrect when the gene was trimmed to the shortest length (i.e. latest start codon). The trimming function didn't consider these cross-origin genes and could result in a gene covering the entire contig, and in some cases crashing due to the translation of that gene being longer than the allowed maximum.

Some inputs crashed inside cluster prediction when a cluster was detected for a cluster with `EXTENDERS` _and_ they had a particular combination of genes at the origin.

Fungal sequences were assumed to never be circular, but some NCBI assemblies include mitochrondions which are circular. This resulted in incorrect detection of exons being in inconsistent ordering and raising an error. This is made more difficult since most fungal inputs are FASTA + GFF, where circularity isn't always specified, but for the moment all inputs are now considered as possibly circular.

Inputs with a cross-origin gene that had `codon_start` qualifiers would crash.

Due to an off-by-one error, GFF parsing would crash when a cross-origin gene had an exon beginning precisely at the origin.

Lastly, but most complicated, is a crash/error when a feature had overlapping exons/sections. This was intended behaviour, but some NCBI assemblies do contain features that have this case. That requirement has been removed, which in turn led to the fetching of contig coordinates from protein coordinates within a feature being wildly incorrect. This accounts for most of the line changes.