### PR TITLE
Split 'minimum' keyword in rules to handle with repeats and without

### DIFF
--- a/antismash/common/hmm_rule_parser/test/test_rule_parser.py
+++ b/antismash/common/hmm_rule_parser/test/test_rule_parser.py
@@ -145,6 +145,10 @@ class DetectionTest(unittest.TestCase):
         results = self.run_test("A", 100, 20, "minimum(2, [b, e])")
         self.expect(results, ["GENE_1", "GENE_3", "GENE_4"])
 
+        # but two hits of the same profile shouldn't count as satisfied
+        results = self.run_test("A", 10, 20, "minimum(2, [a, g])")
+        self.expect(results, [])
+
     def test_minimum_in_and(self):
         # ensures cluster rules using a MinimumCondition inside an AndCondition
         # report the minimum hits properly if another condition is the one
@@ -169,6 +173,17 @@ class DetectionTest(unittest.TestCase):
         # (or no hit, if minimums have to internally obey cutoff checks)
         results = self.run_test("A", 40, 10, "e and minimum(2, [g, c])")
         self.expect(results, ["GENE_3", "GENE_4", "GENE_5"])
+
+    def test_simple_repeatable(self):
+        results = self.run_test("A", 10, 20, "repeatable(2, [a, b])")
+        self.expect(results, ["GENE_1", "GENE_2"])
+
+        results = self.run_test("A", 100, 20, "repeatable(2, [b, e])")
+        self.expect(results, ["GENE_1", "GENE_3", "GENE_4"])
+
+        # two should hit "a", while "g" should be too far away
+        results = self.run_test("A", 10, 20, "repeatable(2, [a, g])")
+        self.expect(results, ["GENE_1", "GENE_2"])
 
     def test_single_gene(self):
         self.results_by_id = {

--- a/antismash/detection/hmm_detection/cluster_rules/loose.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/loose.txt
@@ -8,7 +8,7 @@ RULE saccharide
     DESCRIPTION Saccharide cluster definition from clusterfinder
     CUTOFF 20
     NEIGHBOURHOOD 10
-    CONDITIONS minimum(2,[Alpha-amylase, Alpha-amylase_C, Bac_transf,
+    CONDITIONS repeatable(2,[Alpha-amylase, Alpha-amylase_C, Bac_transf,
                           Capsule_synth, CBM_48, DegT_DnrJ_EryC1, dTDP_sugar_isom,
                           Epimerase_2, Glycos_transf_1, Glycos_transf_2,
                           Glycos_transf_4, Glyco_tran_28_C, Glyco_transf_28,

--- a/antismash/detection/hmm_detection/cluster_rules/strict.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/strict.txt
@@ -656,7 +656,7 @@ RULE oligosaccharide
     DESCRIPTION Oligosaccharide
     CUTOFF 20
     NEIGHBOURHOOD 10
-    CONDITIONS minimum(3,[Glycos_transf_1,Glycos_transf_2,Glyco_transf_28,MGT,DUF1205])
+    CONDITIONS repeatable(3,[Glycos_transf_1,Glycos_transf_2,Glyco_transf_28,MGT,DUF1205])
                and minscore(MGT, 150)
 
 RULE furan


### PR DESCRIPTION
`minimum(2, [a, b,c])` is intuitively "a minimum of 2 of a, b, or c".
The actual interpretation is "a minimum of 2 _CDSes_ with a, b, or c".

Some rules have used it with one interpretation and some have used it with the other.

To handle this, the more intuitive naming has been changed to the stricter form where the count is of distinct hits within the group. The existing form, where the number of distinct hits isn't relevant, has been reintroduced as `repeatable`. The decision to rename the existing functionality instead of the stricter version is that the intuitive interpretation will continue to confuse people and not be obvious when testing new rules.

The saccharide rules, `saccharide` and `oligosaccharide`, are now explicitly repeatable. No cluster previously detected will be lost.

The only other rule affected is `isocyanide-nrp`, which keeps the `minimum` keyword and now requires distinct hits. This will result in some previously detected clusters no longer being detected, however in this case it is not expected that multiple CDS features with _only_ `PP-binding`  domains would cause a cluster to be called.