### PR TITLE
chore: split PR linting into multiple workflows for external fork support

### DIFF
--- a/.github/workflows/pr_commentor.yml
+++ b/.github/workflows/pr_commentor.yml
@@ -1,0 +1,42 @@
+name: Comment on PR
+
+on:
+  workflow_run:
+    workflows: ["Lint comparison"]
+    types:
+      - completed
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 'Download lint report'
+        uses: actions/download-artifact@v8
+        with:
+          name: lint_report
+          path: ${{ runner.temp }}/lint_report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: message_reader
+        run: |
+          echo 'message<<EOF' >> $GITHUB_OUTPUT
+          cat '${{ runner.temp }}/lint_report/message' >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+          echo 'pr<<EOF' >> $GITHUB_OUTPUT
+          cat '${{ runner.temp }}/lint_report/pr' >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+        shell: bash
+      - name: Comment
+        uses: SJShaw/pylint-compare/update-pr@v3
+        with:
+          comment: |
+            ${{ steps.message_reader.outputs.message }}
+          pr_number: ${{ steps.message_reader.outputs.pr }}

--- a/.github/workflows/pylint_issue_reporter.yml
+++ b/.github/workflows/pylint_issue_reporter.yml
@@ -1,4 +1,4 @@
-name: Comment on pylint issue comparison
+name: Lint comparison
 
 on: [pull_request]
 
@@ -28,18 +28,16 @@ jobs:
         pip install -e .[testing]
     # build the comparison report
     - id: comparison
-      uses: SJShaw/pylint-compare/build-report@v2
+      uses: SJShaw/pylint-compare/build-report@v3
       with:
         targets: antismash *.py
         install_pylint: false
-  comment:
-    runs-on: ubuntu-latest
-    needs: lint_comparison
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Comment
-        uses: SJShaw/pylint-compare/update-pr@v2
-        with:
-          comment: |
-            ${{ needs.lint_comparison.outputs.report }}
+    - name: Save lint report
+      run: |
+        mkdir -p ./lint_report
+        echo "${{ steps.comparison.outputs.report }}" >> ./lint_report/message
+        echo "${{ github.event.number }}" >> ./lint_report/pr
+    - uses: actions/upload-artifact@v7
+      with:
+        name: lint_report
+        path: lint_report/


### PR DESCRIPTION
My previous version of this in #913 didn't properly account for permissions with external forks. Combined with a misunderstanding of how action permissions worked when that action was changed within in a PR, it snuck through into main.

As opposed to internal branches, external forks don't allow elevating to write permissions at all (with `pull_request`), so separating into two jobs was insufficient. Now those jobs have become two separate _workflows_, which allows the second workflow to have elevated permissions to make the lint comment on PRs. The comment workflow doesn't have the context for which PR is involved, so that is passed through in the action artifact from the linter workflow.