### PR TITLE
Fixes for missing/invalid main database directory

### DIFF
--- a/antismash/common/path.py
+++ b/antismash/common/path.py
@@ -134,8 +134,8 @@ def find_latest_database_version(database_dir: str, ignore_invalid: bool = False
         except ValueError:
             if ignore_invalid:
                 continue
-            raise ValueError(f"Incompatible database version naming: {name}")
+            raise ValueError(f"Incompatible database version naming: {version}")
     if not potentials:
-        raise ValueError(f"No matching database in location {database_dir}")
+        raise ValueError(f"No matching database in location '{database_dir}'")
     latest = sorted(potentials)[-1]
     return latest[1]

--- a/antismash/common/pfamdb.py
+++ b/antismash/common/pfamdb.py
@@ -208,6 +208,11 @@ def ensure_database_pressed(filepath: str, return_not_raise: bool = False) -> Li
             return [msg]
         raise ValueError(msg)
 
+    if not os.path.exists(filepath):
+        if return_not_raise:
+            return [f"base HMM database not found: {filepath}"]
+        raise FileNotFoundError(filepath)
+
     if path.is_outdated(components, filepath) or any(os.path.getsize(comp) == 0 for comp in components):
         logging.info("%s components missing or obsolete, re-pressing database", filepath)
         if "hmmpress" not in get_config().executables:

--- a/antismash/common/subprocessing/diamond.py
+++ b/antismash/common/subprocessing/diamond.py
@@ -223,6 +223,10 @@ def check_diamond_files(definition_file: str, fasta_file: str, db_file: str,
     elif path.is_outdated(db_file, fasta_file):
         regen_message = f"diamond database outdated: {db_file}"
 
+    # don't attempt database regeneration if there's already failures
+    if failure_messages:
+        return failure_messages
+
     if regen_message:
         try:
             logging.debug("%s, regenerating", regen_message)

--- a/antismash/common/test/test_pfamdb.py
+++ b/antismash/common/test/test_pfamdb.py
@@ -43,13 +43,13 @@ class TestPFAMs(unittest.TestCase):
             os.makedirs(os.path.join(temp_db_layout, "pfam", "invalid30.7"))
             os.makedirs(os.path.join(temp_db_layout, "pfam", "irrelevant"))
 
-            with self.assertRaisesRegex(Exception, f"No matching database in location {temp_db_layout}"):
+            with self.assertRaisesRegex(Exception, f"No matching database in location '{temp_db_layout}/pfam'"):
                 pfamdb.find_latest_database_version(temp_db_layout)
 
             with open(os.path.join(bad, "Pfam-A.hmm"), "w", encoding="utf-8") as handle:
                 handle.write("dummy text")
 
-            with self.assertRaisesRegex(Exception, f"Incompatible database .* {temp_db_layout}"):
+            with self.assertRaisesRegex(Exception, "Incompatible database .* 30.7invalid.*"):
                 pfamdb.find_latest_database_version(temp_db_layout)
 
         # start with a clean temp dir since the last is poisoned

--- a/antismash/detection/genefunctions/__init__.py
+++ b/antismash/detection/genefunctions/__init__.py
@@ -193,10 +193,6 @@ def check_prereqs(options: ConfigType) -> List[str]:
         if binary_name not in options.executables:
             failure_messages.append(f"Failed to locate file: {binary_name!r}")
 
-    database = os.path.join(options.database_dir, 'resfam', 'Resfams.hmm')
-    if "mounted_at_runtime" not in database and path.locate_file(database) is None:
-        failure_messages.append(f"Failed to locate Resfam database in {database!r}")
-
     # normally a module would check the data is prepared here,
     # but only tools currently have data, so prepare_data here would only duplicate those checks
 

--- a/antismash/detection/genefunctions/tools/mite.py
+++ b/antismash/detection/genefunctions/tools/mite.py
@@ -161,7 +161,7 @@ def check_prereqs(options: ConfigType) -> list[str]:
         available = False
         if get_dataset(options.genefunctions_mite_version):
             available = True
-    except (FileNotFoundError, RuntimeError):
+    except (FileNotFoundError, RuntimeError, ValueError):
         pass
 
     if not available:

--- a/antismash/detection/genefunctions/tools/resistance.py
+++ b/antismash/detection/genefunctions/tools/resistance.py
@@ -69,7 +69,8 @@ def prepare_data(logging_only: bool = False) -> list[str]:
     failures = []
     # account for database directories mounted into docker containers
     if "mounted_at_runtime" not in database:
-        failures.extend(hmmer.ensure_database_pressed(database, return_not_raise=logging_only))
+        for failure in hmmer.ensure_database_pressed(database, return_not_raise=logging_only):
+            failures.append(f"resistance: {failure}")
 
     return failures
 

--- a/antismash/detection/tigrfam/__init__.py
+++ b/antismash/detection/tigrfam/__init__.py
@@ -53,6 +53,7 @@ def check_prereqs(options: ConfigType) -> List[str]:
     tigr_db = os.path.join(options.database_dir, "tigrfam", "TIGRFam.hmm")
     if not path.locate_file(tigr_db):
         failure_messages.append(f"Failed to locate TIGRFam db in {os.path.join(options.database_dir, 'tigrfam')}")
+        return failure_messages
 
     failure_messages.extend(hmmer.ensure_database_pressed(tigr_db, return_not_raise=True))
 

--- a/antismash/modules/clusterblast/__init__.py
+++ b/antismash/modules/clusterblast/__init__.py
@@ -130,15 +130,17 @@ def prepare_data(logging_only: bool = False) -> List[str]:
     protein_seqs = os.path.join(clusterblastdir, "proteins.fasta")
     db_file = os.path.join(clusterblastdir, "proteins.dmnd")
 
+    failure_messages.extend(check_clusterblast_files(cluster_defs, protein_seqs, db_file, logging_only=logging_only))
+
+    # if there were errors, further checks won't help
+    if failure_messages:
+        return failure_messages
+
     # check the DBv3 region info exists instead of single cluster numbers
     with open(protein_seqs, encoding="utf-8") as handle:
         sample = handle.readline()
     if "-" not in sample.split("|", 3)[1]:
         failure_messages.append("clusterblast database out of date, update with download-databases")
-        # and don't bother pressing them
-        return failure_messages
-
-    failure_messages.extend(check_clusterblast_files(cluster_defs, protein_seqs, db_file, logging_only=logging_only))
 
     return failure_messages
 

--- a/antismash/modules/clusterblast/core.py
+++ b/antismash/modules/clusterblast/core.py
@@ -108,6 +108,11 @@ def check_clusterblast_files(cluster_path: str, fasta_path: str, diamond_path: s
             a list of error strings
     """
     failures = check_diamond_files(cluster_path, fasta_path, diamond_path, logging_only=logging_only)
+
+    # if there's already errors, further processing will fail anyway
+    if failures:
+        return failures
+
     try:
         build_protein_cache(fasta_path, json_path=cache_path)
     except OSError as err:

--- a/antismash/modules/clusterblast/known.py
+++ b/antismash/modules/clusterblast/known.py
@@ -70,10 +70,14 @@ def prepare_known_data(logging_only: bool = False) -> List[str]:
     config = get_config()
     if "mounted_at_runtime" in config.database_dir:
         return []
-    cluster_defs = _get_datafile_path("clusters.txt", config)
-    protein_seqs = _get_datafile_path("proteins.fasta", config)
-    db_file = _get_datafile_path("proteins.dmnd", config)
-    failure_messages.extend(check_clusterblast_files(cluster_defs, protein_seqs, db_file, logging_only=logging_only))
+    try:
+        cluster_defs = _get_datafile_path("clusters.txt", config)
+        protein_seqs = _get_datafile_path("proteins.fasta", config)
+        db_file = _get_datafile_path("proteins.dmnd", config)
+        failure_messages.extend(check_clusterblast_files(cluster_defs, protein_seqs,
+                                                         db_file, logging_only=logging_only))
+    except ValueError as err:
+        failure_messages.append(f"knownclusterblast: {err}")
 
     return failure_messages
 

--- a/antismash/modules/nrps_pks/nrpys.py
+++ b/antismash/modules/nrps_pks/nrpys.py
@@ -67,16 +67,18 @@ def check_prereqs(options: ConfigType) -> list[str]:
         return failure_messages
     try:
         datafile_path = _get_signature_path(options, minimum_version=MINIMUM_VERSION)
-    except ValueError:
-        datafile_path = ""
-    if not os.path.exists(datafile_path):
-        failure_messages.append(f"Failed to locate {datafile_path}")
+        if not os.path.exists(datafile_path):
+            failure_messages.append(f"Signature file not found '{datafile_path}'")
+    except ValueError as err:
+        failure_messages.append(f"nrpys: {err}")
+
     try:
         model_dir = _get_model_dir(options)
-    except ValueError:
-        model_dir = ""
-    if not os.path.exists(model_dir):
-        failure_messages.append(f"Failed to locate {model_dir}")
+        if not os.path.exists(model_dir):
+            failure_messages.append(f"Model directory not found '{model_dir}'")
+    except ValueError as err:
+        failure_messages.append(f"nrpys: {err}")
+
     return failure_messages
 
 

--- a/antismash/modules/nrps_pks/test/test_nrpys.py
+++ b/antismash/modules/nrps_pks/test/test_nrpys.py
@@ -281,5 +281,5 @@ class TestMisc(unittest.TestCase):
         stach_path = nrpys._get_signature_path(self.config)
         db_path = nrpys._get_model_dir(self.config)
         ret = nrpys.check_prereqs(self.config)
-        assert ret == [f"Failed to locate {stach_path}",
-                       f"Failed to locate {db_path}"]
+        assert ret == [f"Signature file not found '{stach_path}'",
+                       f"Model directory not found '{db_path}'"]


### PR DESCRIPTION
A number of modules and sub-modules crash out instead of nicely reporting issues when a database directory was missing or had missing contents. Other issues were also present, where attempts to prepare some data are made despite the base data not being present.