### PR TITLE
nrps_pks: fix crash when methylating single atom

### DIFF
--- a/antismash/modules/nrps_pks/smiles_generator.py
+++ b/antismash/modules/nrps_pks/smiles_generator.py
@@ -209,6 +209,11 @@ def methylate(smiles: str, variant: str) -> str:
     bonds = Bonds(smiles)
     atoms = list(bonds)
     start = 1
+    if len(atoms) == 1:
+        atom = atoms[0]
+        if atom.symbol == variant and atom.available_bonds > 0:
+            atom.branches.append([Atom("C")])
+        return bonds.to_smiles()
     if atoms[0].symbol == "N" and atoms[1].symbol == "C":
         start = 2  # skip the C too
     for atom in atoms[start:-1]:

--- a/antismash/modules/nrps_pks/test/test_smiles_generator.py
+++ b/antismash/modules/nrps_pks/test/test_smiles_generator.py
@@ -176,3 +176,11 @@ class TestMethylation:
     def test_last_o_skipped(self):
         smiles = "NC(CCCN)C(=O)O"
         assert methylate(smiles, "O") == smiles
+
+    def test_single_matched(self):
+        smiles = "N"
+        assert methylate(smiles, "N") == "N(C)"
+
+    def test_single_unmatched(self):
+        smiles = "N"
+        assert methylate(smiles, "C") == "N"


### PR DESCRIPTION
Fixes #899, caused by the methylation process assuming that there were always two atoms in the SMILES string.