### PR TITLE
Fix cds() conditions not recording the CDS matched via neighbour search

### DIFF
--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -694,17 +694,24 @@ class CDSCondition(Conditions):
         if local_only or satisfied_internally:
             return ConditionMet(xor(self.negated, satisfied_internally.met), satisfied_internally)
 
-        results = satisfied_internally.met
-        # negative matches must also ensure all neighbours are negative
+        # otherwise look for a neighbouring CDS that satisfies all subconditions
+        # on its own, and attribute the matched domains to that CDS (not the anchor)
+        # via ancillary hits, the same way SingleCondition reports neighbour hits
         start_feature = details.features_by_id[details.cds]
+        ancillary: Dict[str, Set[str]] = {}
         for cds, feature in details.features_by_id.items():
             if details.cds == cds:
                 continue
             if not details.in_range(start_feature.location, feature.location):
                 continue
-            results = results or super().are_subconditions_satisfied(details.just_cds(cds), local_only=True).met
+            neighbour = super().are_subconditions_satisfied(details.just_cds(cds), local_only=True)
+            if neighbour.met:
+                ancillary[cds] = set(neighbour.matches)
 
-        return ConditionMet(xor(results, self.negated))
+        if ancillary:
+            return ConditionMet(not self.negated, ancillary_hits=ancillary)
+
+        return ConditionMet(self.negated)
 
     def get_hit_string(self) -> str:
         prefix = "not " if self.negated else ""

--- a/antismash/common/hmm_rule_parser/test/test_rule_parser.py
+++ b/antismash/common/hmm_rule_parser/test/test_rule_parser.py
@@ -110,6 +110,27 @@ class DetectionTest(unittest.TestCase):
         results = self.run_test("A", 10, 20, "cds(a and (b or c))")
         self.expect(results, ["GENE_1", "GENE_2"])
 
+    def test_cds_neighbour_reported(self):
+        # GENE_1's cds(a and b) pair is found via neighbour search from GENE_3
+        results = self.run_test("A", 45, 20, "cds(a and b) and c and f")
+        self.expect(results, ["GENE_1", "GENE_3", "GENE_4"])
+
+    def test_cds_neighbour_attribution(self):
+        # a/b credited to GENE_1 (carries them), not GENE_3 (the anchor)
+        rules = rule_parser.Parser(
+            format_as_rule("A", 45, 20, "cds(a and b) and c and f"),
+            self.signature_names, {"C"}).rules
+        rule = rules[0]
+
+        # GENE_1 can't anchor (f out of range), so the match comes via neighbour search
+        assert not rule.detect("GENE_1", self.feature_by_id, self.results_by_id).met
+
+        anchored = rule.detect("GENE_3", self.feature_by_id, self.results_by_id)
+        assert anchored.met
+        assert anchored.matches == {"c"}  # GENE_3's own local hit only
+        assert anchored.ancillary_hits["GENE_1"] == {"a", "b"}
+        assert anchored.ancillary_hits["GENE_4"] == {"f"}
+
     def test_chained_and_a(self):
         # remove the c hit from GENE_2
         self.results_by_id["GENE_2"] = [FakeHSPHit("a", "GENE_1", 0, 10, 50, 0)]


### PR DESCRIPTION
## Problem

A rule is tested one CDS at a time, with that CDS being the the anchor. A `cds()` condition can be satisfied either by the anchor itself or by a neighbouring CDS within range.

When a `cds()` condition is satisfied by a neighbour, the rule fires correctly. But it failed to record that neighbour (the CDS that fullfills the `cds()` condition), so that CDS was left out of the protocluster. This is masked when the CDS fullfilling the `cds()` condition can also satisfy the rule on its own as an anchor.

Example: rule `cds(a and b) and c and f`. `GENE_1` carries `a,b`; `GENE_3` carries `c`; `GENE_4` carries `f`. `GENE_4` is beyond the cutoff from `GENE_1`, so `GENE_1` can never anchor the rule itself, and only appears if `GENE_3`'s neighbourhood search reports it.

## Cause


In `CDSCondition.is_satisfied`, the neighbour-search branch returned:

    return ConditionMet(xor(results, self.negated))

This gives the correct satisfied/not-satisfied answer but does not report `ancillary_hits`, so it discards which neighbouring CDS satisfied the condition and which domains it matched. `SingleCondition` already reports neighbour hits via ancillary_hits, but `CDSCondition` did not.

## Fix

Report the matching neighbour through `ancillary_hits`, keyed by that CDS's name, mirroring `SingleCondition`.

## Tests

Added to `DetectionTest` in `test_rule_parser.py`, using the existing fixtures:

- `test_cds_neighbour_reported`: with rule `cds(a and b) and c and f`, the `a/b` pair is carried by `GENE_1` and reachable only from the central anchor `GENE_3`. `GENE_1` cannot anchor the rule itself because f is out of its range and can only be included via neighbour search from `GENE_3` as anchor.
- `test_cds_neighbour_attribution`: the matched domains are correctly attributed to the CDS that carries them.

Both fail without the fix.