### PR TITLE
common.hmmer: skip running hmmscan if no features provided

### DIFF
--- a/antismash/common/hmmer.py
+++ b/antismash/common/hmmer.py
@@ -317,6 +317,8 @@ def run_hmmer(record: Record, features: Iterable[CDSFeature], max_evalue: float,
     """
     if not os.path.exists(database):
         raise ValueError(f"Given database does not exist: {database}")
+    if not features:
+        return HmmerResults(record.id, max_evalue, min_score, database, tool, hits=[])
     query_sequence = fasta.get_fasta_from_features(features)
     opts: List[str] = []
     if use_cut_tc:

--- a/antismash/common/test/test_hmmer.py
+++ b/antismash/common/test/test_hmmer.py
@@ -11,7 +11,7 @@ from tempfile import NamedTemporaryFile
 import unittest
 from unittest.mock import patch
 
-from antismash.common import hmmer, json
+from antismash.common import hmmer, json, subprocessing
 from antismash.common.hmmer import (
     ensure_database_pressed,
     HmmerHit,
@@ -246,3 +246,14 @@ class TestPressed(unittest.TestCase):
     def test_caught(self):
         with self.assertRaisesRegex(ValueError, "set to mount at runtime"):
             ensure_database_pressed("/path/mounted_at_runtime/pfam")
+
+
+class TestRunner(unittest.TestCase):
+    def test_empty_features(self):
+        record = DummyRecord()
+        with patch.object(subprocessing.hmmscan, "run_hmmscan") as patched:
+            with patch.object(os.path, "exists", return_value=True):
+                results = hmmer.run_hmmer(record, features=[], max_evalue=1.,
+                                          min_score=0, database="", tool="dummy")
+            patched.assert_not_called()
+        assert not results.hits


### PR DESCRIPTION
Fixes #864, erroring out on reuse of empty records with cluster-/full-hmmer enabled, by adding an early return to `antismash.common.hmmer.run_hmmer()`. The existing call goes through to `common.subprocessing`, which considers it an error to provide no sequence.

While this doesn't address the larger question of how to respect skip states of records from previous runs, where the use of `--limit-to` and `--genefinding-*` aren't treated the same way, it will stop the crash.