### PR TITLE
nrps_pks: fix unclosed collapser in substrate sidepanel

### DIFF
--- a/antismash/modules/nrps_pks/templates/monomers.html
+++ b/antismash/modules/nrps_pks/templates/monomers.html
@@ -29,8 +29,8 @@
                 {{prediction.as_html()}}
               {{collapser_end()}}<br>
           {% endfor %}
-          {{collapser_end()}}
           {%- endif -%}
+          {{collapser_end()}}
           </div>
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
Any NRPS A domain that was so strange the prediction tools had nothing to offer were changed to report "No prediction made" as of 0137795e1b5c2da086a4e74ea488dc84a63d6ae5, instead of just a blank section.

I screwed up with the placement of the conditional, which meant the collapser for that scenario had an unclosed div, which in turn removed all displayed results for regions after the one with no prediction. This also caused javascript crashes when ClusterCompare had results for that region and the following regions, due to the selection logic used and assumptions that region elements weren't nested.