### PR TITLE
genefinding: Allow using the record ID as locus tag base name

### DIFF
--- a/antismash/support/genefinding/__init__.py
+++ b/antismash/support/genefinding/__init__.py
@@ -40,6 +40,11 @@ def get_arguments() -> ModuleArgs:
                     type=str,
                     metavar="GFF3_FILE",
                     help="Specify GFF3 file to extract features from.")
+    args.add_option('use-record-id',
+                    dest='use_record_id',
+                    default=False,
+                    action="store_true",
+                    help="Use the record ID as basis for locus tags on found genes.")
     return args
 
 
@@ -95,6 +100,6 @@ def run_on_record(record: Record, options: ConfigType) -> None:
 
     if options.genefinding_tool in ["prodigal", "prodigal-m"]:
         logging.debug("Running prodigal based genefinding")
-        return run_prodigal(record)
+        return run_prodigal(record, options.genefinding_use_record_id)
 
     raise ValueError(f"Unknown genefinding tool: {options.genefinding_tool}")

--- a/antismash/support/genefinding/prodigal.py
+++ b/antismash/support/genefinding/prodigal.py
@@ -65,7 +65,7 @@ def _filter_genes(genes_found: Iterable[ProdigalGene], record: Record) -> Iterab
     return locations
 
 
-def run_prodigal(record: Record) -> None:
+def run_prodigal(record: Record, use_record_id: bool = False) -> None:
     """ Run progidal to annotate prokaryotic sequences
     """
 
@@ -84,7 +84,11 @@ def run_prodigal(record: Record) -> None:
     count = 0
     for location in locations:
         translation = record.get_aa_translation_from_location(location)
-        feature = CDSFeature(location, locus_tag=f"ctg{record.record_index}_{count + 1}",
+        if use_record_id:
+            tag = f"{record.id}_{count + 1}"
+        else:
+            tag = f"ctg{record.record_index}_{count + 1}"
+        feature = CDSFeature(location, locus_tag=tag,
                              translation=translation, translation_table=record.transl_table)
         record.add_cds_feature(feature)
         count += 1

--- a/antismash/support/genefinding/test/test_genefinding.py
+++ b/antismash/support/genefinding/test/test_genefinding.py
@@ -18,6 +18,7 @@ class TestCore(unittest.TestCase):
         options = Namespace()
         options.taxon = 'bacteria'
         options.genefinding_tool = "none"
+        options.genefinding_use_record_id = False
         assert not check_options(options)
 
         options.taxon = 'fungi'
@@ -31,6 +32,7 @@ class TestCore(unittest.TestCase):
         options.taxon = 'bacteria'
         options.genefinding_tool = 'none'
         options.genefinding_gff3 = False
+        options.genefinding_use_record_id = False
         assert not is_enabled(options)
 
         options.genefinding_tool = 'prodigal'
@@ -48,6 +50,7 @@ class TestCore(unittest.TestCase):
         record = FakeRecord()
         options = Namespace()
         options.genefinding_tool = "none"
+        options.genefinding_use_record_id = False
 
         for taxon in ("fungi", "bacteria"):
             options.taxon = taxon

--- a/antismash/support/genefinding/test/test_prodigal.py
+++ b/antismash/support/genefinding/test/test_prodigal.py
@@ -53,3 +53,27 @@ class TestProdigal(unittest.TestCase):
         with patch.object(prodigal, "MAX_SEQUENCE_LENGTH", max_len):
             with self.assertRaisesRegex(ValueError, "too long"):
                 prodigal.run_prodigal(record)
+
+    def test_default_id(self):
+        record = DummyRecord(record_id="DUMMY", seq="ATGGCAGGGATATGTTAG")
+        with patch.object(prodigal, "exec_prodigal", lambda _x: []), \
+             patch.object(prodigal, "_filter_genes", dummy_filter):
+            prodigal.run_prodigal(record, use_record_id=False)
+
+        features = record.get_cds_features()
+        assert len(features) == 1
+        assert features[0].get_name() == "ctg0_1"
+
+    def test_record_id(self):
+        record = DummyRecord(record_id="DUMMY", seq="ATGGCAGGGATATGTTAG")
+        with patch.object(prodigal, "exec_prodigal", lambda _x: []), \
+             patch.object(prodigal, "_filter_genes", dummy_filter):
+            prodigal.run_prodigal(record, use_record_id=True)
+
+        features = record.get_cds_features()
+        assert len(features) == 1
+        assert features[0].get_name() == "DUMMY_1"
+
+
+def dummy_filter(*_args):
+    return [FeatureLocation(0, 18, 1)]


### PR DESCRIPTION
The default naming scheme antiSMASH uses when running its own gene finding is building locus tags like `ctg{record.record_index}_{running_count}`, which works fine to create unique locus tags for any given run. However, if you want to combine outputs from multiple runs, e.g. in a database, you run into problems with duplicate locus tags.

This adds a `--genefinding-use-record-id` tag that makes the locus tags use `{record.id}_{running_count}` instead.