### PR TITLE
secmet: fix protocluster sorting non-determinism when locations are equal

### DIFF
--- a/antismash/common/secmet/features/protocluster.py
+++ b/antismash/common/secmet/features/protocluster.py
@@ -173,6 +173,11 @@ class Protocluster(CDSCollection, CoredCollectionMixin):
         assert isinstance(updated, Protocluster)
         return updated
 
+    def __lt__(self, other: Feature | Location) -> bool:
+        if isinstance(other, Protocluster) and other.location == self.location:
+            return self.product < other.product
+        return super().__lt__(other)
+
 
 class SideloadedProtocluster(Protocluster):
     """ A variant of Protocluster specifically for sideloaded features

--- a/antismash/common/secmet/features/test/test_protocluster.py
+++ b/antismash/common/secmet/features/test/test_protocluster.py
@@ -80,6 +80,20 @@ class TestProtocluster(unittest.TestCase):
         assert cluster.location.start < len(record.seq) < cluster.core_location.end + cluster.cutoff
         assert cluster.contig_edge is True
 
+    def test_sorting(self):
+        location = FeatureLocation(1, 4, 1)
+
+        def create(loc, product):
+            return Protocluster(loc, loc, tool="test", cutoff=3, neighbourhood_range=5,
+                                product=product, detection_rule="text", product_category="cat")
+
+        first = create(location, "A")
+        second = create(location, "B")
+        different = create(FeatureLocation(3, 5, 1), "A")
+        assert first < second
+        assert second < different
+        assert second > first
+
 
 class TestSideloaded(unittest.TestCase):
     def test_conversion(self):


### PR DESCRIPTION
`Record.from_biopython()` and regeneration of a `Record` from existing JSON results could cause ordering differences when locations were the same. This changes the sort order to include the product name in that situation to make it (more) deterministic.

This can't cover cases where just a location is used as a comparator, but `Record.add_protocluster()` always compares protoclusters with full instances and not just locations.