### PR TITLE
chore: update PR linting action for compatibility

### DIFF
--- a/.github/workflows/pylint_issue_reporter.yml
+++ b/.github/workflows/pylint_issue_reporter.yml
@@ -1,13 +1,12 @@
 name: Comment on pylint issue comparison
 
-on: [pull_request_target]
+on: [pull_request]
 
 jobs:
   lint_comparison:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
+    outputs:
+      report: ${{ steps.comparison.outputs.report}}
     steps:
     # install python
     - uses: actions/setup-python@v4
@@ -27,8 +26,20 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[testing]
-    # make the report
-    - uses: SJShaw/pylint-compare@main
+    # build the comparison report
+    - id: comparison
+      uses: SJShaw/pylint-compare/build-report@v2
       with:
         targets: antismash *.py
         install_pylint: false
+  comment:
+    runs-on: ubuntu-latest
+    needs: lint_comparison
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment
+        uses: SJShaw/pylint-compare/update-pr@v2
+        with:
+          comment: |
+            ${{ needs.lint_comparison.outputs.report }}


### PR DESCRIPTION
Github changed `pull_request_target` in a way that caused the existing action to no longer function. The fix is to change to `pull_request`, but it's a good time to change the permissions to be even more restrictive than they were. The action has now been split into two jobs with separate permission sets.

The first builds the lint comparison report with minimal access/capabilities, notably removing the pull-request write permissions that it previously had.

The second updates the PR with the result of the comparison, with elevated pull-request write permissions in order for it to modify the PR (e.g. make the comment about the changes in linting messages).