### PR TITLE
Prep for 8.0.3 release

### DIFF
--- a/antismash/common/gff_parser.py
+++ b/antismash/common/gff_parser.py
@@ -186,7 +186,7 @@ def split_cross_origin_locations(features: list[SeqFeature], length: int) -> Non
         # most circular records won't have introns, but handle it just in case
         parts = []
         for part in feature.location.parts:
-            if part.end < length:
+            if part.end <= length:
                 # don't change the location, but convert to secmet for better usability
                 parts.append(FeatureLocation(part.start, part.end, part.strand))
             elif part.start >= length:

--- a/antismash/common/hmm_rule_parser/cluster_prediction.py
+++ b/antismash/common/hmm_rule_parser/cluster_prediction.py
@@ -583,6 +583,8 @@ def hsp_overlap_size(first: HSP, second: HSP) -> int:
 
 def filter_results(results: list[HSP], results_by_id: Dict[str, list[HSP]],
                    equivalence_groups: GenericSets,
+                   *,
+                   maximum_overlap: int = 20,
                    ) -> tuple[list[HSP], dict[str, list[HSP]]]:
     """ Filter results by comparing scores of different models """
     for equivalence_group in equivalence_groups:
@@ -595,8 +597,14 @@ def filter_results(results: list[HSP], results_by_id: Dict[str, list[HSP]],
             # Identify overlapping hits
             overlapping_groups: List[Set[HSP]] = []
             for hit in cdsresults:
+                if hit.query_id not in equivalence_group:
+                    continue
                 for otherhit in cdsresults:
-                    if hit == otherhit or hsp_overlap_size(hit, otherhit) <= 20:
+                    if hit is otherhit:
+                        continue
+                    if otherhit.query_id not in equivalence_group:
+                        continue
+                    if hsp_overlap_size(hit, otherhit) <= maximum_overlap:
                         continue
                     new_group_needed = True
                     pairing = {hit, otherhit}

--- a/antismash/common/secmet/features/prepeptide.py
+++ b/antismash/common/secmet/features/prepeptide.py
@@ -70,7 +70,7 @@ class Prepeptide(CDSMotif):  # pylint: disable=too-many-instance-attributes
         return self._leader + self._core + self._tail
 
     @translation.setter
-    def translation(self) -> None:
+    def translation(self, translation: str) -> None:
         raise AttributeError("Cannot assign to translation in a Prepeptide")
 
     @property

--- a/antismash/common/secmet/features/test/test_cds_feature.py
+++ b/antismash/common/secmet/features/test/test_cds_feature.py
@@ -447,19 +447,27 @@ class TestTranslationLength(unittest.TestCase):
             assert _is_valid_translation_length(good, location)
         assert not _is_valid_translation_length("AAA", location)
         # and with an ambiguous end, that becomes ok
-        location = CompoundLocation([FeatureLocation(0, 3), FeatureLocation(6, AfterPosition(11))])
+        location = CompoundLocation([FeatureLocation(6, 9, 1), FeatureLocation(12, AfterPosition(14), 1)])
         assert _is_valid_translation_length("AAA", location)
-        # and reversed ambiguous end
-        location = CompoundLocation([FeatureLocation(BeforePosition(0), 3, -1), FeatureLocation(6, 9, -1)])
+        # an ambiguous start
+        location = CompoundLocation([FeatureLocation(BeforePosition(0), 3, 1), FeatureLocation(6, 9, 1)])
         for good in ["A", "AA", "AAA"]:
             assert _is_valid_translation_length(good, location)
+        # but not a doubly ambiguous location
+        location = CompoundLocation([
+            FeatureLocation(BeforePosition(0), 3, 1),
+            FeatureLocation(6, AfterPosition(9), 1),
+        ])
+        for translation in ["A", "AA"]:
+            assert _is_valid_translation_length(translation, location)
+        assert not _is_valid_translation_length("AAA", location)
 
     def test_ambiguous_coords(self):
         translation = "A" * 10
         for strand in (-1, 1):
             # both ambiguous
             location = FeatureLocation(BeforePosition(10), AfterPosition(20), strand)
-            assert _is_valid_translation_length(translation, location)
+            assert not _is_valid_translation_length(translation, location)
             # start ambiguous
             location = FeatureLocation(BeforePosition(10), 20, strand)
             assert _is_valid_translation_length(translation, location)

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -455,6 +455,10 @@ def _convert_protein_from_front(old_parts: list[FeatureLocation], start: int, le
             new_parts.extend(old_parts[i + 1:])
             break
         start -= len(part)
+    # if no parts included the protein location, then it's outside the sequence
+    if not new_parts:
+        part = old_parts[-1]
+        return [FeatureLocation(part.end, part.end, part.strand)]
 
     # trim to end
     old_parts = new_parts
@@ -485,6 +489,11 @@ def _convert_protein_from_back(old_parts: list[FeatureLocation], start: int, len
             new_parts.extend(old_parts[i + 1:])
             break
         start -= len(part)
+    # if no parts included the protein location, then it's completely outside the sequence
+    if not new_parts:
+        part = old_parts[-1]
+        return [FeatureLocation(part.start, part.start, part.strand)]
+    assert new_parts
 
     # trim to end
     old_parts = new_parts

--- a/antismash/common/secmet/locations.py
+++ b/antismash/common/secmet/locations.py
@@ -152,6 +152,27 @@ class _LocationMixin(_Location):
         """
         return get_distance_between_locations(self, other, wrap_point)
 
+    def has_ambiguous_end(self) -> bool:
+        """ Checks if the location has an ambiguous end.
+
+            Returns:
+                whether the end is ambiguous
+        """
+
+        if self.strand == -1:
+            return isinstance(self.parts[-1].start, BeforePosition)
+        return isinstance(self.parts[-1].end, AfterPosition)
+
+    def has_ambiguous_start(self) -> bool:
+        """ Checks if the location has an ambiguous start.
+
+            Returns:
+                whether the start is ambiguous
+        """
+        if self.strand == -1:
+            return isinstance(self.parts[0].end, AfterPosition)
+        return isinstance(self.parts[0].start, BeforePosition)
+
 
 class FeatureLocation(_LocationMixin, _SimpleLocation):
     """ A wrapper of biopython's SimpleLocation (previously FeatureLocation) to add extra

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -328,6 +328,31 @@ class TestProteinPositionConversion(unittest.TestCase):
         assert new == expected
         assert len(new) < length * 3
 
+    def test_ambiguous_completely_outside_forward(self):
+        original = CompoundLocation([
+            FeatureLocation(BeforePosition(0), 2, 1),
+            FeatureLocation(3, 6, 1),
+        ])
+        # the protein start and end are both in the truncated/ambiguous section
+        protein_start = 3
+        protein_end = 7
+        protein_length = 10
+        expected = FeatureLocation(BeforePosition(0), BeforePosition(0), 1)
+        new = self.func(protein_start, protein_end, original, protein_length=protein_length)
+        assert new == expected
+
+    def test_ambiguous_completely_outside_reverse(self):
+        original = CompoundLocation([
+            FeatureLocation(8, AfterPosition(10), -1),
+            FeatureLocation(3, 6, -1),
+        ])
+        protein_start = 1
+        protein_end = 2
+        protein_length = 10
+        expected = FeatureLocation(AfterPosition(10), AfterPosition(10), -1)
+        new = self.func(protein_start, protein_end, original, protein_length=protein_length)
+        assert new == expected
+
     def test_ambiguous_end_reverse(self):
         original = CompoundLocation([
             FeatureLocation(40, 50, -1),

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -40,6 +40,66 @@ from antismash.common.secmet.locations import (
 )
 
 
+class TestAmbiguity(unittest.TestCase):
+    def test_compound(self):
+        CL = CompoundLocation
+        FL = FeatureLocation
+
+        location = CL([FL(BeforePosition(5), 7, 1), FL(10, 13, 1)])
+        assert location.has_ambiguous_start()
+        assert not location.has_ambiguous_end()
+
+        location = CL([FL(4, 7, 1), FL(10, AfterPosition(12), 1)])
+        assert not location.has_ambiguous_start()
+        assert location.has_ambiguous_end()
+
+        location = CL([FL(10, 13, -1), FL(BeforePosition(5), 7, -1)])
+        assert not location.has_ambiguous_start()
+        assert location.has_ambiguous_end()
+
+        location = CL([FL(10, AfterPosition(12), -1), FL(4, 7, -1),])
+        assert location.has_ambiguous_start()
+        assert not location.has_ambiguous_end()
+
+    def test_forward_simple(self):
+        FL = FeatureLocation
+
+        location = FL(4, 7, 1)
+        assert not location.has_ambiguous_start()
+        assert not location.has_ambiguous_end()
+
+        location = FL(BeforePosition(5), 7, 1)
+        assert location.has_ambiguous_start()
+        assert not location.has_ambiguous_end()
+
+        location = FL(4, AfterPosition(6), 1)
+        assert not location.has_ambiguous_start()
+        assert location.has_ambiguous_end()
+
+        location = FL(BeforePosition(5), AfterPosition(6), 1)
+        assert location.has_ambiguous_start()
+        assert location.has_ambiguous_end()
+
+    def test_reverse_simple(self):
+        FL = FeatureLocation
+
+        location = FL(4, 7, -1)
+        assert not location.has_ambiguous_start()
+        assert not location.has_ambiguous_end()
+
+        location = FL(4, AfterPosition(6), -1)
+        assert location.has_ambiguous_start()
+        assert not location.has_ambiguous_end()
+
+        location = FL(BeforePosition(5), 7, -1)
+        assert not location.has_ambiguous_start()
+        assert location.has_ambiguous_end()
+
+        location = FL(BeforePosition(5), AfterPosition(6), -1)
+        assert location.has_ambiguous_start()
+        assert location.has_ambiguous_end()
+
+
 class TestConnectLocations(unittest.TestCase):
     def setUp(self):
         self.func = connect_locations

--- a/antismash/common/secmet/test/test_locations.py
+++ b/antismash/common/secmet/test/test_locations.py
@@ -100,6 +100,79 @@ class TestAmbiguity(unittest.TestCase):
         assert location.has_ambiguous_end()
 
 
+class TestCloningWithoutAmbiguity(unittest.TestCase):
+    def compare(self, first, second):
+        assert first.parts is not second.parts
+        assert len(first.parts) == len(second.parts)
+        for f, s in zip(first.parts, second.parts):
+            assert isinstance(s.start, type(f.start))
+            assert f.start == s.start
+            assert isinstance(s.end, type(f.end))
+            assert f.end == s.end
+            assert f.strand == s.strand
+
+    def test_simple(self):
+        before = FeatureLocation(BeforePosition(5), AfterPosition(7), 1)
+        cloned = before.clone_without_ambiguity()
+        self.compare(cloned, FeatureLocation(5, 7, 1))
+        cloned = before.clone_without_ambiguity(keep_start=True)
+        self.compare(cloned, FeatureLocation(before.start, 7, 1))
+        cloned = before.clone_without_ambiguity(keep_end=True)
+        self.compare(cloned, FeatureLocation(5, before.end, 1))
+        cloned = before.clone_without_ambiguity(keep_start=True, keep_end=True)
+        self.compare(cloned, before)
+
+    def test_simple_reverse(self):
+        before = FeatureLocation(BeforePosition(5), AfterPosition(7), -1)
+        cloned = before.clone_without_ambiguity()
+        self.compare(cloned, FeatureLocation(5, 7, -1))
+        cloned = before.clone_without_ambiguity(keep_start=True)
+        self.compare(cloned, FeatureLocation(5, AfterPosition(7), -1))
+        cloned = before.clone_without_ambiguity(keep_end=True)
+        self.compare(cloned, FeatureLocation(BeforePosition(5), 7, -1))
+        cloned = before.clone_without_ambiguity(keep_start=True, keep_end=True)
+        self.compare(cloned, before)
+
+    def test_compound(self):
+        before = CompoundLocation([
+            FeatureLocation(BeforePosition(5), 7, 1),
+            FeatureLocation(10, AfterPosition(12), 1),
+        ])
+        cloned = before.clone_without_ambiguity()
+        self.compare(cloned, CompoundLocation([
+            FeatureLocation(5, 7, 1),
+            FeatureLocation(10, 12, 1),
+        ]))
+        cloned = before.clone_without_ambiguity(keep_start=True)
+        self.compare(cloned, CompoundLocation([
+            before.parts[0],
+            FeatureLocation(10, 12, 1),
+        ]))
+        cloned = before.clone_without_ambiguity(keep_end=True)
+        self.compare(cloned, CompoundLocation([
+            FeatureLocation(5, 7, 1),
+            before.parts[1],
+        ]))
+        cloned = before.clone_without_ambiguity(keep_start=True, keep_end=True)
+        self.compare(cloned, before)
+
+        # and checking reverse strand still detects the correct coordinates
+        before = CompoundLocation([
+            FeatureLocation(10, AfterPosition(12), -1),
+            FeatureLocation(BeforePosition(5), 7, -1),
+        ])
+        cloned = before.clone_without_ambiguity(keep_start=True)
+        self.compare(cloned, CompoundLocation([
+            before.parts[0],
+            FeatureLocation(5, 7, -1),
+        ]))
+        cloned = before.clone_without_ambiguity(keep_end=True)
+        self.compare(cloned, CompoundLocation([
+            FeatureLocation(10, 12, -1),
+            before.parts[1],
+        ]))
+
+
 class TestConnectLocations(unittest.TestCase):
     def setUp(self):
         self.func = connect_locations

--- a/antismash/common/subprocessing/memesuite.py
+++ b/antismash/common/subprocessing/memesuite.py
@@ -32,7 +32,7 @@ class FIMOMotif:
         kwargs: dict[str, Union[str, int, float]] = {}
         for part, field in zip(parts, fields(cls)):
             if field.type in (int, float):
-                part = field.type(part or 0)
+                part = field.type(part or 0)  # type: ignore  # mypy still thinks field.type can be 'str'
             kwargs[field.name] = part
         try:
             return cls(**kwargs)  # type: ignore  # this is validated above and mypy can't handle it

--- a/antismash/common/test/test_gff_parser.py
+++ b/antismash/common/test/test_gff_parser.py
@@ -167,6 +167,13 @@ class TestSplitLocation(TestCase):
         with self.assertRaisesRegex(errors.AntismashInputError, "entirely outside record"):
             self.split(10)
 
+    def test_at_edge(self):
+        original = FeatureLocation(20, 30, 1)
+        self.feature.location = original
+        self.split(30)
+        assert self.feature.location is not original
+        assert self.feature.location == original
+
     def test_simple_all_before_point(self):
         original = FeatureLocation(1, 5, 1)
         self.feature.location = original

--- a/antismash/config/args.py
+++ b/antismash/config/args.py
@@ -11,7 +11,11 @@ import argparse
 from collections import defaultdict
 import multiprocessing
 import os
-from typing import Any, AnyStr, Dict, IO, List, Optional, Set, Tuple
+from typing import Any, AnyStr, Dict, IO, List, Optional, Set, Tuple, TYPE_CHECKING
+if TYPE_CHECKING:
+    from _typeshed import SupportsWrite
+else:
+    SupportsWrite = IO
 
 from antismash.custom_typing import AntismashModule
 
@@ -73,7 +77,7 @@ class AntismashParser(argparse.ArgumentParser):
         return super().add_argument_group(title, description, **kwargs)
 # pylint: enable=arguments-differ
 
-    def print_help(self, file: IO = None, show_all: bool = False
+    def print_help(self, file: SupportsWrite[str] = None, show_all: bool = False
                    ) -> None:
         """ Overrides parent print_help() to be able to pass through whether all
             help should be shown or not.

--- a/antismash/detection/hmm_detection/cluster_rules/relaxed.txt
+++ b/antismash/detection/hmm_detection/cluster_rules/relaxed.txt
@@ -27,7 +27,7 @@ RULE transAT-PKS-like
     SUPERIORS transAT-PKS
     CUTOFF 45
     NEIGHBOURHOOD 20
-    CONDITIONS cds(ATd and (PKS_KS or ene_KS or mod_KS or hyb_KS or itr_KS or tra_KS) and not PKS_AT)
+    CONDITIONS cds(ATd and ANY_KS and not PKS_AT)
 
 RULE RiPP-like
     CATEGORY RiPP

--- a/antismash/detection/hmm_detection/data/hmmdetails.txt
+++ b/antismash/detection/hmm_detection/data/hmmdetails.txt
@@ -375,7 +375,7 @@ alpha_am_amid	L-aminoadipate-semialdehyde dehydrogenase	1030	TIGR03443.hmm
 bTGT	homodimeric bacterial tRNA-guanine transglycosylases	22	bTGT.hmm
 delta9_cd03505	delta9 desaturase	22	delta9_cd03505.hmm
 delta12_cd03507	delta12 desaturase	22	delta12_cd03507.hmm
-FAAL_cd05931	FAAL	20	FAAL_cd05931.hmm
+FAAL_cd05931	FAAL	500	FAAL_cd05931.hmm
 PP-binding_2	Acyl-carrier	10	PF14573.hmm
 Thioesterase	Thioesterase domain	26	PF00975.hmm
 LPG_synthase_C	Phosphatidylglycerol lysyltransferase, C-terminal	27	PF09924.hmm

--- a/antismash/detection/hmm_detection/filterhmmdetails.txt
+++ b/antismash/detection/hmm_detection/filterhmmdetails.txt
@@ -1,4 +1,4 @@
-PKS_KS,bt1fas,ft1fas,hglD,hglE,fabH,t2fas,t2clf,t2ks,t2pks2,Chal_sti_synt_N,Chal_sti_synt_C,APE_KS1,APE_KS2,DarB,FabF,ksIII,hr-t2pks-ksa,PUFA_KS
+PKS_KS,bt1fas,ft1fas,hglD,hglE,fabH,t2fas,t2clf,t2ks,t2pks2,Chal_sti_synt_N,Chal_sti_synt_C,APE_KS1,APE_KS2,DarB,FabF,ksIII,hr-t2pks-ksa,PUFA_KS,itr_KS,ene_KS,mod_KS,hyb_KS,tra_KS
 AMP-binding,A-OX,novH,mitE
 Antimicr18,Gallidermin,L_biotic_A,TIGR03731,leader_d,leader_eh,leader_abc,mature_d,mature_ab,mature_a,mature_b,mature_ha,mature_h_beta,lacticin_l,lacticin_mat,strepbact,Antimicrobial14,Bacteriocin_IIc,Bacteriocin_IId,BacteriocIIc_cy,Bacteriocin_II,Bacteriocin_IIi,Lactococcin,Antimicrobial17,Lactococcin_972,LcnG-beta,Subtilosin_A,Cloacin,Linocin_M18,TIGR03651,TIGR03678,TIGR03693,TIGR03798,TIGR03882,TIGR03601,TIGR03602,mvnA,thiostrepton
 Glycos_transf_1,Glycos_transf_2,Glyco_transf_28,MGT,DUF1205,Glyco_transf_9,Bac_transf,Glycos_transf_4,Glyco_transf_8,Glyco_tran_28_C,Glyco_transf_8C

--- a/antismash/detection/sideloader/data_structures.py
+++ b/antismash/detection/sideloader/data_structures.py
@@ -4,6 +4,7 @@
 """ Results classes for the sideloader module
 """
 
+from abc import ABC as AbstractBaseClass, abstractmethod
 import dataclasses
 from typing import Any, Dict, List, Union
 
@@ -68,7 +69,14 @@ class Tool:
         )
 
 
-class SubRegionAnnotation:
+class _AreaAnnotation(AbstractBaseClass):
+    @abstractmethod
+    def build_location(self) -> Location:
+        """ Constructs a location object from the sideloaded details """
+        raise NotImplementedError
+
+
+class SubRegionAnnotation(_AreaAnnotation):
     """ A class for containing arbitrary data about a sideloaded subregion annotation """
     kind = "subregion"
 
@@ -143,7 +151,7 @@ class SubRegionAnnotation:
         return f"Subregion({self.tool.name}, {self.start}-{self.end}, {self.label})"
 
 
-class ProtoclusterAnnotation:
+class ProtoclusterAnnotation(_AreaAnnotation):
     """ A class for containing arbitrary data about a sideloaded protocluster annotation """
     kind = "protocluster"
 

--- a/antismash/main.py
+++ b/antismash/main.py
@@ -41,7 +41,7 @@ from antismash.outputs import html
 from antismash.support import genefinding
 from antismash.custom_typing import AntismashModule
 
-__version__ = "8.0.2"
+__version__ = "8.0.3"
 
 
 def _gather_analysis_modules() -> List[AntismashModule]:

--- a/antismash/modules/nrps_pks/nrpys.py
+++ b/antismash/modules/nrps_pks/nrpys.py
@@ -65,10 +65,16 @@ def check_prereqs(options: ConfigType) -> list[str]:
     failure_messages: list[str] = []
     if "mounted_at_runtime" in options.database_dir:  # can't prepare this one
         return failure_messages
-    datafile_path = _get_signature_path(options, minimum_version=MINIMUM_VERSION)
+    try:
+        datafile_path = _get_signature_path(options, minimum_version=MINIMUM_VERSION)
+    except ValueError:
+        datafile_path = ""
     if not os.path.exists(datafile_path):
         failure_messages.append(f"Failed to locate {datafile_path}")
-    model_dir = _get_model_dir(options)
+    try:
+        model_dir = _get_model_dir(options)
+    except ValueError:
+        model_dir = ""
     if not os.path.exists(model_dir):
         failure_messages.append(f"Failed to locate {model_dir}")
     return failure_messages

--- a/antismash/modules/nrps_pks/orderfinder.py
+++ b/antismash/modules/nrps_pks/orderfinder.py
@@ -472,12 +472,13 @@ def find_colinear_order(cds_features: List[CDSFeature]) -> List[CDSFeature]:
     subgroups = [[cds_features[0]]]
     current_subgroup = subgroups[-1]
 
-    direction = 0
+    direction = cds_features[0].strand
     for gene in cds_features[1:]:
         direction += gene.strand
         # if the first module of a cds has a cross-cds module, then
         # the previous CDS' last module is also cross-cds module, regardless of direction
-        if gene.modules and len(gene.modules[0].parent_cds_names) > 1:
+        cross_cds = gene.modules and gene.modules[0].is_multigene_module()
+        if cross_cds and gene.modules[0] is current_subgroup[-1].modules[-1]:
             current_subgroup.append(gene)
         else:  # no need to check the end, since the next CDS will be found at the start
             subgroups.append([gene])

--- a/antismash/modules/nrps_pks/templates/monomers.html
+++ b/antismash/modules/nrps_pks/templates/monomers.html
@@ -18,14 +18,19 @@
       {% for domain in record.get_cds_by_name(gene_id).nrps_pks.domains %}
         {% if domain.feature_name in results.consensus %}
           <div><strong>{{domain.name}} ({{domain.start}}..{{domain.end}})</strong>: {{results.consensus[domain.feature_name]}}
+          {%- set predictions = results.domain_predictions.get(domain.feature_name, {}).values() -%}
           {{collapser_start(gene_id, level="candidate")}}
-          {% for prediction in results.domain_predictions.get(domain.feature_name, {}).values() %}
+          {%- if not predictions -%}
+          No predictions made
+          {%- else -%}
+          {% for prediction in predictions %}
               {{prediction.method}}:  {{prediction.get_classification() | join(", ") or "(unknown)"}}
               {{collapser_start(gene_id + "-" + prediction.method, level="none")}}
                 {{prediction.as_html()}}
               {{collapser_end()}}<br>
           {% endfor %}
           {{collapser_end()}}
+          {%- endif -%}
           </div>
         {% endif %}
       {% endfor %}

--- a/antismash/outputs/html/visualisers/nrps_pks_domains.py
+++ b/antismash/outputs/html/visualisers/nrps_pks_domains.py
@@ -168,13 +168,12 @@ def _build_paras_link(cds: CDSFeature, domain: NRPSPKSQualifier.Domain, signatur
     return f'<a class="external-link" href="{ link }" target="_blank">Repredict substrate with PARAS</a>'
 
 
-def _parse_domain(record: Record, domain: NRPSPKSQualifier.Domain,
+def _parse_domain(domain: NRPSPKSQualifier.Domain,
                   feature: CDSFeature, signature: str = "",
                   ) -> JSONDomain:
     """ Convert a NRPS/PKS domain string to a dict useable by json.dumps
 
         Arguments:
-            record: the Record containing the domain
             domain: the NRPSPKSQualifier.Domain in question
             feature: the CDSFeature that the domain belongs to
             signature: the extracted signature of the domain, if any, for linking out
@@ -203,11 +202,6 @@ def _parse_domain(record: Record, domain: NRPSPKSQualifier.Domain,
         extra_links.append(_build_paras_link(feature, domain, signature))
 
     dna_sequence = ""
-    for as_domain in record.get_antismash_domains_in_cds(feature):
-        if as_domain.get_name() == domain.feature_name:
-            dna_sequence = as_domain.extract(record.seq)
-            break
-    assert dna_sequence
     css, abbreviation = get_css_class_and_abbreviation(domain.name)
     return JSONDomain.from_domain(
         domain, predictions, napdoslink, blastlink, domainseq, dna_sequence,
@@ -261,7 +255,7 @@ def domains_have_predictions(region: Union[Region, RegionLayer]) -> bool:
     return False
 
 
-def generate_javascript_data(record: Record, region: Region,
+def generate_javascript_data(record: Record, region: Region,  # standard interface, so pylint: disable=unused-argument
                              results: dict[str, ModuleResults]) -> dict[str, Any]:
     """ Generate the javascript data required for interactive visualisation """
     orfs: list[JSONOrf] = []
@@ -292,7 +286,7 @@ def generate_javascript_data(record: Record, region: Region,
             if signatures:
                 assert isinstance(signatures, nrps_pks.results.PredictorSVMResult)
                 signature = signatures.aa34
-            parsed = _parse_domain(record, domain, feature, signature)
+            parsed = _parse_domain(domain, feature, signature)
             js_orf.add_domain(parsed)
 
         for module in feature.modules:

--- a/antismash/outputs/html/visualisers/nrps_pks_domains.py
+++ b/antismash/outputs/html/visualisers/nrps_pks_domains.py
@@ -177,6 +177,7 @@ def _parse_domain(record: Record, domain: NRPSPKSQualifier.Domain,
             record: the Record containing the domain
             domain: the NRPSPKSQualifier.Domain in question
             feature: the CDSFeature that the domain belongs to
+            signature: the extracted signature of the domain, if any, for linking out
 
         Returns:
             a populated JSONDomain instance

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ tests_require = [
     'pytest >= 7.2.0, < 8',
     'coverage',
     'pylint == 3.0.2',
-    'mypy == 1.9.0',  # for consistent type checking
+    'mypy == 1.17.1',  # for consistent type checking
 ]
 
 


### PR DESCRIPTION
Prepares for the 8.0.3 release by pulling in, from master, bug fixes and handling changes for previously rejected inputs.

Some cluster predictions will change due to some of the bug fixes, but the rules remain unchanged.