### PR TITLE
Misc small fixes

### DIFF
--- a/antismash/common/hmm_rule_parser/rule_parser.py
+++ b/antismash/common/hmm_rule_parser/rule_parser.py
@@ -756,7 +756,7 @@ class SingleCondition(Conditions):
 
     def get_hit_string(self) -> str:
         if self.negated:
-            return "{self.hits}*({self.name})"
+            return f"{self.hits}*({self.name})"
         return f"{self.hits}*{self.name}"
 
     def __str__(self) -> str:

--- a/antismash/common/html_renderer.py
+++ b/antismash/common/html_renderer.py
@@ -324,6 +324,7 @@ class _Template:  # pylint: disable=too-few-public-methods
         else:
             loader = _jinja2.FileSystemLoader(search_path)
         self.env = _jinja2.Environment(loader=loader, autoescape=True,
+                                       lstrip_blocks=True, trim_blocks=True,
                                        undefined=_jinja2.StrictUndefined)
 
     def render(self, **kwargs: Any) -> Markup:

--- a/antismash/common/secmet/features/cds_feature.py
+++ b/antismash/common/secmet/features/cds_feature.py
@@ -365,7 +365,13 @@ class CDSFeature(Feature):
         # respect qualifiers given to us
         if qualifiers:
             mine.update(qualifiers)
-        return super().to_biopython(mine)
+        feature = super().to_biopython(mine)
+        # if the original location was adjusted due to a modified codon start,
+        # undo that change
+        codon_start = int(feature[0].qualifiers.get("codon_start", [0])[0])
+        if codon_start > 1:
+            feature[0].location = frameshift_location_by_qualifier(feature[0].location, codon_start, undo=True)
+        return feature
 
     def __repr__(self) -> str:
         return str(self)

--- a/antismash/common/secmet/features/test/test_cds_feature.py
+++ b/antismash/common/secmet/features/test/test_cds_feature.py
@@ -108,6 +108,16 @@ class TestCDSBiopythonConversion(unittest.TestCase):
         assert regen.gene == self.cds.gene
         assert regen.protein_id == self.cds.protein_id
 
+    def test_codon_start_round_trip(self):
+        bio = self.convert()
+        bio.qualifiers["codon_start"] = ["2"]
+        original_location = FeatureLocation(0, AfterPosition(11), 1)
+        bio.location = original_location
+        new = CDSFeature.from_biopython(bio)
+        assert new.location == FeatureLocation(2, AfterPosition(11), 1)
+        regen = new.to_biopython()[0]
+        assert regen.location == original_location
+
     def test_without_genefunctions(self):
         bio = self.convert()
         assert "gene_functions" not in bio.qualifiers

--- a/antismash/modules/terpene/templates/details.html
+++ b/antismash/modules/terpene/templates/details.html
@@ -49,7 +49,7 @@
             {% if prediction.cds_predictions.items() %}
             {% for cds, domain_preds in prediction.cds_predictions.items() %}
               <div>
-              {{ cds_selector_span(cds, ["section-header"]) }}: {{ format_domain_types(domain_preds) }}
+              {{ cds_selector_span(cds, additional_classes=["section-header"]) }}: {{ format_domain_types(domain_preds) }}
               {{collapser_start(target=cds, level="cds")}}
               {% for pred in domain_preds %}
                <div>

--- a/antismash/modules/terpene/test/integration_terpenes.py
+++ b/antismash/modules/terpene/test/integration_terpenes.py
@@ -83,7 +83,7 @@ class TestTerpene(unittest.TestCase):
         destroy_config()
 
     def get_args(self):
-        return ["--minimal", "--enable-terpene"]
+        return ["--minimal", "--enable-terpene", "--enable-html"]
 
     def test_full_pathway(self):
         features = []

--- a/antismash/outputs/html/__init__.py
+++ b/antismash/outputs/html/__init__.py
@@ -123,7 +123,7 @@ def write(records: List[Record], results: List[Dict[str, ModuleResults]],
     with open(os.path.join(options.output_dir, "index.html"), "w", encoding="utf-8") as result_file:
         content = generate_webpage(records, results, options, all_modules)
         # strip all leading whitespace and blank lines, as they're meaningless to HTML
-        content = re.sub("^( *|$)", "", content, flags=re.M)
+        content = re.sub(r"^\s*", "", content, flags=re.M)
         result_file.write(content)
 
 


### PR DESCRIPTION
This PR includes a few fixes that only required a few line changes:

HTML generation now strips more irrelevant whitespace in the output, both during and after rendering. For S. Coelicolor on my machine, this reduced the runtime of the full HTML module by ~5% and reduced the output file size by ~3%. I don't expect browser load/render time will be noticeably improved, as most of the current time is in rendering the content rather than parsing the file itself.

The terpene module used `--minimal` in the full runs of integration testing, which didn't test the module's HTML generation. This caused `cds_selector_span()`'s change in #908 to no be accounted for and caused crashes on any input with a terpene cluster. The template was updated and the integration tests were adjusted to now include HTML generation.

CDS features with `codon_start` qualifiers are adjusted during runtime to be 0-indexed, but weren't adjusted back to 1-indexed prior to writing output files, resulting in chained use of those output files to have incorrect values. Those adjustments are now correctly undone prior to output.

Also includes a fix for a missing f-string in the rule parser.