### PR TITLE
html: revert proportional gene table height limit

### DIFF
--- a/antismash/outputs/html/css/style.scss
+++ b/antismash/outputs/html/css/style.scss
@@ -28,12 +28,7 @@ $kind-protoclusters: white;
     font-family: "Courier New", serif;
 }
 
-html {
-    height: 100%;
-}
-
 body {
-    height: 100%;
     font-family: Helvetica, Verdana, Tahoma, Sans-Serif;
     color: #555;
     background-color: $body-background;
@@ -254,7 +249,6 @@ nav {
 }
 
 .page {
-    height: 100%;
     overflow: hidden;
     h3, .heading {
         font-size: 90%;
@@ -1553,7 +1547,7 @@ ul.dropdown-options {
     }
     .gt-scroll-container {
         overflow-y: scroll;
-        max-height: 30%;
+        max-height: 350px;
     }
     * .gt {
         padding: 1em;


### PR DESCRIPTION
This reverts commit 456f8bda1ae91b47c6aa815a21eaf3cdfb61b089.

While the gene table size did increase at different browser zoom levels and resolutions, it the scroll functionality would break for both itself and the region overview table.

While the functionality is desired, it will be at a later point where time can be taken for more comprehensive layout/style changes.