### PR TITLE
clusterblast: cache protein metadata and load lazily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ antismash/detection/genefunctions/tools/halogenases/data/FDH.hmm
 antismash/databases/*
 antismash/modules/*/data/*.classifier.pkl
 antismash/modules/*/data/*.scaler.pkl
+antismash/modules/clusterblast/data/sub/proteins.json
+antismash/modules/clusterblast/test/data/**/proteins.json
 antismash/modules/terpene/data/all_profiles.hmm
 antismash/outputs/html/js/antismash.js
 antismash.egg-info/*

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ integration: clean
 clean:
 	rm -f antismash/detection/hmm_detection/data/bgc_seeds.hmm*
 	rm -f antismash/modules/clusterblast/test/data/*/*.dmnd
+	find antismash/modules/clusterblast/test/data -name '*.json' -exec rm {} +
 	rm -f antismash/outputs/html/css/*.css
 	find antismash -name "*.scaler.pkl" -o -name "*.classifier.pkl" -exec rm {} +
 	find . -name "*.h3?" -exec rm {} +

--- a/antismash/modules/clusterblast/__init__.py
+++ b/antismash/modules/clusterblast/__init__.py
@@ -19,7 +19,7 @@ from .clusterblast import perform_clusterblast
 from .html_output import generate_html, generate_javascript_data, will_handle
 from .known import run_knownclusterblast_on_record, check_known_prereqs, prepare_known_data
 from .results import ClusterBlastResults, get_result_limit
-from .sub import run_subclusterblast_on_record, check_sub_prereqs
+from .sub import check_sub_prereqs, prepare_sub_data, run_subclusterblast_on_record
 
 NAME = "clusterblast"
 SHORT_DESCRIPTION = "comparative gene cluster analysis"
@@ -118,6 +118,9 @@ def prepare_data(logging_only: bool = False) -> List[str]:
     failure_messages = []
     # known
     failure_messages.extend(prepare_known_data(logging_only))
+
+    # sub
+    failure_messages.extend(prepare_sub_data(logging_only=logging_only))
 
     # general
     clusterblastdir = os.path.join(get_config().database_dir, "clusterblast")

--- a/antismash/modules/clusterblast/clusterblast.py
+++ b/antismash/modules/clusterblast/clusterblast.py
@@ -17,13 +17,13 @@ from .core import (
     run_diamond_on_all_regions,
     score_clusterblast_output,
 )
-from .data_structures import ReferenceCluster, Protein
+from .data_structures import ProteinDB, ReferenceCluster
 from .results import RegionResult, GeneralResults
 
 
 def perform_clusterblast(options: ConfigType, record: Record,
                          db_clusters: Dict[str, ReferenceCluster],
-                         db_proteins: Dict[str, Protein]) -> GeneralResults:
+                         db_proteins: ProteinDB) -> GeneralResults:
     """ Run BLAST on gene cluster proteins for each cluster, parse output and
         return result rankings for each cluster
 
@@ -31,7 +31,7 @@ def perform_clusterblast(options: ConfigType, record: Record,
             options: antismash Config
             record: the Record to analyse
             db_clusters: a dict mapping reference cluster name to ReferenceCluster
-            db_proteins: a dict mapping reference protein name to Protein
+            db_proteins: the protein database
 
         Returns:
             a GeneralResults instance with results for each cluster in the record

--- a/antismash/modules/clusterblast/known.py
+++ b/antismash/modules/clusterblast/known.py
@@ -22,7 +22,7 @@ from .core import (
     score_clusterblast_output,
 )
 from .results import RegionResult, GeneralResults
-from .data_structures import MibigEntry, ReferenceCluster, Protein
+from .data_structures import MibigEntry, ProteinDB, ReferenceCluster
 
 
 def _get_datafile_path(filename: str, config: ConfigType) -> str:
@@ -95,7 +95,7 @@ def run_knownclusterblast_on_record(record: Record, options: ConfigType) -> Gene
 
 def perform_knownclusterblast(options: ConfigType, record: Record,
                               reference_clusters: Dict[str, ReferenceCluster],
-                              proteins: Dict[str, Protein]) -> GeneralResults:
+                              proteins: ProteinDB) -> GeneralResults:
     """ Run BLAST on gene cluster proteins of each cluster, parse output and
         return result rankings for each cluster
 

--- a/antismash/modules/clusterblast/results.py
+++ b/antismash/modules/clusterblast/results.py
@@ -15,7 +15,16 @@ from antismash.common.path import changed_directory
 from antismash.common.secmet import Record, Region
 from antismash.config import ConfigType, get_config
 
-from .data_structures import Score, Query, Subject, ReferenceCluster, Protein, MibigEntry
+from .data_structures import (
+    MibigEntry,
+    Protein,
+    ProteinDB,
+    ProteinMapping,
+    Query,
+    ReferenceCluster,
+    Score,
+    Subject,
+)
 
 _CLUSTER_LIMIT = 50
 
@@ -70,7 +79,7 @@ class RegionResult:
     __slots__ = ["region", "ranking", "total_hits", "prefix", "displayed_reference_proteins"]
 
     def __init__(self, region: Region, ranking: List[Tuple[ReferenceCluster, Score]],
-                 reference_proteins: Dict[str, Protein], prefix: str) -> None:
+                 reference_proteins: ProteinMapping, prefix: str) -> None:
         """ Arguments:
                 cluster: the cluster feature
                 ranking: a list of tuples in the form (ReferenceCluster, Score)
@@ -196,7 +205,7 @@ class GeneralResults(ModuleResults):
         self.data_version: Optional[str] = data_version
 
     def add_region_result(self, result: RegionResult, reference_clusters: Dict[str, ReferenceCluster],
-                          reference_proteins: Dict[str, Protein]) -> None:
+                          reference_proteins: ProteinDB) -> None:
         """ Add a result for a specific cluster. Reference proteins and clusters
             required in order to write the relevant information. Only those used
             are required.
@@ -204,7 +213,7 @@ class GeneralResults(ModuleResults):
             Arguments:
                 result: the RegionResult to add
                 reference_clusters: a dictionary mapping reference cluster name to ReferenceCluster
-                reference_proteins: a dictionary mapping reference protein name to Protein
+                reference_proteins: a protein database
 
             Returns:
                 None


### PR DESCRIPTION
The clusterblast dataset is loaded once for every record in the input. This has become quite time expensive as the database has increased in size. It also affects metagenomic and fragmented assemblies much more significantly than higher quality assemblies.

The upcoming antiSMASH-database v5 is roughly twice the size of v4, which was going to exacerbate this issue.

On my machine, the time to read in the protein metadata was around 35-40 seconds for v4 (again, once per record in the input).

Pre-preparing a JSON file containing protein metadata that is embedded in the FASTA file means that the full read of the FASTA can be skipped and a simpler JSON read used. Loading the JSON by itself takes around 8 seconds, but there is still an overhead as the creation of a `Protein` instance for 5 million entries also takes some time.

By creating `ProteinDB` that contains the raw data and only converts to `Protein` instances when a specific entry is fetched, the load time is significantly reduced at the cost of a slight overhead for the extra checks when accessing the entries.

That lazy conversion overhead for a whole chromosome still results in the full timing being 20 seconds. For very small record with few regions, the timing is closer to the raw 8 seconds. For an input with a single cluster, the whole of clusterblast took 22 seconds, which includes running diamond.

Another advantage of this method is that the memory use drops. While a `Protein` instance is about 1.5 KB (even with `__slots__`) that's still 7.5 GB for aSDB v4. With v5 doubling the number of entries, this would prevent any machine with 16 GB of RAM from running clusterblast. Since raw dictionaries are smaller, the initial size of `ProteinDB` is roughly 2.2 GB, growing to around 2.7 GB when used on a full chromosome.

The end result is that clusterblast now uses (on my machine) 50% or less of the time to load the database, while using only 30-50% of the memory for the vast majority of inputs. This should keep performance roughly the same for aSDB v5 as it is currently for v4 in the average case.