### PR TITLE
Make it possible to not create html outputs without requiring `--minimal`

### DIFF
--- a/antismash/outputs/html/__init__.py
+++ b/antismash/outputs/html/__init__.py
@@ -87,8 +87,8 @@ def check_options(_options: ConfigType) -> List[str]:
 
 
 def is_enabled(options: ConfigType) -> bool:
-    """ Is the HMTL module enabled (currently always enabled) """
-    return options.html_enabled or not options.minimal
+    """ Is the HMTL module enabled """
+    return options.html_enabled
 
 
 def write(records: List[Record], results: List[Dict[str, ModuleResults]],

--- a/antismash/test/integration/integration_antismash.py
+++ b/antismash/test/integration/integration_antismash.py
@@ -27,7 +27,7 @@ class TestAntismash(unittest.TestCase):
         self.file_prefix = "nisin"
 
     def get_args(self):
-        return ["--minimal"]
+        return ["--minimal", "--no-enable-html"]
 
     def tearDown(self):
         destroy_config()


### PR DESCRIPTION
This is the HTML change part of #887.

It's not really correct in the current stage, as this version always turns off html output unless `--enable-html` is explicitly passed on the command line.

Just putting this here to split it out from #887 while iterating on it a bit more.