### PR TITLE
Declutter HTML overview

### DIFF
--- a/antismash/modules/clusterblast/html_output.py
+++ b/antismash/modules/clusterblast/html_output.py
@@ -22,7 +22,7 @@ from antismash.common.secmet import CDSFeature, Record, Region
 from antismash.config import get_config
 
 from .data_structures import ReferenceCluster, Protein, Query, Subject
-from .results import ClusterBlastResults
+from .results import ClusterBlastResults, KnownHitSummary
 from .svg_builder import build_colour_groups
 
 ASDB_URL = (
@@ -36,9 +36,46 @@ TITLE_GENERAL = "Similar known clusters"
 TITLE_KNOWN = f"{TITLE_GENERAL} from MIBiG %s"
 TITLE_SUB = "Similar subclusters"
 
+# categories in MIBiG that don't directly match to antiSMASH categories
+MIBIG_CATEGORY_MAPPING = {
+    "ribosomal": "RiPP",
+}
+# a similarity percentage above this needs no further checks
+MIBIG_CATEGORY_EXCEPTION_LIMIT = 50
+
 
 def will_handle(_products: List[str], _product_categories: Set[str]) -> bool:
     """ Relevant to every region, so return True for every product """
+    return True
+
+
+def is_good_enough(hit: KnownHitSummary | None, region: Region,
+                   bypass_threshold: int = MIBIG_CATEGORY_EXCEPTION_LIMIT,
+                   ) -> bool:
+    """ Checks if the MIBiG cluster types are present in the hit.
+
+        Arguments:
+            hit: the reference cluster data
+            region: the region to which the hit matched
+            bypass_threshold: a maximum similarity for which type checks should
+                              apply
+
+        Returns:
+            a boolean indicating whether the hit is good enough to show outside
+            the clusterblast-specific panel
+    """
+    if not hit:
+        return False
+    if hit.similarity_percentage >= bypass_threshold:
+        return True
+    haystack = [cat.lower() for cat in region.product_categories]
+    ref_categories = [product.split(":", 1)[0].lower() for product in hit.product.split("+")]
+    for ref_cat in ref_categories:
+        if ref_cat == "other":
+            continue
+        needle = MIBIG_CATEGORY_MAPPING.get(ref_cat, ref_cat).lower()
+        if needle not in haystack:
+            return False
     return True
 
 
@@ -84,7 +121,8 @@ def generate_html(region_layer: RegionLayer, results: ClusterBlastResults,
         region_results = results.knowncluster.region_results[region.get_region_number() - 1]
         references = [ref for ref, _ in region_results.ranking]
         best_match = region_results.get_best_match()
-        if best_match:
+        if is_good_enough(best_match, region):
+            assert best_match is not None
             region_layer.most_related_area = best_match
         title = TITLE_KNOWN % results.knowncluster.data_version
         div = generate_div(region_layer, record_layer, options_layer, "knownclusterblast",

--- a/antismash/modules/clusterblast/test/test_html.py
+++ b/antismash/modules/clusterblast/test/test_html.py
@@ -46,7 +46,8 @@ class TestHTMLReuse(unittest.TestCase):
 
     def test_known(self):
         self.results.knowncluster = self.build_result()
-        sections = self.check()
+        with patch.object(clusterblast.html_output, "is_good_enough", return_value=True):
+            sections = self.check()
         assert len(sections.detail_sections) == 1
         assert sections.detail_sections[0].label == "KnownClusterBlast"
 
@@ -60,13 +61,42 @@ class TestHTMLReuse(unittest.TestCase):
         self.results.knowncluster = self.build_result()
         self.results.general = self.build_result()
         self.results.subcluster = self.build_result()
-        sections = self.check(expected_call_count=3)
+        with patch.object(clusterblast.html_output, "is_good_enough", return_value=True):
+            sections = self.check(expected_call_count=3)
         assert len(sections.detail_sections) == 3
         assert {section.label for section in sections.detail_sections} == {
             "ClusterBlast",
             "KnownClusterBlast",
             "SubClusterBlast",
         }
+
+
+class TestGoodEnough(unittest.TestCase):
+    def setUp(self):
+        self.func = clusterblast.html_output.is_good_enough
+
+    def build_hit(self, bgc_id="dummy1", name="name", cluster_number="1",
+                  similarity=75, cluster_type="other:other"):
+        return clusterblast.results.KnownHitSummary(bgc_id, name, cluster_number,
+                                                    similarity, cluster_type)
+
+    def test_above_threshold(self):
+        region = Mock(product_categories=["unmatchable"])
+        hit = self.build_hit(cluster_type="arbitrary_type", similarity=80)
+        assert self.func(hit, region)
+
+    def test_type_mismatch(self):
+        region = Mock(product_categories=["type1"])
+        hit = self.build_hit(cluster_type="type2:some_subtype+type3", similarity=20)
+        assert not self.func(hit, region)
+
+    def test_type_match(self):
+        region = Mock(product_categories=["type1", "type2"])
+        hit = self.build_hit(cluster_type="type2:some_subtype", similarity=20)
+        assert self.func(hit, region)
+
+        hit = self.build_hit(cluster_type="type1+type2:some_subtype", similarity=20)
+        assert self.func(hit, region)
 
 
 class TestQueryJSON(unittest.TestCase):

--- a/antismash/outputs/html/templates/region_table_macros.html
+++ b/antismash/outputs/html/templates/region_table_macros.html
@@ -6,7 +6,7 @@
    <th>From</th>
    <th>To</th>
    <th>Similarity Confidence</th>
-   <th colspan="2">Most similar known cluster</th>
+   <th>Most similar known cluster</th>
   </tr>
  </thead>
 {%- endmacro %}
@@ -48,7 +48,6 @@
        {%- else %}
        <td>{{region.most_related_area.description}}</td>
        {%- endif %}
-       <td>{{region.most_related_area.product}}</td>
       {% else %}
        <td class="similarity-text"></td>
        <td colspan="2"></td>


### PR DESCRIPTION
Currently there is a field in the region table for the product/category of the best MIBiG match. Some users are overwhelmed by it, some ignore it, and some use it to help determine whether the match is relevant. To help those first two groups, the field can simply be removed. To also account for the latter, the "low" confidence matches will now be hidden in the table when the MIBiG top-level product categories aren't included in the region's set of cluster type categories. The exception here is the MIBiG category `other`, a kind of catch-all, which will always be considered as included for the type checks.

The detail sections within each region page are unchanged.

Using `NZ_AMPN02000002` as an example, before:
<img width="1721" height="450" alt="image" src="https://github.com/user-attachments/assets/b92f85fd-25c4-41d3-a031-ba910fb2bf33" />

And after, with 4.9 no longer showing a match due to being low confidence with mismatching types:
<img width="1679" height="413" alt="image" src="https://github.com/user-attachments/assets/437c3dba-0f4e-44dc-bcb8-78b7e9681074" />